### PR TITLE
Variable, vars -> Sym, syms

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,27 +4,27 @@ SymbolicUtils.jl provides various utilities for symbolic computing.
 
 [![Build Status](https://travis-ci.org/JuliaSymbolics/SymbolicUtils.jl.svg?branch=master)](https://travis-ci.com/github/JuliaSymbolics/SymbolicUtils.jl)  [![Coverage Status](https://coveralls.io/repos/github/JuliaSymbolics/SymbolicUtils.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaSymbolics/SymbolicUtils.jl?branch=master)
 
-## Variables and expressions
+## Symbols and expressions
 
-Symbolic variables can be created using the `@vars` macro:
+Symbols can be created using the `@syms` macro:
 
 ```julia
 julia> using SymbolicUtils
 
-julia> @vars a::Integer b c d x::Real y::Number
+julia> @syms a::Integer b c d x::Real y::Number
 (a, b, c, d, x, y)
 ```
 
-This macro also defines the Julia variables of the same name and each is set to the its respective symbolic variable object.
+This macro also defines the Julia variables of the same name and each is set to the its respective symbolic object.
 
-The associated type `T` in the `@vars a::T` syntax, called `symtype` of the variable, is the type the value of the variable is supposed to be of. These types may determine the rules of symbolic simplification.
+The associated type `T` in the `@syms a::T` syntax, called `symtype` of the symbol, is the type the value of the symbol is supposed to be of. These types may determine the rules of symbolic simplification.
 
-Arithmetic and math functions are defined on variables and return `Term` objects which represent function call expressions.
+Arithmetic and math functions are defined on symbols and return `Term` objects which represent function call expressions.
 
-Variables can be defined to behave like functions. Both the input and output types for the function can be specified. Any application to that function will only admit either values of those types or symbolic variables of the same `symtype`.
+Symbols can be defined to behave like functions. Both the input and output types for the function can be specified. Any application to that function will only admit either values of those types or symbols of the same `symtype`.
 
 ```julia
-julia> @vars f(x) g(x::Real, y::Real)::Real
+julia> @syms f(x) g(x::Real, y::Real)::Real
 (f(::Number)::Number, g(::Real, ::Real)::Real)
 
 julia> f(c)
@@ -67,7 +67,7 @@ _Example:_
 Simple rule to turn any `sin` into `cos`:
 
 ```julia
-julia> @vars a b c
+julia> @syms a b c
 (a, b, c)
 
 julia> r = @rule sin(~x) => cos(~x)
@@ -153,7 +153,7 @@ is equivalent to `f(x, y, z, u, v, w)` and commutative if the order of arguments
 SymbolicUtils has a special `@acrule` macro meant for rules on functions which are associate 
 and commutative such as addition and multiplication of real and complex numbers.
 ```julia
-julia> @vars x y
+julia> @syms x y
 (x, y)
 
 julia> acr = @acrule((~y)^(~n) * ~y => (~y)^(~n+1))
@@ -169,7 +169,7 @@ Rules are applied to an entire term, they do not see sub-terms
 ```julia
 julia> using SymbolicUtils
 
-julia> @vars x y
+julia> @syms x y
 (x, y)
 
 julia> r = @rule sin(~x) => cos(~x)
@@ -233,7 +233,7 @@ Called only if `istree(x)` is `true`. Part of the API required
 for `simplify` to work. Other required methods are `operation` and `istree`
 
 #### `to_symbolic(x::S)`
-Convert your variable type to a `SymbolicUtils.Variable`. Suppose you have
+Convert your variable type to a `SymbolicUtils.Sym`. Suppose you have
 ```julia
 struct MySymbol
    s::Symbol
@@ -241,7 +241,7 @@ end
 ```
 which could represent any type symbolically, then you would define 
 ```julia
-SymbolicUtils.to_symbolic(s::MySymbol) = SymbolicUtils.Variable(s.s)
+SymbolicUtils.to_symbolic(s::MySymbol) = SymbolicUtils.Sym(s.s)
 ```
 
 ### Optional
@@ -283,12 +283,12 @@ julia> ex = 1 + (:x - 2)
 How can we use SymbolicUtils.jl to convert `ex` to `(-)(:x, 1)`? We simply implement `istree`,
 `operation`, `arguments` and `to_symbolic` and we'll be off to the races:
 ```julia
-using SymbolicUtils: Variable, istree, operation, arguments, to_symbolic
+using SymbolicUtils: Sym, istree, operation, arguments, to_symbolic
 
 SymbolicUtils.istree(ex::Expr) = ex.head == :call
 SymbolicUtils.operation(ex::Expr) = ex.args[1]
 SymbolicUtils.arguments(ex::Expr) = ex.args[2:end]
-SymbolicUtils.to_symbolic(s::Symbol) = Variable(s)
+SymbolicUtils.to_symbolic(s::Symbol) = Sym(s)
 
 julia> simplify(ex)
 (-1 + x)
@@ -298,7 +298,7 @@ Term{Any}
   f: + (function of type typeof(+))
   arguments: Array{Any}((2,))
     1: Int64 -1
-    2: Variable{Any}
+    2: Sym{Any}
       name: Symbol x
 ```
 this thing returns a `Term{Any}`, but it's not hard to convert back to `Expr`:
@@ -327,7 +327,7 @@ Term{Real}
   f: + (function of type typeof(+))
   arguments: Array{Any}((2,))
     1: Int64 -1
-    2: Variable{Real}
+    2: Sym{Real}
       name: Symbol x
 ```
 and now all our analysis is able to figure out that the `Term`s are `Number`s.

--- a/src/SymbolicUtils.jl
+++ b/src/SymbolicUtils.jl
@@ -28,7 +28,7 @@ else
 end
 
 
-export @vars, term, @fun, showraw
+export @syms, term, @fun, showraw
 include("types.jl")
 
 

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -8,8 +8,8 @@ for f in diadic
                    T::Type{<:Number},
                    S::Type{<:Number}) = promote_type(T, S)
 
-    for T in [Variable, Term]
-        for S in [Variable, Term]
+    for T in [Sym, Term]
+        for S in [Sym, Term]
             @eval (::$(typeof(f)))(a::$T, b::$S) = term($f, a, b)
         end
         @eval begin

--- a/src/rule_dsl.jl
+++ b/src/rule_dsl.jl
@@ -56,7 +56,7 @@ _Example:_
 Simple rule to turn any `sin` into `cos`:
 
 ```julia
-julia> @vars a b c
+julia> @syms a b c
 (a, b, c)
 
 julia> r = @rule sin(~x) => cos(~x)
@@ -176,7 +176,7 @@ Base.show(io::IO, acr::ACRule) = print(io, "ACRule(", acr.rule, ")")
 
 function (acr::ACRule)(term)
     r = Rule(acr)
-    if term isa Variable
+    if term isa Sym
         r(term)
     else
         f =  operation(term)

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -21,7 +21,7 @@ _isone(x::Number) = isone(x)
 <ₑ(a::Number,   b::Symbolic) = true
 
 arglength(a) = length(arguments(a))
-function <ₑ(a::Variable, b::Term)
+function <ₑ(a::Sym, b::Term)
     args = arguments(b)
     if length(args) === 2
         n1, n2 = !isnumber(args[1]) , !isnumber(args[2])
@@ -54,7 +54,7 @@ function <ₑ(a::Variable, b::Term)
     end
 end
 
-<ₑ(a::Symbolic, b::Variable) = !(b <ₑ a)
+<ₑ(a::Symbolic, b::Sym) = !(b <ₑ a)
 
 function <ₑ(a::Symbol, b::Symbol)
     # Enforce the order [+,-,\,/,^,*]
@@ -75,7 +75,7 @@ function <ₑ(a::Symbol, b::Symbol)
     end
 end
 
-<ₑ(a::Variable, b::Variable) = a.name < b.name
+<ₑ(a::Sym, b::Sym) = a.name < b.name
 <ₑ(a::T, b::S) where {T, S} = T===S ? isless(a, b) : nameof(T) < nameof(S)
 
 function <ₑ(a::Term, b::Term)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1,21 +1,21 @@
-using SymbolicUtils: Variable, FnType, Term, symtype
+using SymbolicUtils: Sym, FnType, Term, symtype
 using SymbolicUtils
 using Test
 
-@testset "@vars" begin
+@testset "@syms" begin
     let
-        @vars a b::Float64 f(::Real) g(p, h(q::Real))::Int
+        @syms a b::Float64 f(::Real) g(p, h(q::Real))::Int
 
-        @test a isa Variable{Number}
+        @test a isa Sym{Number}
         @test a.name === :a
 
-        @test b isa Variable{Float64}
+        @test b isa Sym{Float64}
         @test b.name === :b
 
-        @test f isa Variable{FnType{Tuple{Real}, Number}}
+        @test f isa Sym{FnType{Tuple{Real}, Number}}
         @test f.name === :f
 
-        @test g isa Variable{FnType{Tuple{Number, FnType{Tuple{Real}, Number}}, Int}}
+        @test g isa Sym{FnType{Tuple{Number, FnType{Tuple{Real}, Number}}, Int}}
         @test g.name === :g
 
         @test f(b) isa Term
@@ -30,7 +30,7 @@ using Test
 end
 
 @testset "methods test" begin
-    @vars w::Complex z::Complex a::Real b::Real x
+    @syms w::Complex z::Complex a::Real b::Real x
 
     @test w + z == Term{Complex}(+, [w, z])
     @test z + a == Term{Number}(+, [z, a])

--- a/test/fuzz.jl
+++ b/test/fuzz.jl
@@ -5,8 +5,8 @@ using SymbolicUtils: showraw
 
 const leaf_funcs = [()->100*randn(),
                     ()->rand(-100:100),
-                    ()->rand(@vars a b c d e f),
-                    ()->rand(@vars a b c d e f)]
+                    ()->rand(@syms a b c d e f),
+                    ()->rand(@syms a b c d e f)]
 
 const fns = vcat(1 .=> SymbolicUtils.monadic,
                  2 .=> vcat(SymbolicUtils.diadic, fill(+, 5), [-,-], fill(*, 5)),
@@ -16,7 +16,7 @@ const fns = vcat(1 .=> SymbolicUtils.monadic,
 function gen_rand_expr(inputs; leaf_prob=0.92, depth=0, min_depth=1, max_depth=5)
     if depth > max_depth  || (min_depth <= depth && rand() < leaf_prob)
         leaf = rand(leaf_funcs)()
-        if leaf isa SymbolicUtils.Variable
+        if leaf isa SymbolicUtils.Sym
             push!(inputs, leaf)
         end
         return leaf

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1,10 +1,10 @@
 using SymbolicUtils, Test
-using SymbolicUtils: Term, Variable, to_symbolic, istree, operation, arguments, symtype
+using SymbolicUtils: Term, Sym, to_symbolic, istree, operation, arguments, symtype
 
 SymbolicUtils.istree(ex::Expr) = ex.head == :call
 SymbolicUtils.operation(ex::Expr) = ex.args[1]
 SymbolicUtils.arguments(ex::Expr) = ex.args[2:end]
-SymbolicUtils.to_symbolic(s::Symbol) = Variable(s)
+SymbolicUtils.to_symbolic(s::Symbol) = Sym(s)
 
 for f ∈ [:+, :-, :*, :/, :^]
     @eval begin
@@ -16,11 +16,11 @@ end
 
 ex = 1 + (:x - 2)
 
-@test to_symbolic(ex) == Term{Any}(+, [1, Term{Any}(-, [Variable{Any}(:x), 2])])
+@test to_symbolic(ex) == Term{Any}(+, [1, Term{Any}(-, [Sym{Any}(:x), 2])])
 @test simplify(ex) == to_symbolic(-1 + :x)
 
 to_expr(t::Term) = Expr(:call, operation(t), to_expr.(arguments(t))...) 
-to_expr(s::Variable) = s.name
+to_expr(s::Sym) = s.name
 to_expr(x) = x
 
 @test to_expr(simplify(ex)) == Expr(:call, +, -1, :x)

--- a/test/order.jl
+++ b/test/order.jl
@@ -2,7 +2,7 @@ using Test
 using SymbolicUtils: <ₑ
 SymbolicUtils.show_simplified[] = false
 
-@vars a b c
+@syms a b c
 
 function istotal(x,y)
     #either

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -1,4 +1,4 @@
-@vars a b c
+@syms a b c
 
 @testset "Equality" begin
     @test a == a

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -1,5 +1,5 @@
 @testset "Numeric" begin
-    @vars a::Integer b c d x::Real y::Number
+    @syms a::Integer b c d x::Real y::Number
     @test simplify(x - y) == x + -1*y
     @test simplify(x - sin(y)) == x + -1*sin(y)
     @test simplify(-sin(x)) == -sin(x)
@@ -22,7 +22,7 @@
 end
 
 @testset "Pythagorean Identities" begin
-    @vars a::Integer x::Real y::Number
+    @syms a::Integer x::Real y::Number
 
     @test simplify(cos(x)^2 + 1 + sin(x)^2) == 2
     @test simplify(cos(y)^2 + 1 + sin(y)^2) == 2
@@ -33,14 +33,14 @@ end
 end
 
 #@testset "2π Identities" begin
-#    @vars a::Integer x::Real y::Number
+#    @syms a::Integer x::Real y::Number
 #
 #    @test simplify(cos(x + 2π + a)) == cos(a + x)
 #    @test simplify(tan(x + 2π * a)) == tan(x)
 #end
 
 @testset "Depth" begin
-    @vars x
+    @syms x
     R = RuleSet([@rule(sin(~x) => cos(~x)),
                  @rule( ~x + 1 => ~x - 1)])
     @test R(sin(sin(sin(x + 1)))) == cos(cos(cos(x - 1)))
@@ -50,7 +50,7 @@ end
 @testset "RuleRewriteError" begin
     pred(x) = error("Fail")
 
-    @vars a b
+    @syms a b
 
     rs = RuleSet([@rule ~x + ~y::pred => ~x])
     @test_throws SymbolicUtils.RuleRewriteError rs(a+b)
@@ -59,7 +59,7 @@ end
 end
 
 @testset "timerwrite" begin
-    @vars a b c d
+    @syms a b c d
     expr1 = foldr((x,y)->rand([*, /])(x,y), rand([a,b,c,d], 100))
     SymbolicUtils.@timerewrite simplify(expr1)
 end


### PR DESCRIPTION
I noticed we have to say "symbolic variable" to refer to... symbols. Variable is an overloaded term anyway.