### PR TITLE
Simple benchmark script

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,13 +12,15 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 [compat]
 Combinatorics = "1.0"
 NaNMath = "0.3"
-TimerOutputs = "0.5"
 SpecialFunctions = "0.10"
+TimerOutputs = "0.5"
 julia = "1"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random"]
+test = ["Test", "Random", "PkgBenchmark", "BenchmarkTools"]

--- a/Project.toml
+++ b/Project.toml
@@ -17,8 +17,8 @@ TimerOutputs = "0.5"
 julia = "1"
 
 [extras]
-PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,18 @@
+using BenchmarkTools, SymbolicUtils
+
+using Random
+
+SUITE = BenchmarkGroup()
+
+@syms a b c
+let r = @rule(~x => ~x), rs = RuleSet([r])
+    rewriter_suite = SUITE["rewriter"]  = BenchmarkGroup()
+
+    rewriter_suite["rule:noop:Int"]  = @benchmarkable $r(1)
+    rewriter_suite["rule:noop:Sym"]  = @benchmarkable $r(a)
+    rewriter_suite["rule:noop:Term"] = @benchmarkable $r(a+2)
+
+    rewriter_suite["ruleset:noop:Int"]  = @benchmarkable $rs(1)
+    rewriter_suite["ruleset:noop:Sym"]  = @benchmarkable $rs(a)
+    rewriter_suite["ruleset:noop:Term"] = @benchmarkable $rs(a+2)
+end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -6,13 +6,15 @@ SUITE = BenchmarkGroup()
 
 @syms a b c
 let r = @rule(~x => ~x), rs = RuleSet([r])
-    rewriter_suite = SUITE["rewriter"]  = BenchmarkGroup()
+    overhead = SUITE["overhead"]  = BenchmarkGroup()
+    overhead["rule"]  = BenchmarkGroup()
 
-    rewriter_suite["rule:noop:Int"]  = @benchmarkable $r(1)
-    rewriter_suite["rule:noop:Sym"]  = @benchmarkable $r(a)
-    rewriter_suite["rule:noop:Term"] = @benchmarkable $r(a+2)
+    overhead["rule"]["noop:Int"]  = @benchmarkable $r(1)
+    overhead["rule"]["noop:Sym"]  = @benchmarkable $r($a)
+    overhead["rule"]["noop:Term"] = @benchmarkable $r($(a+2))
 
-    rewriter_suite["ruleset:noop:Int"]  = @benchmarkable $rs(1)
-    rewriter_suite["ruleset:noop:Sym"]  = @benchmarkable $rs(a)
-    rewriter_suite["ruleset:noop:Term"] = @benchmarkable $rs(a+2)
+    overhead["ruleset"]  = BenchmarkGroup()
+    overhead["ruleset"]["noop:Int"]  = @benchmarkable $rs(1)
+    overhead["ruleset"]["noop:Sym"]  = @benchmarkable $rs($a)
+    overhead["ruleset"]["noop:Term"] = @benchmarkable $rs($(a+2))
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -17,4 +17,14 @@ let r = @rule(~x => ~x), rs = RuleSet([r])
     overhead["ruleset"]["noop:Int"]  = @benchmarkable $rs(1)
     overhead["ruleset"]["noop:Sym"]  = @benchmarkable $rs($a)
     overhead["ruleset"]["noop:Term"] = @benchmarkable $rs($(a+2))
+
+    overhead["simplify"]  = BenchmarkGroup()
+    overhead["simplify"]["noop:Int"]  = @benchmarkable simplify(1)
+    overhead["simplify"]["noop:Sym"]  = @benchmarkable simplify($a)
+    overhead["simplify"]["noop:Term"] = @benchmarkable simplify($(a+2))
+
+    overhead["simplify_no_fixp"]  = BenchmarkGroup()
+    overhead["simplify_no_fixp"]["noop:Int"]  = @benchmarkable simplify(1, fixpoint=false)
+    overhead["simplify_no_fixp"]["noop:Sym"]  = @benchmarkable simplify($a, fixpoint=false)
+    overhead["simplify_no_fixp"]["noop:Term"] = @benchmarkable simplify($(a+2), fixpoint=false)
 end

--- a/src/matchers.jl
+++ b/src/matchers.jl
@@ -114,7 +114,7 @@ end
 function matcher(slot::Slot)
     function slot_matcher(data, bindings, next)
         isempty(data) && return
-        val = bindings[slot.name]
+        val = get(bindings, slot.name, nothing)
         if val !== nothing
             if isequal(val, car(data))
                 return next(bindings, 1)
@@ -157,7 +157,7 @@ end
 
 function matcher(segment::Segment)
     function segment_matcher(data, bindings, success)
-        val = bindings[segment.name]
+        val = get(bindings, segment.name, nothing)
 
         if val !== nothing
             n = trymatchexpr(data, val, 0)

