### PR TITLE
Multithreaded rules application

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
 os:
   - linux
 julia:
-  - 1
+  - 1.3.1
   - 1.4.1
   - nightly
 matrix:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicUtils"
 uuid = "d1185830-fcd6-423d-90d6-eec64667417b"
 authors = ["Shashi Gowda"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Combinatorics = "1.0"
 NaNMath = "0.3"
 SpecialFunctions = "0.10"
 TimerOutputs = "0.5"
-julia = "1"
+julia = "1.3"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/src/SymbolicUtils.jl
+++ b/src/SymbolicUtils.jl
@@ -27,7 +27,6 @@ else
     end
 end
 
-
 export @syms, term, @fun, showraw
 include("types.jl")
 

--- a/src/rule_dsl.jl
+++ b/src/rule_dsl.jl
@@ -251,7 +251,7 @@ end
 node_count(atom, count; cutoff) = count + 1
 node_count(t::Term, count=0; cutoff=100) = sum(node_count(arg, count; cutoff=cutoff) for arg ∈ arguments(t))
 
-function _recurse_apply_ruleset_threaded(r::RuleSet, term, context; depth, applyall, thread_subtree_cutoff)
+function _recurse_apply_ruleset_threaded(r::RuleSet, term, context; depth, thread_subtree_cutoff)
     _args = map(arguments(term)) do arg
         if node_count(arg) > thread_subtree_cutoff
             Threads.@spawn r(arg, context; depth=depth-1, applyall=applyall, threaded=true,
@@ -275,11 +275,11 @@ function (r::RuleSet)(term, context=EmptyCtx();  depth=typemax(Int), applyall::B
     if term isa Symbolic
         expr = if term isa Term && recurse
             if threaded
-                _recurse_apply_ruleset_threaded(r, term, context; depth=depth, applyall=applyall,
+                _recurse_apply_ruleset_threaded(r, term, context; depth=depth,
                                                 thread_subtree_cutoff=thread_subtree_cutoff)
             else
                 expr = Term{symtype(term)}(operation(term),
-                                           map(t -> r(t, context, depth=depth-1, applyall=applyall), arguments(term)))
+                                           map(t -> r(t, context, depth=depth-1), arguments(term)))
             end
         else
             term

--- a/src/rule_dsl.jl
+++ b/src/rule_dsl.jl
@@ -253,12 +253,12 @@ node_count(atom, count; cutoff) = count + 1
 node_count(t::Term, count=0; cutoff=100) = sum(node_count(arg, count; cutoff=cutoff) for arg ∈ arguments(t))
 
 function _recurse_apply_ruleset(r::RuleSet, term, context; depth, recurse, applyall,
-                                threaded=false, thread_depth_cutoff=100)
+                                threaded=false, thread_subtree_cutoff=100)
     kwargs = (;applyall=applyall, recurse=recurse, threaded=threaded,
-              thread_depth_cutoff=thread_depth_cutoff)
+              thread_subtree_cutoff=thread_subtree_cutoff)
     if threaded
         _args = map(arguments(term)) do arg
-            if node_count(term) > thread_depth_cutoff
+            if node_count(term) > thread_subtree_cutoff
                 Threads.@spawn r(arg, context; depth=depth-1, kwargs...)
             else
                 r(arg, context; depth=depth-1, kwargs..., threaded=false)

--- a/src/rule_dsl.jl
+++ b/src/rule_dsl.jl
@@ -257,18 +257,22 @@ function _recurse_apply_ruleset(r::RuleSet, term, context; depth, recurse, apply
     kwargs = (;applyall=applyall, recurse=recurse, threaded=threaded,
               thread_subtree_cutoff=thread_subtree_cutoff)
     if threaded
-        _args = map(arguments(term)) do arg
-            if node_count(term) > thread_subtree_cutoff
-                Threads.@spawn r(arg, context; depth=depth-1, kwargs...)
-            else
-                r(arg, context; depth=depth-1, kwargs..., threaded=false)
-            end
-        end
-        args = map(t -> t isa Task ? fetch(t) : t, _args)
+        _args = _recurse_apply_ruleset_threaded_args(r, arguments(term), context, kwargs...)
     else
         args = map(t -> r(t, context; depth=depth-1, kwargs...), arguments(term))
     end
     expr = Term{symtype(term)}(operation(term), args)
+end
+
+function _recurse_apply_ruleset_threaded_args(r::RuleSet, args, context, kwargs)
+    _args = map(arguments(term)) do arg
+        if node_count(term) > thread_subtree_cutoff
+            Threads.@spawn r(arg, context; depth=depth-1, kwargs...)
+        else
+            r(arg, context; depth=depth-1, kwargs..., threaded=false)
+        end
+    end
+    map(t -> t isa Task ? fetch(t) : t, _args)
 end
 
 function (r::RuleSet)(term, context=EmptyCtx();  depth=typemax(Int), applyall=false, recurse=true, thread_kwargs...)

--- a/src/rule_dsl.jl
+++ b/src/rule_dsl.jl
@@ -265,7 +265,7 @@ function (r::RuleSet)(term; depth=typemax(Int), applyall=false, recurse=true, th
             expr = term
         end
         for i in 1:length(rules)
-            expr′ = try
+             expr′ = try
                 @timer(repr(rules[i]), rules[i](expr))
             catch err
                 throw(RuleRewriteError(rules[i], expr))

--- a/src/rule_dsl.jl
+++ b/src/rule_dsl.jl
@@ -254,10 +254,10 @@ node_count(t::Term, count=0; cutoff=100) = sum(node_count(arg, count; cutoff=cut
 function _recurse_apply_ruleset_threaded(r::RuleSet, term, context; depth, thread_subtree_cutoff)
     _args = map(arguments(term)) do arg
         if node_count(arg) > thread_subtree_cutoff
-            Threads.@spawn r(arg, context; depth=depth-1, applyall=applyall, threaded=true,
+            Threads.@spawn r(arg, context; depth=depth-1, threaded=true,
                              thread_subtree_cutoff=thread_subtree_cutoff)
         else
-            r(arg, context; depth=depth-1, applyall=applyall, threaded=false)
+            r(arg, context; depth=depth-1, threaded=false)
         end
     end
     args = map(t -> t isa Task ? fetch(t) : t, _args)

--- a/src/rule_dsl.jl
+++ b/src/rule_dsl.jl
@@ -257,7 +257,7 @@ function _recurse_apply_ruleset(r::RuleSet, term, context; depth, recurse, apply
     kwargs = (;applyall=applyall, recurse=recurse, threaded=threaded,
               thread_subtree_cutoff=thread_subtree_cutoff)
     if threaded
-        _args = _recurse_apply_ruleset_threaded_args(r, arguments(term), context, kwargs...)
+        _args = _recurse_apply_ruleset_threaded_args(r, arguments(term), context, kwargs)
     else
         args = map(t -> r(t, context; depth=depth-1, kwargs...), arguments(term))
     end

--- a/src/rule_dsl.jl
+++ b/src/rule_dsl.jl
@@ -265,8 +265,8 @@ function _recurse_apply_ruleset(r::RuleSet, term, context; depth, recurse, apply
 end
 
 function _recurse_apply_ruleset_threaded_args(r::RuleSet, args, context, kwargs)
-    _args = map(arguments(term)) do arg
-        if node_count(term) > thread_subtree_cutoff
+    _args = map(args) do arg
+        if node_count(arg) > thread_subtree_cutoff
             Threads.@spawn r(arg, context; depth=depth-1, kwargs...)
         else
             r(arg, context; depth=depth-1, kwargs..., threaded=false)

--- a/src/rule_dsl.jl
+++ b/src/rule_dsl.jl
@@ -237,7 +237,7 @@ node_count(atom, count; cutoff) = count + 1
 node_count(t::Term, count=0; cutoff=100) = sum(node_count(arg, count; cutoff=cutoff) for arg ∈ arguments(t))
 
 function (r::RuleSet)(term; depth=typemax(Int), applyall=false, recurse=true, threaded=false,
-                      thread_depth_cutoff=50)
+                      thread_depth_cutoff=100)
     kwargs = (;applyall=applyall, recurse=recurse, threaded=threaded,
               thread_depth_cutoff=thread_depth_cutoff)
     rules = r.rules

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -11,11 +11,11 @@ Applies them once if `fixpoint=false`.
 The `applyall` and `recurse` keywords are forwarded to the enclosed
 `RuleSet`.
 """
-function simplify(x, rules=SIMPLIFY_RULES; fixpoint=true, applyall=true, recurse=true)
+function simplify(x, rules=SIMPLIFY_RULES; fixpoint=true, applyall=true, threaded=true, kwargs...)
     if fixpoint
-        SymbolicUtils.fixpoint(rules; recurse=recurse, applyall=recurse)(x)
+        SymbolicUtils.fixpoint(rules; applyall=applyall, threaded=threaded, kwargs...)(x)
     else
-        rules(x; recurse=recurse, applyall=recurse)
+        rules(x; applyall=applyall, threaded=threaded, kwargs...)
     end
 end
 

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -11,11 +11,11 @@ Applies them once if `fixpoint=false`.
 The `applyall` and `recurse` keywords are forwarded to the enclosed
 `RuleSet`.
 """
-function simplify(x, rules=SIMPLIFY_RULES; fixpoint=true, applyall=true, threaded=true, kwargs...)
+function simplify(x, rules=SIMPLIFY_RULES; fixpoint=true, applyall=true, kwargs...)
     if fixpoint
-        SymbolicUtils.fixpoint(rules; applyall=applyall, threaded=threaded, kwargs...)(x)
+        SymbolicUtils.fixpoint(rules; applyall=applyall, kwargs...)(x)
     else
-        rules(x; applyall=applyall, threaded=threaded, kwargs...)
+        rules(x; applyall=applyall, kwargs...)
     end
 end
 

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -35,7 +35,7 @@ The `applyall` and `recurse` keywords are forwarded to the enclosed
 """
 function simplify(x, ctx=EmptyCtx(); rules=default_rules(x, ctx), fixpoint=true, applyall=true, kwargs...)
     if fixpoint
-        SymbolicUtils.fixpoint(rules, x, ctx; recurse=recurse, applyall=applyall)
+        SymbolicUtils.fixpoint(rules, x, ctx; applyall=applyall)
     else
         rules(x, ctx; applyall=applyall, kwargs...)
     end

--- a/test/benchmark.jl
+++ b/test/benchmark.jl
@@ -1,5 +1,5 @@
 # A little trick for travis
-using PkgBenchmark
+using PkgBenchmark, SymbolicUtils
 
 pkgpath = dirname(dirname(pathof(SymbolicUtils)))
 # move it out of the repository so that you can check out different branches

--- a/test/fuzz.jl
+++ b/test/fuzz.jl
@@ -82,7 +82,7 @@ function fuzz_test(ntrials)
             @test typeof(simplified.err) == typeof(unsimplified.err)
         else
             try
-                @test unsimplified ≈ simplified
+                @test unsimplified ≈ simplified || (isnan(unsimplified) & isnan(simplified))
                 if !(unsimplified ≈ simplified)
                     error("Failed")
                 end
@@ -102,7 +102,6 @@ end
 using Random: seed!
 
 @testset "Fuzz test" begin
-
     seed!(6174)
     for i=1:2000
         fuzz_test(10)

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -12,8 +12,8 @@ using SymbolicUtils: fixpoint, getdepth
 
     ex = 2 * (w+w+α+β)
     
-    @test rset(ex) == (((2 * w) + (2 * w)) + (2 * α)) + (2 * β)
-    @test rset(ex) == simplify(ex; rules=rset, fixpoint=false, applyall=false) 
+    @eqtest rset(ex) == (((2 * w) + (2 * w)) + (2 * α)) + (2 * β)
+    @eqtest rset(ex) == simplify(ex; rules=rset, fixpoint=false, applyall=false) 
     @eqtest fixpoint(rset, ex, "ctx") == ((2 * (2 * w)) + (2 * α)) + (2 * β)
 end
 
@@ -99,7 +99,7 @@ end
           (1.0 / (((1 * d) / (1 + b)) * (1 / b)))) +
           ((((1 * a) + (1 * a)) / ((2.0 * (d + 1)) / 1.0)) +
            ((((d * 1) / (1 + c)) * 2.0) / ((1 / d) + (1 / c))))
-    @test simplify(ex) == simplify(ex, threaded=true, thread_subtree_cutoff=3)
+    @eqtest simplify(ex) == simplify(ex, threaded=true, thread_subtree_cutoff=3)
     @test SymbolicUtils.node_count(a + b * c / d) == 4
 end
 

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -77,7 +77,7 @@ end
           (1.0 / (((1 * d) / (1 + b)) * (1 / b)))) +
           ((((1 * a) + (1 * a)) / ((2.0 * (d + 1)) / 1.0)) +
            ((((d * 1) / (1 + c)) * 2.0) / ((1 / d) + (1 / c))))
-    @test simplify(ex) == simplify(ex, threaded=true, thread_depth_cutoff=3)
+    @test simplify(ex) == simplify(ex, threaded=true, thread_subtree_cutoff=3)
     @test SymbolicUtils.node_count(a + b * c / d) == 4
 end
 

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -13,7 +13,7 @@ using SymbolicUtils: fixpoint, getdepth
     ex = 2 * (w+w+α+β)
     
     @test rset(ex) == (((2 * w) + (2 * w)) + (2 * α)) + (2 * β)
-    @test rset(ex) == simplify(ex; rules=rset fixpoint=false, applyall=false) 
+    @test rset(ex) == simplify(ex; rules=rset, fixpoint=false, applyall=false) 
     
     @test fixpoint(rset, ex, "ctx") == ((2 * (2 * w)) + (2 * α)) + (2 * β)
 end

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -13,7 +13,7 @@ using SymbolicUtils: fixpoint, getdepth
     ex = 2 * (w+w+α+β)
     
     @test rset(ex) == (((2 * w) + (2 * w)) + (2 * α)) + (2 * β)
-    @test rset(ex) == simplify(ex, rset; fixpoint=false, applyall=false) 
+    @test rset(ex) == simplify(ex; rules=rset fixpoint=false, applyall=false) 
     
     @test fixpoint(rset, ex, "ctx") == ((2 * (2 * w)) + (2 * α)) + (2 * β)
 end

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -71,6 +71,16 @@ end
     @test sprint(io->Base.showerror(io, err)) == "Failed to apply rule ~x + ~(y::pred) => ~x on expression a + b"
 end
 
+@testset "Threading" begin
+    @syms a b c d
+    ex = (((0.6666666666666666 / (c / 1)) + ((1 * a) / (c / 1))) +
+          (1.0 / (((1 * d) / (1 + b)) * (1 / b)))) +
+          ((((1 * a) + (1 * a)) / ((2.0 * (d + 1)) / 1.0)) +
+           ((((d * 1) / (1 + c)) * 2.0) / ((1 / d) + (1 / c))))
+    @test simplify(ex) == simplify(ex, threaded=true, thread_depth_cutoff=3)
+    @test SymbolicUtils.node_count(a + b * c / d) == 4
+end
+
 @testset "timerwrite" begin
     @syms a b c d
     expr1 = foldr((x,y)->rand([*, /])(x,y), rand([a,b,c,d], 100))


### PR DESCRIPTION
Okay, so this "works", but it's a bit tricky to actually generate a an expression where it's worth doing. You need really big, deep terms and they can't be too 'lopsided', i.e. `(x + y) + (z + w)` is preferred to `(x + (y + (z + w)))` because it provides more opportunities for worthwhile task spawning. 

Here's something that I suspect is a bit of a 'best case' scenario. I'm using `Transducers` here to make expressions because it's `reduce` won't generate lopsided terms, unlike `foldl`. 
```julia
julia> using SymbolicUtils, Transducers

julia> begin 
           function generate_random_term(length)
               reduce(Map(_ -> rand([a,b,c,d,1,2])), 1:length, basesize=0, init=0) do x, y
                   x, y = rand(Bool) ? (x, y) : (y, x)
                   rand([*, +, /])(x, y)
               end
           end
       
           @syms a b c d
           expr1 = generate_random_term(1500)
           print("Threaded simplify \n   ")
           @btime simplify($expr1, threaded=true, fixpoint=false);
           print("Serial simplify \n   ")
           @btime simplify($expr1, threaded=false, fixpoint=false);
       end;
Threaded simplify 
     182.579 ms (3556803 allocations: 125.67 MiB)
Serial simplify 
     573.032 ms (3463980 allocations: 122.80 MiB)

julia> versioninfo()
Julia Version 1.4.1
Commit 381693d3df* (2020-04-14 17:20 UTC)
Platform Info:
  OS: Linux (x86_64-pc-linux-gnu)
  CPU: AMD Ryzen 5 2600 Six-Core Processor
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-8.0.1 (ORCJIT, znver1)
Environment:
  JULIA_NUM_THREADS = 6
```

This still likely needs a lot of work to make it satisfactory. 