### PR TITLE
boolean methods and rules

### DIFF
--- a/src/SymbolicUtils.jl
+++ b/src/SymbolicUtils.jl
@@ -33,6 +33,7 @@ include("types.jl")
 
 
 using SpecialFunctions, NaNMath
+export cond
 include("methods.jl")
 
 

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -78,6 +78,8 @@ Base.:!(s::Symbolic{Bool}) = Term{Bool}(!, [s])
 Base.:~(s::Symbolic{Bool}) = Term{Bool}(!, [s])
 
 # An ifelse node, ifelse is a built-in unfortunately
-function cond(_if, _then, _else)
+#
+cond(_if::Bool, _then, _else) = ifelse(_if, _then, _else)
+function cond(_if::Symbolic{Bool}, _then, _else)
     Term{Union{symtype(_then), symtype(_else)}}(cond, Any[_if, _then, _else])
 end

--- a/src/rulesets.jl
+++ b/src/rulesets.jl
@@ -96,8 +96,11 @@ const BOOLEAN_RULES = RuleSet([
     @rule(~x > ~x => false)
 
     # simplify terms with no symbolic arguments
-    @rule(!(~x::isliteral(Bool)) => !(~x))
-    @rule((~f)(~x::isliteral(Bool), ~y::isliteral(Bool)) => (~f)(~x, ~y))
+    # e.g. this simplifies term(isodd, 3, type=Bool)
+    # or term(!, false)
+    @rule((~f)(~x::isnumber) => (~f)(~x))
+    # and this simplifies any binary comparison operator
+    @rule((~f)(~x::isnumber, ~y::isnumber) => (~f)(~x, ~y))
 ])
 
 