--- a/src/rule_dsl.jl
+++ b/src/rule_dsl.jl
@@ -227,7 +227,7 @@ struct RuleRewriteError
     expr
 end
 
-function (r::RuleSet)(@nospecialize(term); depth=typemax(Int), applyall=false, recurse=true)
+function (r::RuleSet)(term; depth=typemax(Int), applyall=false, recurse=true)
     rules = r.rules
     term = to_symbolic(term)
     # simplify the subexpressions

--- a/src/rule_dsl.jl
+++ b/src/rule_dsl.jl
@@ -27,9 +27,15 @@ function Base.show(io::IO, r::Rule)
     Base.print(io, r.expr)
 end
 
+const EMPTY_DICT = ImmutableDict{Symbol, Any}(:____, nothing)
+
 function (r::Rule)(term)
-    m, rhs, dict = r.matcher, r.rhs, ImmutableDict{Symbol, Any}(:____, nothing)
-    m((term,), dict, (d, n) -> n == 1 ? (@timer "RHS" rhs(d)) : nothing)
+    match_function = r.matcher
+    rhs = r.rhs
+
+    match_function((term,),
+                   EMPTY_DICT,
+                   (d, n) -> n === 1 ? (@timer "RHS" rhs(d)) : nothing)
 end
 
 """

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -23,7 +23,7 @@ end
 
 sym_isa(::Type{T}) where {T} = @nospecialize(x) -> x isa T || symtype(x) <: T
 is_operation(f) = @nospecialize(x) -> (x isa Term) && (operation(x) == f)
-    
+
 isnumber(x) = x isa Number
 
 _iszero(t) = false

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -21,9 +21,6 @@ end
 
 ### Predicates
 
-# https://github.com/JuliaSymbolics/SymbolicUtils.jl/issues/23
-#multiple_of(x, tol=1e-10) = y -> (y isa Number) && abs(y % x) < 1e-10
-
 sym_isa(::Type{T}) where {T} = @nospecialize(x) -> x isa T || symtype(x) <: T
 is_operation(f) = @nospecialize(x) -> (x isa Term) && (operation(x) == f)
     

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,3 +1,7 @@
+using Base: ImmutableDict
+
+@inline assoc(d::ImmutableDict, k, v) = ImmutableDict(d, k=>v)
+
 struct LL{V}
     v::V
     i::Int
@@ -30,16 +34,3 @@ drop_n(ll, n) = n === 0 ? ll : drop_n(cdr(ll), n-1)
 @inline drop_n(ll::AbstractArray, n) = drop_n(LL(ll, 1), n)
 @inline drop_n(ll::LL, n) = LL(ll.v, ll.i+n)
 
-# Fastest possible dict
-struct MatchDict{K,V}
-    k::K
-    v::V
-end
-function matchdict(names)
-    MatchDict((; map(=>, names, 1:length(names))...),
-              ((Ref{Any}(nothing) for n in names)...,))
-end
-@inline _copy(r) = Ref{Any}(r[])
-assoc(d::MatchDict, k, v) = MatchDict(d.k, (d1 = map(_copy,d.v); d1[d.k[k]][] = v; d1))
-#Base.haskey(d::MatchDict, k) = d.v[d.k[k]] !== nothing
-Base.getindex(d::MatchDict, k) = d.v[d.k[k]][]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,3 +11,17 @@ include("rewrite.jl")
 include("rulesets.jl")
 include("interface.jl")
 include("fuzz.jl")
+
+if haskey(ENV, "TRAVIS")
+    # A little trick for travis
+    using PkgBenchmark
+
+    pkgpath = dirname(dirname(pathof(SymbolicUtils)))
+    # move it out of the repository so that you can check out different branches
+    script = tempname() * ".jl"
+    benchpath = joinpath(pkgpath, "benchmark", "benchmarks.jl")
+    cp(benchpath, script)
+
+    j = judge(pkgpath, "master", retune=true, script=script)
+    export_markdown(stdout, j, export_invariants=true)
+end


### PR DESCRIPTION
```
Benchmarkresults:
    Package: /home/shashi/.julia/dev/SymbolicUtils
    Date: 2 May 2020 - 10:16
    Package commit: c62477
    Julia commit: 381693
    BenchmarkGroup:
        6-element BenchmarkTools.BenchmarkGroup:
          tags: []
          "rule:noop:Sym" => Trial(34.001 ns)
          "rule:noop:Int" => Trial(21.444 ns)
          "ruleset:noop:Term" => Trial(2.823 μs)
          "ruleset:noop:Int" => Trial(0.024 ns)
          "ruleset:noop:Sym" => Trial(139.023 ns)
          "rule:noop:Term" => Trial(495.682 ns)
```

Will post comparison vs master soon. ImmutableDict is much faster it turns out.