### PR TITLE
add shuffle rules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,7 @@ julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [targets]
 test = ["Test", "Random"]

--- a/Project.toml
+++ b/Project.toml
@@ -20,4 +20,4 @@ julia = "1"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Random"]

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -63,3 +63,34 @@ end
     expr1 = foldr((x,y)->rand([*, /])(x,y), rand([a,b,c,d], 100))
     SymbolicUtils.@timerewrite simplify(expr1)
 end
+
+using Random: shuffle
+
+@testset "Shuffle Rules" begin
+    @syms a::Integer b c d x::Real y::Number
+    for _ ∈ 1:10
+        R1 = RuleSet(SymbolicUtils.SIMPLIFY_RULES)
+        R2 = RuleSet(shuffle(R1.rules))
+        simplify_shuffle_tester(ex) = R1(ex) == R1(R2(ex))
+        
+        @test simplify_shuffle_tester(x - y)
+        @test simplify_shuffle_tester(x - sin(y))
+        @test simplify_shuffle_tester(-sin(x)) 
+        @test simplify_shuffle_tester(1 * x * 2)
+        @test simplify_shuffle_tester(1 + x + 2)
+        @test simplify_shuffle_tester(b*b)
+        @test simplify_shuffle_tester((a*b)^c) 
+
+        @test simplify_shuffle_tester(1x + 2x)
+        @test simplify_shuffle_tester(3x + 2x)
+
+        @test simplify_shuffle_tester(a + b + (x * y) + c + 2 * (x * y) + d)
+        @test simplify_shuffle_tester(a + b + 2 * (x * y) + c + 2 * (x * y) + d)
+
+        @test simplify_shuffle_tester(a * x^y * b * x^d)
+
+        @test simplify_shuffle_tester(a + b + 0*c + d)
+        @test simplify_shuffle_tester(a * b * c^0 * d)
+        @test simplify_shuffle_tester(a * b * 1*c * d)
+    end
+end

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -68,31 +68,12 @@ using Random: shuffle
 
 @testset "Shuffle Rules" begin
     @syms a::Integer b c d x::Real y::Number
-    for _ ∈ 1:10
-        R1 = RuleSet(SymbolicUtils.SIMPLIFY_RULES)
-        R2 = RuleSet(shuffle(R1.rules))
-        simplify_shuffle_tester(ex) = R1(ex) == R1(R2(ex))
+    R1 = RuleSet(SymbolicUtils.SIMPLIFY_RULES)
+    R2 = RuleSet(shuffle(R1.rules))
+    simplify_shuffle_tester(ex) = (R2 ∘ R1)(ex) == (R1 ∘ R2)(ex)
 
-        @test simplify_shuffle_tester(foldr((x,y)->rand([*, /, +, -, ^])(x,y), rand([a,b,c, 1, 2, 1e-2], 20)))
-        
-        @test simplify_shuffle_tester(x - y)
-        @test simplify_shuffle_tester(x - sin(y))
-        @test simplify_shuffle_tester(-sin(x)) 
-        @test simplify_shuffle_tester(1 * x * 2)
-        @test simplify_shuffle_tester(1 + x + 2)
-        @test simplify_shuffle_tester(b*b)
-        @test simplify_shuffle_tester((a*b)^c) 
-
-        @test simplify_shuffle_tester(1x + 2x)
-        @test simplify_shuffle_tester(3x + 2x)
-
-        @test simplify_shuffle_tester(a + b + (x * y) + c + 2 * (x * y) + d)
-        @test simplify_shuffle_tester(a + b + 2 * (x * y) + c + 2 * (x * y) + d)
-
-        @test simplify_shuffle_tester(a * x^y * b * x^d)
-
-        @test simplify_shuffle_tester(a + b + 0*c + d)
-        @test simplify_shuffle_tester(a * b * c^0 * d)
-        @test simplify_shuffle_tester(a * b * 1*c * d)
+    for ex ∈ [foldr((x,y)->rand([*, +, -, ^, /])(x,y), rand([a, b, c, d, x, y, 0, 1, 2], 5))
+              for _ ∈ 1:20]
+        @test (R2 ∘ R1)(ex) == (R1 ∘ R2)(ex)
     end
 end

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -72,6 +72,8 @@ using Random: shuffle
         R1 = RuleSet(SymbolicUtils.SIMPLIFY_RULES)
         R2 = RuleSet(shuffle(R1.rules))
         simplify_shuffle_tester(ex) = R1(ex) == R1(R2(ex))
+
+        @test simplify_shuffle_tester(foldr((x,y)->rand([*, /, +, -, ^])(x,y), rand([a,b,c], 100)))
         
         @test simplify_shuffle_tester(x - y)
         @test simplify_shuffle_tester(x - sin(y))

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -73,7 +73,7 @@ using Random: shuffle
         R2 = RuleSet(shuffle(R1.rules))
         simplify_shuffle_tester(ex) = R1(ex) == R1(R2(ex))
 
-        @test simplify_shuffle_tester(foldr((x,y)->rand([*, /, +, -, ^])(x,y), rand([a,b,c], 20)))
+        @test simplify_shuffle_tester(foldr((x,y)->rand([*, /, +, -, ^])(x,y), rand([a,b,c, 1, 2, 1e-2], 20)))
         
         @test simplify_shuffle_tester(x - y)
         @test simplify_shuffle_tester(x - sin(y))

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -73,7 +73,7 @@ using Random: shuffle
         R2 = RuleSet(shuffle(R1.rules))
         simplify_shuffle_tester(ex) = R1(ex) == R1(R2(ex))
 
-        @test simplify_shuffle_tester(foldr((x,y)->rand([*, /, +, -, ^])(x,y), rand([a,b,c], 100)))
+        @test simplify_shuffle_tester(foldr((x,y)->rand([*, /, +, -, ^])(x,y), rand([a,b,c], 20)))
         
         @test simplify_shuffle_tester(x - y)
         @test simplify_shuffle_tester(x - sin(y))


### PR DESCRIPTION
This adds a test-set where we apply this to a bunch of expressions:
```julia
R1 = RuleSet(SymbolicUtils.SIMPLIFY_RULES)
R2 = RuleSet(shuffle(R1.rules))
R1(ex) == R1(R2(ex))
```
the idea is that apply rules in a random order and then simplifying using the standard order should be the same as just simplifying with the standard order. 

This might be better suited to being done in the fuzzer, but I didn't really understand the fuzzer very well.