### PR TITLE
Simplify rules refactor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicUtils"
 uuid = "d1185830-fcd6-423d-90d6-eec64667417b"
 authors = ["Shashi Gowda"]
-version = "0.1.2"
+version = "0.2.0"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/rule_dsl.jl
+++ b/src/rule_dsl.jl
@@ -257,8 +257,6 @@ end
 
 getdepth(::RuleSet) = typemax(Int)
 
-Base.vcat(Rs::RuleSet...) = RuleSet(vcat((R -> R.rules).(Rs)...))
-
 function fixpoint(f, x; kwargs...)
     x1 = f(x; kwargs...)
     while !isequal(x1, x)

--- a/src/rule_dsl.jl
+++ b/src/rule_dsl.jl
@@ -214,8 +214,9 @@ a RuleSet until there are no changes.
 struct RuleSet <: AbstractRule
     rules::Vector{AbstractRule}
     applyall::Bool
+    recurse::Bool
 end
-RuleSet(rules; applyall=false) = RuleSet(rules, applyall)
+RuleSet(rules; applyall=false, recurse=true) = RuleSet(rules, applyall, recurse)
 
 
 struct RuleRewriteError
@@ -231,7 +232,7 @@ function (r::RuleSet)(@nospecialize(term); depth=typemax(Int))
         return term
     end
     if term isa Symbolic
-        if term isa Term
+        if term isa Term && r.recurse
             expr = Term{symtype(term)}(operation(term),
                                        map(t -> r(t, depth=depth-1), arguments(term)))
         else

--- a/src/rule_dsl.jl
+++ b/src/rule_dsl.jl
@@ -214,8 +214,9 @@ a RuleSet until there are no changes.
 struct RuleSet <: AbstractRule
     rules::Vector{AbstractRule}
     applyall::Bool
+    recurse::Bool
 end
-RuleSet(rules; applyall=false) = RuleSet(rules, applyall)
+RuleSet(rules; applyall=false, recurse=true) = RuleSet(rules, applyall, recurse)
 
 
 struct RuleRewriteError
@@ -223,7 +224,7 @@ struct RuleRewriteError
     expr
 end
 
-function (r::RuleSet)(term; depth=typemax(Int))
+function (r::RuleSet)(@nospecialize(term); depth=typemax(Int))
     rules = r.rules
     term = to_symbolic(term)
     # simplify the subexpressions
@@ -231,7 +232,7 @@ function (r::RuleSet)(term; depth=typemax(Int))
         return term
     end
     if term isa Symbolic
-        if term isa Term
+        if term isa Term && r.recurse
             expr = Term{symtype(term)}(operation(term),
                                        map(t -> r(t, depth=depth-1), arguments(term)))
         else

--- a/src/rule_dsl.jl
+++ b/src/rule_dsl.jl
@@ -176,7 +176,7 @@ Base.show(io::IO, acr::ACRule) = print(io, "ACRule(", acr.rule, ")")
 
 function (acr::ACRule)(term)
     r = Rule(acr)
-    if term isa Sym
+    if !(term isa Term)
         r(term)
     else
         f =  operation(term)
@@ -196,6 +196,7 @@ function (acr::ACRule)(term)
         end
     end
 end
+
 
 #-----------------------------
 #### Rulesets
@@ -243,7 +244,7 @@ function (r::RuleSet)(term; depth=typemax(Int))
                 # this rule doesn't apply
                 continue
             else
-                return r(expr′, depth=getdepth(rules[i])) # levels touched
+                expr = r(expr′, depth=getdepth(rules[i]))# levels touched
             end
         end
     else
@@ -251,6 +252,10 @@ function (r::RuleSet)(term; depth=typemax(Int))
     end
     return expr # no rule applied
 end
+
+getdepth(::RuleSet) = typemax(Int)
+
+Base.vcat(Rs::RuleSet...) = RuleSet(vcat((R -> R.rules).(Rs)...))
 
 function fixpoint(f, x)
     x1 = f(x)

