### PR TITLE
Descendants

### DIFF
--- a/src/rewriters.jl
+++ b/src/rewriters.jl
@@ -167,7 +167,7 @@ function (p::Walk{ord, C, true})(x) where {ord, C}
         end
         if istree(x)
             _args = map(arguments(x)) do arg
-                if node_count(arg) > p.thread_cutoff
+                if num_descendants(arg) > p.thread_cutoff
                     Threads.@spawn p(arg)
                 else
                     p(arg)

--- a/src/rewriters.jl
+++ b/src/rewriters.jl
@@ -27,7 +27,7 @@ rewriters.
 """
 module Rewriters
 using SymbolicUtils: @timer, is_operation, istree, symtype, Term, operation, arguments,
-                     node_count
+                     num_descendants
 
 export Empty, IfElse, If, Chain, RestartedChain, Fixpoint, Postwalk, Prewalk, PassThrough
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -265,8 +265,9 @@ struct Term{T} <: Symbolic{T}
     f::Any
     arguments::Any
     descendants::Int
-    Term{T}(f, arguments) where {T} = new{T}(f, arguments, sum(num_descendants, arguments))
+    Term{T}(f, arguments) where {T} = new{T}(f, arguments, isempty(arguments) ? 0 : sum(num_descendants, arguments))
 end
+
 num_descendants(x) = 1
 num_descendants(t::Term) = t.descendants
 
@@ -299,8 +300,6 @@ function term(f, args...; type = nothing)
     end
     Term{T}(f, [args...])
 end
-
-node_count(t) = istree(t) ? reduce(+, node_count(x) for x in  arguments(t), init=0) + 1 : 1
 
 #--------------------
 #--------------------

--- a/src/types.jl
+++ b/src/types.jl
@@ -264,7 +264,11 @@ See [promote_symtype](#promote_symtype)
 struct Term{T} <: Symbolic{T}
     f::Any
     arguments::Any
+    descendants::Int
+    Term{T}(f, arguments) where {T} = new{T}(f, arguments, sum(num_descendants, arguments))
 end
+num_descendants(x) = 1
+num_descendants(t::Term) = t.descendants
 
 istree(t::Term) = true
 

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -109,7 +109,7 @@ end
           ((((1 * a) + (1 * a)) / ((2.0 * (d + 1)) / 1.0)) +
            ((((d * 1) / (1 + c)) * 2.0) / ((1 / d) + (1 / c))))
     @eqtest simplify(ex) == simplify(ex, threaded=true, thread_subtree_cutoff=3)
-    @test SymbolicUtils.node_count(a + b * c / d) == 7
+    @test SymbolicUtils.num_descendants(a + b * c / d) == 7
 end
 
 @testset "timerwrite" begin

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -109,7 +109,7 @@ end
           ((((1 * a) + (1 * a)) / ((2.0 * (d + 1)) / 1.0)) +
            ((((d * 1) / (1 + c)) * 2.0) / ((1 / d) + (1 / c))))
     @eqtest simplify(ex) == simplify(ex, threaded=true, thread_subtree_cutoff=3)
-    @test SymbolicUtils.num_descendants(a + b * c / d) == 7
+    @test SymbolicUtils.num_descendants(a + b * c / d) == 4
 end
 
 @testset "timerwrite" begin


### PR DESCRIPTION
This makes `Term`s carry around their number of descendants. It seems to offer no real performance improvement from what I see locally though. Maybe I did something wrong? 