--- a/src/rulesets.jl
+++ b/src/rulesets.jl
@@ -1,6 +1,7 @@
 
 const SIMPLIFY_RULES = RuleSet([
     @rule ~t::sym_isa(Number) => NUMBER_RULES(~t, applyall=true, recurse=true)
+    @rule ~t::sym_isa(Bool)   => BOOLEAN_RULES(~t, applyall=true, recurse=true)
 ])
 
 const NUMBER_RULES = RuleSet([
@@ -71,6 +72,19 @@ const TRIG_RULES = RuleSet([
     @acrule(csc(~x)^2 + -1 => cot(~x)^2)
 ])
 
+const BOOLEAN_RULES = RuleSet([
+    @rule((true | (~x)) => true)
+    @rule(((~x) | true) => true)
+    @rule((false | (~x)) => ~x)
+    @rule(((~x) | false) => ~x)
+    @rule((true & (~x)) => ~x)
+    @rule(((~x) & true) => ~x)
+    @rule((false & (~x)) => false)
+    @rule(((~x) & false) => false)
+    @rule(cond(~c::isnumber, ~x, ~y) => (~c) ? (~x) : (~y))
+    @rule((~f)(~x::isnumber) => (~f)(~x)) # collapse
+    @rule((~f)(~x::isnumber, ~y::isnumber) => (~f)(~x, ~y)) # collapse
+])
 
 
 OLD_BASIC_NUMBER_RULES = let # Keep these around for benchmarking purposes

--- a/src/rulesets.jl
+++ b/src/rulesets.jl
@@ -95,8 +95,9 @@ const BOOLEAN_RULES = RuleSet([
     @rule(~x < ~x => false)
     @rule(~x > ~x => false)
 
-    @rule((~f)(~x::isnumber) => (~f)(~x)) # collapse
-    @rule((~f)(~x::isnumber, ~y::isnumber) => (~f)(~x, ~y)) # collapse
+    # simplify terms with no symbolic arguments
+    @rule(!(~x::isliteral(Bool)) => !(~x))
+    @rule((~f)(~x::isliteral(Bool), ~y::isliteral(Bool)) => (~f)(~x, ~y))
 ])
 
 

--- a/src/rulesets.jl
+++ b/src/rulesets.jl
@@ -56,6 +56,7 @@ const ASSORTED_RULES = RuleSet([
     @rule(-(~x) => -1*~x)
     @rule(-(~x, ~y) => ~x + -1(~y))
     @rule(~x / ~y => ~x * pow(~y, -1))
+    @rule(cond(~x::isnumber, ~y, ~z) => ~x ? ~y : ~z)
 ])
 
 const TRIG_RULES = RuleSet([
@@ -81,7 +82,6 @@ const BOOLEAN_RULES = RuleSet([
     @rule(((~x) & true) => ~x)
     @rule((false & (~x)) => false)
     @rule(((~x) & false) => false)
-    @rule(cond(~c::isnumber, ~x, ~y) => (~c) ? (~x) : (~y))
     @rule((~f)(~x::isnumber) => (~f)(~x)) # collapse
     @rule((~f)(~x::isnumber, ~y::isnumber) => (~f)(~x, ~y)) # collapse
 ])

--- a/src/rulesets.jl
+++ b/src/rulesets.jl
@@ -82,6 +82,19 @@ const BOOLEAN_RULES = RuleSet([
     @rule(((~x) & true) => ~x)
     @rule((false & (~x)) => false)
     @rule(((~x) & false) => false)
+
+    @rule(!(~x) & ~x => false)
+    @rule(~x & !(~x) => false)
+    @rule(!(~x) | ~x => true)
+    @rule(~x | !(~x) => true)
+    @rule(xor(~x, !(~x)) => true)
+    @rule(xor(~x, ~x) => true)
+
+    @rule(~x == ~x => true)
+    @rule(~x != ~x => false)
+    @rule(~x < ~x => false)
+    @rule(~x > ~x => false)
+
     @rule((~f)(~x::isnumber) => (~f)(~x)) # collapse
     @rule((~f)(~x::isnumber, ~y::isnumber) => (~f)(~x, ~y)) # collapse
 ])

--- a/src/rulesets.jl
+++ b/src/rulesets.jl
@@ -1,7 +1,7 @@
 
 const SIMPLIFY_RULES = RuleSet([
-    @rule ~t::sym_isa(Number) => NUMBER_RULES(~t, applyall=true, recurse=true)
     @rule ~t::sym_isa(Bool)   => BOOLEAN_RULES(~t, applyall=true, recurse=true)
+    @rule ~t::sym_isa(Number) => NUMBER_RULES(~t, applyall=true, recurse=true)
 ])
 
 const NUMBER_RULES = RuleSet([

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -228,6 +228,8 @@ end
 
 pow(x,y) = y==0 ? 1 : y<0 ? inv(x)^(-y) : x^y
 pow(x::Symbolic,y) = y==0 ? 1 : Base.:^(x,y)
+pow(x, y::Symbolic) = Base.:^(x,y)
+pow(x::Symbolic,y::Symbolic) = Base.:^(x,y)
 
 # Numbers to the back
 function flatten_term(⋆, args)

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -59,7 +59,8 @@ end
 sym_isa(::Type{T}) where {T} = @nospecialize(x) -> x isa T || symtype(x) <: T
 is_operation(f) = @nospecialize(x) -> (x isa Term) && (operation(x) == f)
 
-isnumber(x) = x isa Number
+isliteral(::Type{T}) where {T} = x -> x isa T
+isnumber(x) = isliteral(Number)(x)
 
 _iszero(t) = false
 _iszero(x::Number) = iszero(x)

--- a/src/types.jl
+++ b/src/types.jl
@@ -58,6 +58,7 @@ symtype(::Symbolic{T}) where {T} = T
 
 Base.isequal(s::Symbolic, x) = false
 Base.isequal(x, s::Symbolic) = false
+Base.isequal(x::Symbolic, y::Symbolic) = false
 ### End of interface
 
 """

--- a/src/types.jl
+++ b/src/types.jl
@@ -56,6 +56,8 @@ symtype(x) = Any
 
 symtype(::Symbolic{T}) where {T} = T
 
+Base.isequal(s::Symbolic, x) = false
+Base.isequal(x, s::Symbolic) = false
 ### End of interface
 
 """
@@ -109,9 +111,6 @@ When constructing [`Term`](#Term)s without an explicit symtype,
 promote_symtype(f, Ts...) = Any
 
 
-
-Base.:(==)(a::Symbolic, b::Symbolic) = a === b || isequal(a,b)
-
 #--------------------
 #--------------------
 #### Syms
@@ -132,13 +131,7 @@ Sym(x) = Sym{symtype(x)}(x)
 
 Base.nameof(v::Sym) = v.name
 
-Base.:(==)(a::Sym, b::Sym) = a === b
-
-Base.:(==)(::Sym, ::Symbolic) = false
-
-Base.:(==)(::Symbolic, ::Sym) = false
-
-Base.isequal(v1::Sym, v2::Sym) = isequal(v1.name, v2.name)
+Base.isequal(v1::Sym{T}, v2::Sym{T}) where {T} = v1 === v2
 
 Base.show(io::IO, v::Sym) = print(io, v.name)
 
@@ -283,6 +276,7 @@ function Base.hash(t::Term{T}, salt::UInt) where {T}
 end
 
 function Base.isequal(t1::Term, t2::Term)
+    t1 === t2 && return true
     a1 = arguments(t1)
     a2 = arguments(t2)
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -49,18 +49,24 @@ end
 @testset "methods test" begin
     @syms w::Complex z::Complex a::Real b::Real x
 
-    @test w + z == Term{Complex}(+, [w, z])
-    @test z + a == Term{Number}(+, [z, a])
-    @test a + b == Term{Real}(+, [a, b])
-    @test a + x == Term{Number}(+, [a, x])
-    @test a + z == Term{Number}(+, [a, z])
+    @test isequal(w + z, Term{Complex}(+, [w, z]))
+    @test isequal(z + a, Term{Number}(+, [z, a]))
+    @test isequal(a + b, Term{Real}(+, [a, b]))
+    @test isequal(a + x, Term{Number}(+, [a, x]))
+    @test isequal(a + z, Term{Number}(+, [a, z]))
 
     # promote_symtype of identity
-    @test Term(identity, [w]) == Term{Complex}(identity, [w])
-    @test +(w) == w
-    @test +(a) == a
+    @test isequal(Term(identity, [w]), Term{Complex}(identity, [w]))
+    @test isequal(+(w), w)
+    @test isequal(+(a), a)
 
-    @test rem2pi(a, RoundNearest) == Term{Real}(rem2pi, [a, RoundNearest])
+    @test isequal(rem2pi(a, RoundNearest), Term{Real}(rem2pi, [a, RoundNearest]))
+
+    for f in [(==), (!=), (<=), (>=), (< ), (& ),   (| ), xor]
+        @test isequal(f(a, 0), Term{Bool}(f, [a, 0]))
+    end
+    @test_throws MethodError w < 0
+    @test isequal(w == 0, Term{Bool}(==, [w, 0]))
 end
 
 @testset "err test" begin

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -46,7 +46,7 @@ end
     @test hash(sin(a+1)) == hash(sin(c+1))
 end
 
-@testset "methods test" begin
+@testset "Base methods" begin
     @syms w::Complex z::Complex a::Real b::Real x
 
     @test isequal(w + z, Term{Complex}(+, [w, z]))
@@ -62,9 +62,13 @@ end
 
     @test isequal(rem2pi(a, RoundNearest), Term{Real}(rem2pi, [a, RoundNearest]))
 
-    for f in [(==), (!=), (<=), (>=), (< ), (& ),   (| ), xor]
+    # bool
+    for f in [(==), (!=), (<=), (>=), (<), (>)]
         @test isequal(f(a, 0), Term{Bool}(f, [a, 0]))
     end
+
+    @test symtype(cond(true, 4, 5)) == Int
+    @test symtype(cond(a < 0, b, w)) == Union{Real, Complex}
     @test_throws MethodError w < 0
     @test isequal(w == 0, Term{Bool}(==, [w, 0]))
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -90,7 +90,7 @@ end
 @testset "substitute" begin
     @syms a b
     @test substitute(a, Dict(a=>1)) == 1
-    @test substitute(sin(a+b), Dict(a=>1)) == sin(1+b)
+    @test isequal(substitute(sin(a+b), Dict(a=>1)), sin(1+b))
     @test substitute(a+b, Dict(a=>1, b=>3)) |> simplify == 4
 end
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -65,6 +65,8 @@ end
     # bool
     for f in [(==), (!=), (<=), (>=), (<), (>)]
         @test isequal(f(a, 0), Term{Bool}(f, [a, 0]))
+        @test isequal(f(0, a), Term{Bool}(f, [0, a]))
+        @test isequal(f(a, a), Term{Bool}(f, [a, a]))
     end
 
     @test symtype(cond(true, 4, 5)) == Int

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -16,13 +16,13 @@ end
 
 ex = 1 + (:x - 2)
 
-@test to_symbolic(ex) == Term{Any}(+, [1, Term{Any}(-, [Sym{Any}(:x), 2])])
-@test simplify(ex) == to_symbolic(ex) # Not simplified because symtype Any
+@eqtest to_symbolic(ex) == Term{Any}(+, [1, Term{Any}(-, [Sym{Any}(:x), 2])])
+@eqtest simplify(ex) == to_symbolic(ex) # Not simplified because symtype Any
 
 
 SymbolicUtils.symtype(::Symbol) = Real
 
-@test simplify(ex) == to_symbolic(-1 + :x)
+@eqtest simplify(ex) == to_symbolic(-1 + :x)
 
 to_expr(t::Term) = Expr(:call, operation(t), to_expr.(arguments(t))...) 
 to_expr(s::Sym) = s.name

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -1,11 +1,11 @@
 @syms a b c
 
 @testset "Equality" begin
-    @test a == a
-    @test a != b
-    @test a*b == a*b
-    @test a*b != a
-    @test a != a*b
+    @eqtest a == a
+    @eqtest a != b
+    @eqtest a*b == a*b
+    @eqtest a*b != a
+    @eqtest a != a*b
 end
 
 @testset "Literal Matcher" begin
@@ -22,7 +22,7 @@ end
 
 @testset "Term matcher" begin
     @test @rule(sin(~x) => ~x)(sin(a)) === a
-    @test @rule(sin(~x) => ~x)(sin(a^2)) == a^2
+    @eqtest @rule(sin(~x) => ~x)(sin(a^2)) == a^2
     @test @rule(sin(~x) => ~x)(sin(a)^2) === nothing
     @test @rule(sin(sin(~x)) => ~x)(sin(a^2)) === nothing
     @test @rule(sin(sin(~x)) => ~x)(sin(sin(a))) === a
@@ -33,13 +33,13 @@ end
     @test @rule((~x)^(~x) => ~x)(a^a) === a
     @test @rule((~x)^(~x) => ~x)(b^a) === nothing
     @test @rule((~x)^(~x) => ~x)(a+a) === nothing
-    @test @rule((~x)^(~x) => ~x)(sin(a)^sin(a)) == sin(a)
-    @test @rule((~x*~y + ~x*~z)  => ~x * (~y+~z))(a*b + a*c) == a*(b+c)
+    @eqtest @rule((~x)^(~x) => ~x)(sin(a)^sin(a)) == sin(a)
+    @eqtest @rule((~x*~y + ~x*~z)  => ~x * (~y+~z))(a*b + a*c) == a*(b+c)
 
-    @test @rule(+(~~x) => ~~x)(a + b) == [a,b]
-    @test @rule(+(~~x) => ~~x)(a + b + c) == [a,b,c]
-    @test @rule(+(~~x) => ~~x)(+(a, b, c)) == [a,b,c]
-    @test @rule(+(~~x,~y, ~~x) => (~~x, ~y))(term(+,9,8,9,type=Any)) == ([9,],8)
-    @test @rule(+(~~x,~y, ~~x) => (~~x, ~y, ~~x))(term(+,9,8,9,9,8,type=Any)) == ([9,8], 9, [9,8])
-    @test @rule(+(~~x,~y,~~x) => (~~x, ~y, ~~x))(term(+,6,type=Any)) == ([], 6, [])
+    @eqtest @rule(+(~~x) => ~~x)(a + b) == [a,b]
+    @eqtest @rule(+(~~x) => ~~x)(a + b + c) == [a,b,c]
+    @eqtest @rule(+(~~x) => ~~x)(+(a, b, c)) == [a,b,c]
+    @eqtest @rule(+(~~x,~y, ~~x) => (~~x, ~y))(term(+,9,8,9,type=Any)) == ([9,],8)
+    @eqtest @rule(+(~~x,~y, ~~x) => (~~x, ~y, ~~x))(term(+,9,8,9,9,8,type=Any)) == ([9,8], 9, [9,8])
+    @eqtest @rule(+(~~x,~y,~~x) => (~~x, ~y, ~~x))(term(+,6,type=Any)) == ([], 6, [])
 end

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -12,33 +12,54 @@ using SymbolicUtils: fixpoint, getdepth
 
     ex = 2 * (w+w+α+β)
     
-    @test rset(ex) == (((2 * w) + (2 * w)) + (2 * α)) + (2 * β)
-    @test rset(ex) == simplify(ex, rset; fixpoint=false, applyall=false) 
+    @eqtest rset(ex) == (((2 * w) + (2 * w)) + (2 * α)) + (2 * β)
+    @eqtest rset(ex) == simplify(ex, rset; fixpoint=false, applyall=false) 
     
-    @test fixpoint(rset, ex, "ctx") == ((2 * (2 * w)) + (2 * α)) + (2 * β)
+    @eqtest fixpoint(rset, ex, "ctx") == ((2 * (2 * w)) + (2 * α)) + (2 * β)
 end
 
 @testset "Numeric" begin
     @syms a::Integer b c d x::Real y::Number
-    @test simplify(x - y) == x + -1*y
-    @test simplify(x - sin(y)) == x + -1*sin(y)
-    @test simplify(-sin(x)) == -1*sin(x)
-    @test simplify(1 * x * 2) == 2 * x
-    @test simplify(1 + x + 2) == 3 + x
-    @test simplify(b*b) == b^2 # tests merge_repeats
-    @test simplify((a*b)^c) == a^c * b^c
+    @eqtest simplify(x - y) == x + -1*y
+    @eqtest simplify(x - sin(y)) == x + -1*sin(y)
+    @eqtest simplify(-sin(x)) == -1*sin(x)
+    @eqtest simplify(1 * x * 2) == 2 * x
+    @eqtest simplify(1 + x + 2) == 3 + x
+    @eqtest simplify(b*b) == b^2 # tests merge_repeats
+    @eqtest simplify((a*b)^c) == a^c * b^c
 
-    @test simplify(1x + 2x) == 3x
-    @test simplify(3x + 2x) == 5x
+    @eqtest simplify(1x + 2x) == 3x
+    @eqtest simplify(3x + 2x) == 5x
 
-    @test simplify(a + b + (x * y) + c + 2 * (x * y) + d)     == (3 * x * y) + a + b + c + d
-    @test simplify(a + b + 2 * (x * y) + c + 2 * (x * y) + d) == (4 * x * y) + a + b + c + d
+    @eqtest simplify(a + b + (x * y) + c + 2 * (x * y) + d)     == (3 * x * y) + a + b + c + d
+    @eqtest simplify(a + b + 2 * (x * y) + c + 2 * (x * y) + d) == (4 * x * y) + a + b + c + d
 
-    @test simplify(a * x^y * b * x^d) == (a * b * (x ^ (d + y)))
+    @eqtest simplify(a * x^y * b * x^d) == (a * b * (x ^ (d + y)))
 
-    @test simplify(a + b + 0*c + d) == a + b + d
-    @test simplify(a * b * c^0 * d) == a * b * d
-    @test simplify(a * b * 1*c * d) == a * b * c * d
+    @eqtest simplify(a + b + 0*c + d) == a + b + d
+    @eqtest simplify(a * b * c^0 * d) == a * b * d
+    @eqtest simplify(a * b * 1*c * d) == a * b * c * d
+end
+
+@testset "boolean" begin
+    @syms a::Real b c
+
+    @eqtest simplify(a < 0) == (a < 0)
+    @eqtest simplify(0 < a) == (0 < a)
+    @eqtest simplify((0 < a) | true) == true
+    @eqtest simplify(true | (0 < a)) == true
+    @eqtest simplify((0 < a) & true) == (0 < a)
+    @eqtest simplify(true & (0 < a)) == (0 < a)
+    @eqtest simplify(false & (0 < a)) == false
+    @eqtest simplify((0 < a) & false) == false
+    @eqtest simplify(Term{Bool}(!, [true])) == false
+    @eqtest simplify(Term{Bool}(|, [false, true])) == true
+    @eqtest simplify(cond(true, a,b)) == a
+    @eqtest simplify(cond(false, a,b)) == b
+
+    # abs
+    @eqtest simplify(substitute(cond(a < 0, -a,a), Dict(a=>-1))) == 1
+    @eqtest simplify(substitute(cond(a < 0, -a,a), Dict(a=>1))) == 1
 end
 
 @testset "Pythagorean Identities" begin
@@ -48,16 +69,16 @@ end
     @test simplify(cos(y)^2 + 1 + sin(y)^2) == 2
     @test simplify(sin(y)^2 + cos(y)^2 + 1) == 2
 
-    @test simplify(1 + y + tan(x)^2) == sec(x)^2 + y
-    @test simplify(1 + y + cot(x)^2) == csc(x)^2 + y
+    @eqtest simplify(1 + y + tan(x)^2) == sec(x)^2 + y
+    @eqtest simplify(1 + y + cot(x)^2) == csc(x)^2 + y
 end
 
 @testset "Depth" begin
     @syms x
     R = RuleSet([@rule(sin(~x) => cos(~x)),
                  @rule( ~x + 1 => ~x - 1)])
-    @test R(sin(sin(sin(x + 1)))) == cos(cos(cos(x - 1)))
-    @test R(sin(sin(sin(x + 1))), depth=2) == cos(cos(sin(x + 1)))
+    @eqtest R(sin(sin(sin(x + 1)))) == cos(cos(cos(x - 1)))
+    @eqtest R(sin(sin(sin(x + 1))), depth=2) == cos(cos(sin(x + 1)))
 end
 
 @testset "RuleRewriteError" begin

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -58,8 +58,8 @@ end
     @eqtest simplify(cond(false, a,b)) == b
 
     # abs
-    @eqtest simplify(substitute(cond(a < 0, -a,a), Dict(a=>-1))) == 1
-    @eqtest simplify(substitute(cond(a < 0, -a,a), Dict(a=>1))) == 1
+    @eqtest simplify(substitute(cond(!(a < 0), a,-a), Dict(a=>-1))) == 1
+    @eqtest simplify(substitute(cond(!(a < 0), a,-a), Dict(a=>1))) == 1
 end
 
 @testset "Pythagorean Identities" begin

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -58,10 +58,10 @@ end
     @eqtest simplify(cond(false, a,b)) == b
 
     # abs
-    @test_broken simplify(substitute(cond(!(a < 0), a,-a), Dict(a=>-1))) == 1
-    @test_broken simplify(substitute(cond(!(a < 0), a,-a), Dict(a=>1))) == 1
-    @test_broken simplify(substitute(cond(a < 0, -a, a), Dict(a=>-1))) == 1
-    @test_broken simplify(substitute(cond(a < 0, -a, a), Dict(a=>1))) == 1
+    @test simplify(substitute(cond(!(a < 0), a,-a), Dict(a=>-1))) == 1
+    @test simplify(substitute(cond(!(a < 0), a,-a), Dict(a=>1))) == 1
+    @test simplify(substitute(cond(a < 0, -a, a), Dict(a=>-1))) == 1
+    @test simplify(substitute(cond(a < 0, -a, a), Dict(a=>1))) == 1
 end
 
 @testset "Pythagorean Identities" begin

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -58,8 +58,10 @@ end
     @eqtest simplify(cond(false, a,b)) == b
 
     # abs
-    @eqtest simplify(substitute(cond(!(a < 0), a,-a), Dict(a=>-1))) == 1
-    @eqtest simplify(substitute(cond(!(a < 0), a,-a), Dict(a=>1))) == 1
+    @test_broken simplify(substitute(cond(!(a < 0), a,-a), Dict(a=>-1))) == 1
+    @test_broken simplify(substitute(cond(!(a < 0), a,-a), Dict(a=>1))) == 1
+    @test_broken simplify(substitute(cond(a < 0, -a, a), Dict(a=>-1))) == 1
+    @test_broken simplify(substitute(cond(a < 0, -a, a), Dict(a=>1))) == 1
 end
 
 @testset "Pythagorean Identities" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,14 @@
 using Test
 using SymbolicUtils
 
-# == syntax is nice, but we can't use it because
-# it returns a Term{Bool}
+# == / != syntax is nice, let's use it in tests
 macro eqtest(expr)
-    @assert expr.hear == :call && expr.args[1] == :(==)
-    :(@test isequal($(expr.args[2]), $(expr.args[3]))) |> esc
+    @assert expr.head == :call && expr.args[1] in [:(==), :(!=)]
+    if expr.args[1] == :(==)
+        :(@test isequal($(expr.args[2]), $(expr.args[3])))
+    else
+        :(@test !isequal($(expr.args[2]), $(expr.args[3])))
+    end |> esc
 end
 SymbolicUtils.show_simplified[] = false
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,12 @@
 using Test
 using SymbolicUtils
 
+# == syntax is nice, but we can't use it because
+# it returns a Term{Bool}
+macro eqtest(expr)
+    @assert expr.hear == :call && expr.args[1] == :(==)
+    :(@test isequal($(expr.args[2]), $(expr.args[3]))) |> esc
+end
 SymbolicUtils.show_simplified[] = false
 
 #using SymbolicUtils: Rule


### PR DESCRIPTION
Added some boolean algebra rules.

`cond` is like `ifelse`. Unfortunately `ifelse` itself is not a generic function.

```julia
julia>@syms a::Real
julia> simplify(substitute(cond(a < 0, -a,a), Dict(a=>-1)))
-1
```

closes #67 