--- a/src/rule_dsl.jl
+++ b/src/rule_dsl.jl
@@ -213,7 +213,10 @@ a RuleSet until there are no changes.
 """
 struct RuleSet <: AbstractRule
     rules::Vector{AbstractRule}
+    applyall::Bool
 end
+RuleSet(rules; applyall=false) = RuleSet(rules, applyall)
+
 
 struct RuleRewriteError
     rule
@@ -245,6 +248,7 @@ function (r::RuleSet)(term; depth=typemax(Int))
                 continue
             else
                 expr = r(expr′, depth=getdepth(rules[i]))# levels touched
+                r.applyall || return expr
             end
         end
     else

--- a/src/rule_dsl.jl
+++ b/src/rule_dsl.jl
@@ -214,9 +214,8 @@ a RuleSet until there are no changes.
 struct RuleSet <: AbstractRule
     rules::Vector{AbstractRule}
     applyall::Bool
-    recurse::Bool
 end
-RuleSet(rules; applyall=false, recurse=true) = RuleSet(rules, applyall, recurse)
+RuleSet(rules; applyall=false) = RuleSet(rules, applyall)
 
 
 struct RuleRewriteError
@@ -232,7 +231,7 @@ function (r::RuleSet)(@nospecialize(term); depth=typemax(Int))
         return term
     end
     if term isa Symbolic
-        if term isa Term && r.recurse
+        if term isa Term
             expr = Term{symtype(term)}(operation(term),
                                        map(t -> r(t, depth=depth-1), arguments(term)))
         else

--- a/src/rulesets.jl
+++ b/src/rulesets.jl
@@ -1,14 +1,15 @@
 
 const SIMPLIFY_RULES = RuleSet([
-    @rule ~t::sym_isa(Number) => NUMBER_RULES(~t)
-], applyall=true)
+    @rule ~t::sym_isa(Number) => NUMBER_RULES(~t, applyall=true, recurse=true)
+])
 
 const NUMBER_RULES = RuleSet([
-    @rule ~t => ASSORTED_RULES(~t)
-    @rule ~t::is_operation(+) => PLUS_RULES(~t)
-    @rule ~t::is_operation(*) => TIMES_RULES(~t)
-    @rule ~t::is_operation(^) => POW_RULES(~t)
-], applyall=true)
+    @rule ~t               => ASSORTED_RULES(~t, recurse=false)
+    @rule ~t::is_operation(+) =>  PLUS_RULES(~t, recurse=false)
+    @rule ~t::is_operation(*) => TIMES_RULES(~t, recurse=false)
+    @rule ~t::is_operation(^) =>   POW_RULES(~t, recurse=false)
+    @rule ~t                  =>  TRIG_RULES(~t, recurse=false)
+])
 
 const PLUS_RULES = RuleSet([
     @rule(+(~~x::isnotflat(+)) => flatten_term(+, ~~x))
@@ -25,19 +26,7 @@ const PLUS_RULES = RuleSet([
     
     @acrule((~z::_iszero + ~x) => ~x)
     @rule(+(~x) => ~x)
-
-    @acrule(sin(~x)^2 + cos(~x)^2 => one(~x))
-    @acrule(sin(~x)^2 + -1        => cos(~x)^2)
-    @acrule(cos(~x)^2 + -1        => sin(~x)^2)
-
-    @acrule(tan(~x)^2 + -1*sec(~x)^2 => one(~x))
-    @acrule(tan(~x)^2 +  1 => sec(~x)^2)
-    @acrule(sec(~x)^2 + -1 => tan(~x)^2)
-
-    @acrule(cot(~x)^2 + -1*csc(~x)^2 => one(~x))
-    @acrule(cot(~x)^2 +  1 => csc(~x)^2)
-    @acrule(csc(~x)^2 + -1 => cot(~x)^2)
-], recurse=false)
+])
 
 const TIMES_RULES = RuleSet([
     @rule(*(~~x::isnotflat(*)) => flatten_term(*, ~~x))
@@ -52,34 +41,34 @@ const TIMES_RULES = RuleSet([
     @acrule((~z::_isone  * ~x) => ~x)
     @acrule((~z::_iszero *  ~x) => ~z)
     @rule(*(~x) => ~x)
-], recurse=false)
+])
 
 const POW_RULES = RuleSet([
     @rule(^(*(~~x), ~y) => *(map(a->pow(a, ~y), ~~x)...))
     @rule((((~x)^(~p))^(~q)) => (~x)^((~p)*(~q)))
     @rule(^(~x, ~z::_iszero) => 1)
     @rule(^(~x, ~z::_isone) => ~x)
-], recurse=false)
+])
 
 const ASSORTED_RULES = RuleSet([
     @rule(identity(~x) => ~x)
     @rule(-(~x, ~y) => ~x + -1(~y))
     @rule(~x / ~y => ~x * pow(~y, -1))
-], recurse=false)
+])
 
-# const TRIG_RULES = RuleSet([
-#     @acrule(sin(~x)^2 + cos(~x)^2 => one(~x))
-#     @acrule(sin(~x)^2 + -1        => cos(~x)^2)
-#     @acrule(cos(~x)^2 + -1        => sin(~x)^2)
+const TRIG_RULES = RuleSet([
+    @acrule(sin(~x)^2 + cos(~x)^2 => one(~x))
+    @acrule(sin(~x)^2 + -1        => cos(~x)^2)
+    @acrule(cos(~x)^2 + -1        => sin(~x)^2)
 
-#     @acrule(tan(~x)^2 + -1*sec(~x)^2 => one(~x))
-#     @acrule(tan(~x)^2 +  1 => sec(~x)^2)
-#     @acrule(sec(~x)^2 + -1 => tan(~x)^2)
+    @acrule(tan(~x)^2 + -1*sec(~x)^2 => one(~x))
+    @acrule(tan(~x)^2 +  1 => sec(~x)^2)
+    @acrule(sec(~x)^2 + -1 => tan(~x)^2)
 
-#     @acrule(cot(~x)^2 + -1*csc(~x)^2 => one(~x))
-#     @acrule(cot(~x)^2 +  1 => csc(~x)^2)
-#     @acrule(csc(~x)^2 + -1 => cot(~x)^2)
-# ])
+    @acrule(cot(~x)^2 + -1*csc(~x)^2 => one(~x))
+    @acrule(cot(~x)^2 +  1 => csc(~x)^2)
+    @acrule(csc(~x)^2 + -1 => cot(~x)^2)
+])
 
 
 

--- a/src/rulesets.jl
+++ b/src/rulesets.jl
@@ -1,15 +1,15 @@
 
 const SIMPLIFY_RULES = RuleSet([
     @rule ~t::sym_isa(Number) => NUMBER_RULES(~t)
-], applyall=true)
+], applyall=true, recurse=false)
 
 const NUMBER_RULES = RuleSet([
-    @rule ~t::is_operation(+) => PLUS_RULES(~t)
-    @rule ~t::is_operation(*) => TIMES_RULES(~t)
-    @rule ~t::is_operation(^) => POW_RULES(~t)
-    @rule ~t => TRIG_RULES(~t)
     @rule ~t => ASSORTED_RULES(~t)
-], true)
+    @rule ~t::is_operation(*) => TIMES_RULES(~t)
+    @rule ~t::is_operation(+) => PLUS_RULES(~t)
+    @rule ~t::is_operation(^) => POW_RULES(~t)
+  #  @rule ~t => TRIG_RULES(~t)
+], applyall=true, recurse=false)
 
 const PLUS_RULES = RuleSet([
     @rule(+(~~x::isnotflat(+)) => flatten_term(+, ~~x))
@@ -26,6 +26,18 @@ const PLUS_RULES = RuleSet([
     
     @acrule((~z::_iszero + ~x) => ~x)
     @rule(+(~x) => ~x)
+
+    @acrule(sin(~x)^2 + cos(~x)^2 => one(~x))
+    @acrule(sin(~x)^2 + -1        => cos(~x)^2)
+    @acrule(cos(~x)^2 + -1        => sin(~x)^2)
+
+    @acrule(tan(~x)^2 + -1*sec(~x)^2 => one(~x))
+    @acrule(tan(~x)^2 +  1 => sec(~x)^2)
+    @acrule(sec(~x)^2 + -1 => tan(~x)^2)
+
+    @acrule(cot(~x)^2 + -1*csc(~x)^2 => one(~x))
+    @acrule(cot(~x)^2 +  1 => csc(~x)^2)
+    @acrule(csc(~x)^2 + -1 => cot(~x)^2)
 ])
 
 const TIMES_RULES = RuleSet([
@@ -56,19 +68,19 @@ const ASSORTED_RULES = RuleSet([
     @rule(~x / ~y => ~x * pow(~y, -1))
 ])
 
-const TRIG_RULES = RuleSet([
-    @acrule(sin(~x)^2 + cos(~x)^2 => one(~x))
-    @acrule(sin(~x)^2 + -1        => cos(~x)^2)
-    @acrule(cos(~x)^2 + -1        => sin(~x)^2)
+# const TRIG_RULES = RuleSet([
+#     @acrule(sin(~x)^2 + cos(~x)^2 => one(~x))
+#     @acrule(sin(~x)^2 + -1        => cos(~x)^2)
+#     @acrule(cos(~x)^2 + -1        => sin(~x)^2)
 
-    @acrule(tan(~x)^2 + -1*sec(~x)^2 => one(~x))
-    @acrule(tan(~x)^2 +  1 => sec(~x)^2)
-    @acrule(sec(~x)^2 + -1 => tan(~x)^2)
+#     @acrule(tan(~x)^2 + -1*sec(~x)^2 => one(~x))
+#     @acrule(tan(~x)^2 +  1 => sec(~x)^2)
+#     @acrule(sec(~x)^2 + -1 => tan(~x)^2)
 
-    @acrule(cot(~x)^2 + -1*csc(~x)^2 => one(~x))
-    @acrule(cot(~x)^2 +  1 => csc(~x)^2)
-    @acrule(csc(~x)^2 + -1 => cot(~x)^2)
-])
+#     @acrule(cot(~x)^2 + -1*csc(~x)^2 => one(~x))
+#     @acrule(cot(~x)^2 +  1 => csc(~x)^2)
+#     @acrule(csc(~x)^2 + -1 => cot(~x)^2)
+# ])
 
 
 

--- a/src/rulesets.jl
+++ b/src/rulesets.jl
@@ -1,7 +1,7 @@
 
 const SIMPLIFY_RULES = RuleSet([
     @rule ~t::sym_isa(Number) => NUMBER_RULES(~t)
-], applyall=true, recurse=false)
+], applyall=true)
 
 const NUMBER_RULES = RuleSet([
     @rule ~t => ASSORTED_RULES(~t)
@@ -9,7 +9,7 @@ const NUMBER_RULES = RuleSet([
     @rule ~t::is_operation(+) => PLUS_RULES(~t)
     @rule ~t::is_operation(^) => POW_RULES(~t)
   #  @rule ~t => TRIG_RULES(~t)
-], applyall=true, recurse=false)
+], applyall=true)
 
 const PLUS_RULES = RuleSet([
     @rule(+(~~x::isnotflat(+)) => flatten_term(+, ~~x))

--- a/src/rulesets.jl
+++ b/src/rulesets.jl
@@ -5,10 +5,9 @@ const SIMPLIFY_RULES = RuleSet([
 
 const NUMBER_RULES = RuleSet([
     @rule ~t => ASSORTED_RULES(~t)
-    @rule ~t::is_operation(*) => TIMES_RULES(~t)
     @rule ~t::is_operation(+) => PLUS_RULES(~t)
+    @rule ~t::is_operation(*) => TIMES_RULES(~t)
     @rule ~t::is_operation(^) => POW_RULES(~t)
-  #  @rule ~t => TRIG_RULES(~t)
 ], applyall=true)
 
 const PLUS_RULES = RuleSet([
@@ -38,7 +37,7 @@ const PLUS_RULES = RuleSet([
     @acrule(cot(~x)^2 + -1*csc(~x)^2 => one(~x))
     @acrule(cot(~x)^2 +  1 => csc(~x)^2)
     @acrule(csc(~x)^2 + -1 => cot(~x)^2)
-])
+], recurse=false)
 
 const TIMES_RULES = RuleSet([
     @rule(*(~~x::isnotflat(*)) => flatten_term(*, ~~x))
@@ -53,20 +52,20 @@ const TIMES_RULES = RuleSet([
     @acrule((~z::_isone  * ~x) => ~x)
     @acrule((~z::_iszero *  ~x) => ~z)
     @rule(*(~x) => ~x)
-])
+], recurse=false)
 
 const POW_RULES = RuleSet([
     @rule(^(*(~~x), ~y) => *(map(a->pow(a, ~y), ~~x)...))
     @rule((((~x)^(~p))^(~q)) => (~x)^((~p)*(~q)))
     @rule(^(~x, ~z::_iszero) => 1)
     @rule(^(~x, ~z::_isone) => ~x)
-])
+], recurse=false)
 
 const ASSORTED_RULES = RuleSet([
     @rule(identity(~x) => ~x)
     @rule(-(~x, ~y) => ~x + -1(~y))
     @rule(~x / ~y => ~x * pow(~y, -1))
-])
+], recurse=false)
 
 # const TRIG_RULES = RuleSet([
 #     @acrule(sin(~x)^2 + cos(~x)^2 => one(~x))

--- a/src/rulesets.jl
+++ b/src/rulesets.jl
@@ -1,7 +1,7 @@
 
 const SIMPLIFY_RULES = RuleSet([
     @rule ~t::sym_isa(Number) => NUMBER_RULES(~t)
-])
+], applyall=true)
 
 const NUMBER_RULES = RuleSet([
     @rule ~t::is_operation(+) => PLUS_RULES(~t)
@@ -9,7 +9,7 @@ const NUMBER_RULES = RuleSet([
     @rule ~t::is_operation(^) => POW_RULES(~t)
     @rule ~t => TRIG_RULES(~t)
     @rule ~t => ASSORTED_RULES(~t)
-])
+], true)
 
 const PLUS_RULES = RuleSet([
     @rule(+(~~x::isnotflat(+)) => flatten_term(+, ~~x))

--- a/src/rulesets.jl
+++ b/src/rulesets.jl
@@ -1,62 +1,75 @@
-BASIC_NUMBER_RULES = let
-    [@rule(identity(~x) => ~x)
-     @rule(-(~x, ~y) => ~x + -1(~y))
-     @rule(~x / ~y => ~x * pow(~y, -1))
-     #@rule(*(~~x, *(~~y), ~~z) => *((~~x)..., (~~y)..., (~~z)...))
-     @rule(*(~~x::isnotflat(*)) => flatten_term(*, ~~x))
-     @rule(*(~~x::!(issortedₑ)) => sort_args(*, ~~x))
-     @acrule(~a::isnumber * ~b::isnumber => ~a * ~b)
 
-     #@rule(+(~~x, +(~~y), ~~z) => +((~~x)..., (~~y)..., (~~z)...))
-     @rule(+(~~x::isnotflat(+)) => flatten_term(+, ~~x))
-     @rule(+(~~x::!(issortedₑ)) => sort_args(+, ~~x))
-     @acrule(~a::isnumber + ~b::isnumber => ~a + ~b)
+const SIMPLIFY_RULES = RuleSet([
+    @rule ~t::sym_isa(Number) => NUMBER_RULES(~t)
+])
 
-     @acrule(*(~~x) + *(~β, ~~x) => *(1 + ~β, (~~x)...))
-     @acrule(*(~α, ~~x) + *(~β, ~~x) => *(~α +  ~β, (~~x)...))
-     @acrule(*(~~x, ~α) + *(~~x, ~β,) => *(~α +  ~β, (~~x)...))
+const NUMBER_RULES = RuleSet([
+    @rule ~t::is_operation(+) => PLUS_RULES(~t)
+    @rule ~t::is_operation(*) => TIMES_RULES(~t)
+    @rule ~t::is_operation(^) => POW_RULES(~t)
+    @rule ~t => TRIG_RULES(~t)
+    @rule ~t => ASSORTED_RULES(~t)
+])
 
-     @acrule(~x + *(~β, ~x) => *(1 + ~β, ~x))
-     @acrule(*(~α::isnumber, ~x) + ~x => *(~α + 1, ~x))
+const PLUS_RULES = RuleSet([
+    @rule(+(~~x::isnotflat(+)) => flatten_term(+, ~~x))
+    @rule(+(~~x::!(issortedₑ)) => sort_args(+, ~~x))
+    @acrule(~a::isnumber + ~b::isnumber => ~a + ~b)
 
-     # group stuff
-     @rule(^(*(~~x), ~y) => *(map(a->pow(a, ~y), ~~x)...))
-     @acrule((~y)^(~n) * ~y => (~y)^(~n+1))
-     @acrule((~x)^(~n) * (~x)^(~m) => (~x)^(~n + ~m))
-     @rule((((~x)^(~p))^(~q)) => (~x)^((~p)*(~q)))
-     @rule(+(~~x::hasrepeats) => +(merge_repeats(*, ~~x)...))
-     @rule(*(~~x::hasrepeats) => *(merge_repeats(^, ~~x)...))
+    @acrule(*(~~x) + *(~β, ~~x) => *(1 + ~β, (~~x)...))
+    @acrule(*(~α, ~~x) + *(~β, ~~x) => *(~α +  ~β, (~~x)...))
+    @acrule(*(~~x, ~α) + *(~~x, ~β,) => *(~α +  ~β, (~~x)...))
 
-     @acrule((~z::_iszero *  ~x) => ~z)
+    @acrule(~x + *(~β, ~x) => *(1 + ~β, ~x))
+    @acrule(*(~α::isnumber, ~x) + ~x => *(~α + 1, ~x))
+    @rule(+(~~x::hasrepeats) => +(merge_repeats(*, ~~x)...))
+    
+    @acrule((~z::_iszero + ~x) => ~x)
+    @rule(+(~x) => ~x)
+])
 
-     # remove the idenitities
-     @acrule((~z::_isone  * ~x) => ~x)
-     @acrule((~z::_iszero + ~x) => ~x)
-     @rule(^(~x, ~z::_iszero) => 1)
-     @rule(^(~x, ~z::_isone) => ~x)
-     @rule(+(~x) => ~x)
-     @rule(*(~x) => ~x)
-    ]
-end
+const TIMES_RULES = RuleSet([
+    @rule(*(~~x::isnotflat(*)) => flatten_term(*, ~~x))
+    @rule(*(~~x::!(issortedₑ)) => sort_args(*, ~~x))
+    
+    @acrule(~a::isnumber * ~b::isnumber => ~a * ~b)
+    @rule(*(~~x::hasrepeats) => *(merge_repeats(^, ~~x)...))
+    
+    @acrule((~y)^(~n) * ~y => (~y)^(~n+1))
+    @acrule((~x)^(~n) * (~x)^(~m) => (~x)^(~n + ~m))
 
-TRIG_RULES = let
-    [
-     @acrule(sin(~x)^2 + cos(~x)^2 => one(~x))
-     @acrule(sin(~x)^2 + -1        => cos(~x)^2)
-     @acrule(cos(~x)^2 + -1        => sin(~x)^2)
+    @acrule((~z::_isone  * ~x) => ~x)
+    @acrule((~z::_iszero *  ~x) => ~z)
+    @rule(*(~x) => ~x)
+])
 
-     @acrule(tan(~x)^2 + -1*sec(~x)^2 => one(~x))
-     @acrule(tan(~x)^2 +  1 => sec(~x)^2)
-     @acrule(sec(~x)^2 + -1 => tan(~x)^2)
+const POW_RULES = RuleSet([
+    @rule(^(*(~~x), ~y) => *(map(a->pow(a, ~y), ~~x)...))
+    @rule((((~x)^(~p))^(~q)) => (~x)^((~p)*(~q)))
+    @rule(^(~x, ~z::_iszero) => 1)
+    @rule(^(~x, ~z::_isone) => ~x)
+])
 
-     @acrule(cot(~x)^2 + -1*csc(~x)^2 => one(~x))
-     @acrule(cot(~x)^2 +  1 => csc(~x)^2)
-     @acrule(csc(~x)^2 + -1 => cot(~x)^2)
-     ]
-end
+const ASSORTED_RULES = RuleSet([
+    @rule(identity(~x) => ~x)
+    @rule(-(~x, ~y) => ~x + -1(~y))
+    @rule(~x / ~y => ~x * pow(~y, -1))
+])
 
+const TRIG_RULES = RuleSet([
+    @acrule(sin(~x)^2 + cos(~x)^2 => one(~x))
+    @acrule(sin(~x)^2 + -1        => cos(~x)^2)
+    @acrule(cos(~x)^2 + -1        => sin(~x)^2)
 
-SIMPLIFY_RULES = vcat(BASIC_NUMBER_RULES, TRIG_RULES)
+    @acrule(tan(~x)^2 + -1*sec(~x)^2 => one(~x))
+    @acrule(tan(~x)^2 +  1 => sec(~x)^2)
+    @acrule(sec(~x)^2 + -1 => tan(~x)^2)
+
+    @acrule(cot(~x)^2 + -1*csc(~x)^2 => one(~x))
+    @acrule(cot(~x)^2 +  1 => csc(~x)^2)
+    @acrule(csc(~x)^2 + -1 => cot(~x)^2)
+])
+
 
 
 OLD_BASIC_NUMBER_RULES = let # Keep these around for benchmarking purposes

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -8,7 +8,7 @@ these rules are `SymbolicUtils.SIMPLIFY_RULES`. If `fixpoint=true`
 repeatedly applies the set of rules until there are no changes.
 Applies them once if `fixpoint=false`.
 """
