### PR TITLE
Remove unbound parameter

### DIFF
--- a/src/rule.jl
+++ b/src/rule.jl
@@ -304,7 +304,7 @@ end
 
 Base.show(io::IO, acr::ACRule) = print(io, "ACRule(", acr.rule, ")")
 
-function (acr::ACRule)(term) where {comm}
+function (acr::ACRule)(term)
     r = Rule(acr)
     if !(term isa Term)
         r(term)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ end
 SymbolicUtils.show_simplified[] = false
 
 #using SymbolicUtils: Rule
+@test_broken isempty(detect_unbound_args(SymbolicUtils))
 
 include("basics.jl")
 include("order.jl")


### PR DESCRIPTION
Fixes #114 

Tiny change to fix unbound parameter.

Still fails `isempty(detect_unbound_args(SymbolicUtils))` due to weird unbound parameter in AbstractAlgebra.

Might want to include explict test.  I've included a commit with that test (`@test_broken`, for now, and probably for the foreseeable future, due to the dependence on upstream compliance), but you can easily remove that commit if desired. 