### PR TITLE
Simplify one and zero terms

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -54,7 +54,7 @@ for f in [+, *]
     end
 end
 
-for f in [identity, one, *, +]
+for f in [identity, one, zero, *, +]
     @eval promote_symtype(::$(typeof(f)), T::Type{<:Number}) = T
 end
 

--- a/src/rulesets.jl
+++ b/src/rulesets.jl
@@ -56,6 +56,8 @@ const ASSORTED_RULES = RuleSet([
     @rule(-(~x) => -1*~x)
     @rule(-(~x, ~y) => ~x + -1(~y))
     @rule(~x / ~y => ~x * pow(~y, -1))
+    @rule(one(~x) => one(symtype(~x)))
+    @rule(zero(~x) => zero(symtype(~x)))
     @rule(cond(~x::isnumber, ~y, ~z) => ~x ? ~y : ~z)
 ])
 

--- a/test/fuzzlib.jl
+++ b/test/fuzzlib.jl
@@ -37,7 +37,7 @@ const num_spec = let
     binops = SymbolicUtils.diadic
     nopow  = filter(x->x!==(^), binops)
     twoargfns = vcat(nopow, (x,y)->x isa Union{Int, Rational, Complex{<:Rational}} ? x * y : x^y)
-    fns = vcat(1 .=> SymbolicUtils.monadic,
+    fns = vcat(1 .=> vcat(SymbolicUtils.monadic, [one, zero]),
                2 .=> vcat(twoargfns, fill(+, 5), [-,-], fill(*, 5)),
     3 .=> [+, *])
 
@@ -141,9 +141,16 @@ function fuzz_test(ntrials, spec)
             @test typeof(simplified.err) == typeof(unsimplified.err)
         else
             try
-                @test unsimplified ≈ simplified
-                if !(unsimplified ≈ simplified)
-                    error("Failed")
+                if isnan(unsimplified)
+                    @test isnan(simplified)
+                    if !isnan(simplified)
+                        error("Failed")
+                    end
+                else
+                    @test unsimplified ≈ simplified
+                    if !(unsimplified ≈ simplified)
+                        error("Failed")
+                    end
                 end
             catch err
                 println("""Test failed for expression

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -39,6 +39,15 @@ end
     @eqtest simplify(a + b + 0*c + d) == a + b + d
     @eqtest simplify(a * b * c^0 * d) == a * b * d
     @eqtest simplify(a * b * 1*c * d) == a * b * c * d
+
+    @test simplify(Term(one, [a])) == 1
+    @test simplify(Term(one, [b+1])) == 1
+    @test simplify(Term(one, [x+2])) == 1
+
+
+    @test simplify(Term(zero, [a])) == 0
+    @test simplify(Term(zero, [b+1])) == 0
+    @test simplify(Term(zero, [x+2])) == 0
 end
 
 @testset "boolean" begin


### PR DESCRIPTION
ModelingToolkit keeps these around after applying DiffRules rules.

closes #81 