-function simplify(x, rules=SIMPLIFY_RULES; fixpoint=true)
+function simplify(x, rules=SIMPLIFY_RULES.rules; fixpoint=true)
     if fixpoint
         SymbolicUtils.fixpoint(RuleSet(rules))(x)
     else
@@ -21,6 +21,9 @@ end
 # https://github.com/JuliaSymbolics/SymbolicUtils.jl/issues/23
 #multiple_of(x, tol=1e-10) = y -> (y isa Number) && abs(y % x) < 1e-10
 
+sym_isa(::Type{T}) where {T} = x -> x isa T || symtype(x) <: T
+is_operation(f) = x -> (x isa Term) && (operation(x) == f)
+    
 isnumber(x) = x isa Number
 
 _iszero(t) = false

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -8,14 +8,14 @@ these rules are `SymbolicUtils.SIMPLIFY_RULES`. If `fixpoint=true`
 repeatedly applies the set of rules until there are no changes.
 Applies them once if `fixpoint=false`.
 """
-function simplify(x, rules=SIMPLIFY_RULES.rules; fixpoint=true)
+function simplify(x, rules::Vector; fixpoint=true)
     if fixpoint
         SymbolicUtils.fixpoint(RuleSet(rules))(x)
     else
         RuleSet(rules)(x)
     end
 end
-function simplify(x, rules::RuleSet; fixpoint=true)
+function simplify(x, rules=SIMPLIFY_RULES; fixpoint=true)
     if fixpoint
         SymbolicUtils.fixpoint(rules)(x)
     else

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -8,18 +8,11 @@ these rules are `SymbolicUtils.SIMPLIFY_RULES`. If `fixpoint=true`
 repeatedly applies the set of rules until there are no changes.
 Applies them once if `fixpoint=false`.
 """
