### PR TITLE
in RuleSet loop handle cases where rules are no-op

### DIFF
--- a/src/rule_dsl.jl
+++ b/src/rule_dsl.jl
@@ -298,7 +298,7 @@ function (r::RuleSet)(term, context=DefaultCtx();
             catch err
                 throw(RuleRewriteError(rules[i], expr))
             end
-            if expr′ === nothing
+            if expr′ === nothing || isequal(expr, expr′)
                 # this rule doesn't apply
                 continue
             else


### PR DESCRIPTION
This gives a 2x speedup on

```
x2=foldl((x,y)->rand([*,/])(x,y),rand([a,b,c,d,1//2,2], 1000));
```

cc @MasonProtter 