### PR TITLE
Pass around a context object from simplify to matchers and rewriters

### DIFF
--- a/src/matchers.jl
+++ b/src/matchers.jl
@@ -101,7 +101,14 @@ function makeconsequent(expr)
             end
         else
             if expr.head == :macrocall
-                return esc(expr)
+                if expr.args[1] === Symbol("@ctx")
+                    if length(filter(x->!(x isa LineNumberNode), expr.args)) != 1
+                        error("@ctx takes no arguments. try (@ctx)")
+                    end
+                    return :__CTX__
+                else
+                    return esc(expr)
+                end
             end
             return Expr(expr.head, map(makeconsequent, expr.args)...)
         end

--- a/src/rule_dsl.jl
+++ b/src/rule_dsl.jl
@@ -41,13 +41,6 @@ function (r::Rule)(term, ctx=EmptyCtx())
 end
 
 """
-When used on the right hand side of a rule, it refers to the current context.
-"""
-macro CTX()
-    :__CTX__ |> esc
-end
-
-"""
     `@rule LHS => RHS`
 
 Creates a `Rule` object. A rule object is callable, and  takes an expression and rewrites
@@ -161,7 +154,7 @@ macro rule(expr)
         Rule($(QuoteNode(expr)),
              lhs_pattern,
              matcher(lhs_pattern),
-             (__MATCHES__, $(esc(:__CTX__))) -> $(makeconsequent(rhs)),
+             (__MATCHES__, __CTX__) -> $(makeconsequent(rhs)),
              rule_depth($lhs_term))
     end
 end

--- a/src/rule_dsl.jl
+++ b/src/rule_dsl.jl
@@ -251,7 +251,7 @@ function (r::RuleSet)(term, context=EmptyCtx(); depth=typemax(Int), applyall=fal
         end
         for i in 1:length(rules)
             expr′ = try
-                @timer(repr(rules[i]), rules[i](expr))
+                @timer(repr(rules[i]), rules[i](expr, context))
             catch err
                 throw(RuleRewriteError(rules[i], expr))
             end

--- a/src/rule_dsl.jl
+++ b/src/rule_dsl.jl
@@ -31,13 +31,12 @@ const EMPTY_DICT = ImmutableDict{Symbol, Any}(:____, nothing)
 struct EmptyCtx end
 
 function (r::Rule)(term, ctx=EmptyCtx())
-    match_function = r.matcher
     rhs = r.rhs
 
-    match_function((term,),
-                   EMPTY_DICT,
-                   ctx,
-                   (d, n) -> n === 1 ? (@timer "RHS" rhs(d, ctx)) : nothing)
+    r.matcher((term,), EMPTY_DICT, ctx) do bindings, n
+        # n == 1 means that exactly one term of the input (term,) was matched
+        n === 1 ? (@timer "RHS" rhs(bindings, ctx)) : nothing
+    end
 end
 
 """

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -11,13 +11,19 @@ Applies them once if `fixpoint=false`.
 The `applyall` and `recurse` keywords are forwarded to the enclosed
 `RuleSet`.
 """
-function simplify(x, rules=SIMPLIFY_RULES; fixpoint=true, applyall=true, recurse=true)
+function simplify(x, ctx=EmptyCtx(); rules=SIMPLIFY_RULES, fixpoint=true, applyall=true, recurse=true)
     if fixpoint
-        SymbolicUtils.fixpoint(rules; recurse=recurse, applyall=recurse)(x)
+        SymbolicUtils.fixpoint(rules, x, ctx; recurse=recurse, applyall=recurse)
     else
-        rules(x; recurse=recurse, applyall=recurse)
+        rules(x, ctx; recurse=recurse, applyall=recurse)
     end
 end
+
+function substitute(x, dict)
+    RuleSet([@rule(~x::(x->haskey(dict, x)) => dict[~x])])(x)
+end
+
+Base.@deprecate simplify(x, rules::RuleSet; kwargs...)  simplify(x, rules=rules; kwargs...)
 
 ### Predicates
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -61,4 +61,5 @@ end
     @test @rule(~x => @ctx)(a, "test") == "test"
     @test @rule(~x::Contextual((x, ctx) -> haskey(ctx, x)) => (@ctx)[~x])(a, Dict(a=>1)) === 1
     @test @rule(~x::Contextual((x, ctx) -> haskey(ctx, x)) => (@ctx)[~x])(b, Dict(a=>1)) === nothing
+    @test simplify(a+a, "test", rules=RuleSet([@rule ~x => @ctx])) == "test"
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1,4 +1,4 @@
-using SymbolicUtils: Sym, FnType, Term, symtype
+using SymbolicUtils: Sym, FnType, Term, symtype, Contextual, EmptyCtx, @CTX
 using SymbolicUtils
 using Test
 
@@ -49,4 +49,16 @@ end
 @testset "err test" begin
     @syms t()
     @test_throws ErrorException t(2)
+end
+
+@testset "Contexts" begin
+    @syms a b c
+
+    @test @rule(~x::Contextual((x, ctx) -> ctx==EmptyCtx()) => "yes")(1) == "yes"
+    @test @rule(~x::Contextual((x, ctx) -> haskey(ctx, x)) => true)(a, Dict(a=>1))
+    @test @rule(~x::Contextual((x, ctx) -> haskey(ctx, x)) => true)(b, Dict(a=>1)) === nothing
+    @test @rule(~x => __CTX__)(a, "test") == "test"
+    @test @rule(~x => @CTX)(a, "test") == "test"
+    @test @rule(~x::Contextual((x, ctx) -> haskey(ctx, x)) => @CTX()[~x])(a, Dict(a=>1)) === 1
+    @test @rule(~x::Contextual((x, ctx) -> haskey(ctx, x)) => @CTX()[~x])(b, Dict(a=>1)) === nothing
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1,4 +1,4 @@
-using SymbolicUtils: Sym, FnType, Term, symtype, Contextual, EmptyCtx, @CTX
+using SymbolicUtils: Sym, FnType, Term, symtype, Contextual, EmptyCtx
 using SymbolicUtils
 using Test
 
@@ -57,8 +57,8 @@ end
     @test @rule(~x::Contextual((x, ctx) -> ctx==EmptyCtx()) => "yes")(1) == "yes"
     @test @rule(~x::Contextual((x, ctx) -> haskey(ctx, x)) => true)(a, Dict(a=>1))
     @test @rule(~x::Contextual((x, ctx) -> haskey(ctx, x)) => true)(b, Dict(a=>1)) === nothing
-    @test @rule(~x => __CTX__)(a, "test") == "test"
-    @test @rule(~x => @CTX)(a, "test") == "test"
-    @test @rule(~x::Contextual((x, ctx) -> haskey(ctx, x)) => @CTX()[~x])(a, Dict(a=>1)) === 1
-    @test @rule(~x::Contextual((x, ctx) -> haskey(ctx, x)) => @CTX()[~x])(b, Dict(a=>1)) === nothing
+    @test_throws UndefVarError @rule(~x => __CTX__)(a, "test")
+    @test @rule(~x => @ctx)(a, "test") == "test"
+    @test @rule(~x::Contextual((x, ctx) -> haskey(ctx, x)) => (@ctx)[~x])(a, Dict(a=>1)) === 1
+    @test @rule(~x::Contextual((x, ctx) -> haskey(ctx, x)) => (@ctx)[~x])(b, Dict(a=>1)) === nothing
 end

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -15,7 +15,7 @@ using SymbolicUtils: fixpoint, getdepth
     @test rset(ex) == (((2 * w) + (2 * w)) + (2 * α)) + (2 * β)
     @test rset(ex) == simplify(ex, rset; fixpoint=false, applyall=false) 
     
-    @test fixpoint(rset, ex) == ((2 * (2 * w)) + (2 * α)) + (2 * β)
+    @test fixpoint(rset, ex, "ctx") == ((2 * (2 * w)) + (2 * α)) + (2 * β)
 end
 
 @testset "Numeric" begin


### PR DESCRIPTION
This `@CTX` syntax is useful for #67 

```julia
@rule(~x::Contextual((x, ctx) -> ctx==EmptyCtx()) => "yes")(1) == "yes"
@rule(~x::Contextual((x, ctx) -> haskey(ctx, x)) => true)(a, Dict(a=>1))
@rule(~x::Contextual((x, ctx) -> haskey(ctx, x)) => true)(b, Dict(a=>1)) === nothing

@rule(~x => @ctx)(a, "test") == "test"
@rule(~x::Contextual((x, ctx) -> haskey(ctx, x)) => (@ctx)[~x])(a, Dict(a=>1)) === 1
@rule(~x::Contextual((x, ctx) -> haskey(ctx, x)) => (@ctx)[~x])(b, Dict(a=>1)) === nothing
```