-function simplify(x, rules::Vector; fixpoint=true)
+function simplify(x, rules=SIMPLIFY_RULES; fixpoint=true, recurse=true, applyall=true)
     if fixpoint
-        SymbolicUtils.fixpoint(RuleSet(rules))(x)
+        SymbolicUtils.fixpoint(rules; recurse=recurse, applyall=recurse)(x)
     else
-        RuleSet(rules)(x)
-    end
-end
-function simplify(x, rules=SIMPLIFY_RULES; fixpoint=true)
-    if fixpoint
-        SymbolicUtils.fixpoint(rules)(x)
-    else
-        rules(x)
+        rules(x; recurse=recurse, applyall=recurse)
     end
 end
 

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -15,14 +15,21 @@ function simplify(x, rules=SIMPLIFY_RULES.rules; fixpoint=true)
         RuleSet(rules)(x)
     end
 end
+function simplify(x, rules::RuleSet; fixpoint=true)
+    if fixpoint
+        SymbolicUtils.fixpoint(rules)(x)
+    else
+        rules(x)
+    end
+end
 
 ### Predicates
 
 # https://github.com/JuliaSymbolics/SymbolicUtils.jl/issues/23
 #multiple_of(x, tol=1e-10) = y -> (y isa Number) && abs(y % x) < 1e-10
 
-sym_isa(::Type{T}) where {T} = x -> x isa T || symtype(x) <: T
-is_operation(f) = x -> (x isa Term) && (operation(x) == f)
+sym_isa(::Type{T}) where {T} = @nospecialize(x) -> x isa T || symtype(x) <: T
+is_operation(f) = @nospecialize(x) -> (x isa Term) && (operation(x) == f)
     
 isnumber(x) = x isa Number
 

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -8,7 +8,7 @@ these rules are `SymbolicUtils.SIMPLIFY_RULES`. If `fixpoint=true`
 repeatedly applies the set of rules until there are no changes.
 Applies them once if `fixpoint=false`.
 """
-function simplify(x, rules=SIMPLIFY_RULES; fixpoint=true, recurse=true, applyall=true)
+function simplify(x, rules=SIMPLIFY_RULES; fixpoint=true, applyall=true, recurse=true)
     if fixpoint
         SymbolicUtils.fixpoint(rules; recurse=recurse, applyall=recurse)(x)
     else

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -17,6 +17,11 @@ end
 ex = 1 + (:x - 2)
 
 @test to_symbolic(ex) == Term{Any}(+, [1, Term{Any}(-, [Sym{Any}(:x), 2])])
+@test simplify(ex) == to_symbolic(ex) # Not simplified because symtype Any
+
+
+SymbolicUtils.symtype(::Symbol) = Real
+
 @test simplify(ex) == to_symbolic(-1 + :x)
 
 to_expr(t::Term) = Expr(:call, operation(t), to_expr.(arguments(t))...) 
@@ -24,7 +29,3 @@ to_expr(s::Sym) = s.name
 to_expr(x) = x
 
 @test to_expr(simplify(ex)) == Expr(:call, +, -1, :x)
-
-SymbolicUtils.symtype(::Symbol) = Real
-
-@test symtype(simplify(ex)) == Real

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -1,4 +1,22 @@
 using Random: shuffle, seed!
+using SymbolicUtils: fixpoint, getdepth
+
+@testset "RuleSet" begin
+    @syms w z α::Real β::Real
+    
+    r1 = @rule ~x + ~x => 2 * (~x)
+    r2 = @rule ~x * +(~~ys) => sum(map(y-> ~x * y, ~~ys));
+
+    rset = RuleSet([r1, r2])
+    @test getdepth(rset) == typemax(Int)
+
+    ex = 2 * (w+w+α+β)
+    
+    @test rset(ex) == (((2 * w) + (2 * w)) + (2 * α)) + (2 * β)
+    @test rset(ex) == simplify(ex, rset; fixpoint=false, applyall=false) 
+    
+    @test fixpoint(rset, ex) == ((2 * (2 * w)) + (2 * α)) + (2 * β)
+end
 
 @testset "Numeric" begin
     @syms a::Integer b c d x::Real y::Number

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -13,8 +13,8 @@ using Random: shuffle, seed!
     @test simplify(1x + 2x) == 3x
     @test simplify(3x + 2x) == 5x
 
-    @test simplify(a + b + (x * y) + c + 2 * (x * y) + d)     == (3 * x * y) + a + b + c + d
-    @test simplify(a + b + 2 * (x * y) + c + 2 * (x * y) + d) == (4 * x * y) + a + b + c + d
+    @test simplify(a + b + (x * y) + c + 2 * (x * y) + d)     == a + b + c + d + (3 * (x * y))
+    @test simplify(a + b + 2 * (x * y) + c + 2 * (x * y) + d) == a + b + c + d + (4 * (x * y))
 
     @test simplify(a * x^y * b * x^d) == (a * b * (x ^ (d + y)))
 

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -65,18 +65,3 @@ end
     expr1 = foldr((x,y)->rand([*, /])(x,y), rand([a,b,c,d], 100))
     SymbolicUtils.@timerewrite simplify(expr1)
 end
-
-@testset "Shuffle Rules" begin
-    @syms a::Integer b c d x::Real y::Number
-    R1 = SymbolicUtils.SIMPLIFY_RULES
-
-    seed!(1729)
-    R2 = RuleSet(shuffle(R1.rules))
-    simplify_shuffle_tester(ex) = (R2 ∘ R1)(ex) == (R1 ∘ R2)(ex)
-
-    for ex ∈ [foldr((x,y)->rand([*, +, -, ^, /])(x,y),
-                        rand([a, b, c, d, x, y, 0, 1.0, 2], 5))
-              for _ ∈ 1:20]
-        @test isequal((R2 ∘ R1)(ex), (R1 ∘ R2)(ex))
-    end
-end

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -34,13 +34,6 @@ end
     @test simplify(1 + y + cot(x)^2) == csc(x)^2 + y
 end
 
-#@testset "2π Identities" begin
-#    @syms a::Integer x::Real y::Number
-#
-#    @test simplify(cos(x + 2π + a)) == cos(a + x)
-#    @test simplify(tan(x + 2π * a)) == tan(x)
-#end
-
 @testset "Depth" begin
     @syms x
     R = RuleSet([@rule(sin(~x) => cos(~x)),

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -68,7 +68,7 @@ end
 
 @testset "Shuffle Rules" begin
     @syms a::Integer b c d x::Real y::Number
-    R1 = RuleSet(SymbolicUtils.SIMPLIFY_RULES)
+    R1 = SymbolicUtils.SIMPLIFY_RULES
 
     seed!(1729)
     R2 = RuleSet(shuffle(R1.rules))

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -13,8 +13,8 @@ using Random: shuffle, seed!
     @test simplify(1x + 2x) == 3x
     @test simplify(3x + 2x) == 5x
 
-    @test simplify(a + b + (x * y) + c + 2 * (x * y) + d)     == a + b + c + d + (3 * (x * y))
-    @test simplify(a + b + 2 * (x * y) + c + 2 * (x * y) + d) == a + b + c + d + (4 * (x * y))
+    @test simplify(a + b + (x * y) + c + 2 * (x * y) + d)     == (3 * x * y) + a + b + c + d
+    @test simplify(a + b + 2 * (x * y) + c + 2 * (x * y) + d) == (4 * x * y) + a + b + c + d
 
     @test simplify(a * x^y * b * x^d) == (a * b * (x ^ (d + y)))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,6 @@ SymbolicUtils.show_simplified[] = false
 include("basics.jl")
 include("order.jl")
 include("rewrite.jl")
-include("interface.jl")
 include("rulesets.jl")
+include("interface.jl")
 include("fuzz.jl")


### PR DESCRIPTION
Okay, this changes how we do simplification. Instead of one big, `RuleSet` which is applied, this uses nested rulesets to determine which rules actually get applied. In theory, this should be more efficient than our current system once we have more rules, but I find that currently it's a couple percent slower on this benchmark compared to master:
```julia
using SymbolicUtils, Random
Random.seed!(1)
let
    @syms a b c d
    expr1 = foldr((x,y)->rand([*, /, +])(x,y), rand([a,b,c,d,1,2], 20))
    SymbolicUtils.@timerewrite simplify(expr1)
end
```
(note that you have to run it like 3 times to get compilation out of the way).

I'll write up a more detailed report of what I changed and why in a bit.