### PR TITLE
use interface on the matched expression instead of requiring it to be a `Term`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -24,13 +24,13 @@ using SymbolicUtils # hide
 
 ## Interfacing
 
-{{doc to_symbolic to_symbolic fn}}
-
 {{doc istree istree fn}}
 
 {{doc operation operation fn}}
 
 {{doc arguments arguments fn}}
+
+{{doc similarterm similarterm fn}}
 
 ## Rewriters
 

--- a/src/SymbolicUtils.jl
+++ b/src/SymbolicUtils.jl
@@ -1,6 +1,6 @@
 module SymbolicUtils
 
-export @syms, term, @fun, showraw
+export @syms, term, showraw
 
 # Sym, Term and other types
 include("types.jl")
@@ -21,7 +21,7 @@ include("rewriters.jl")
 using .Rewriters
 
 using Combinatorics: permutations, combinations
-export @rule, @acrule, @arule, RuleSet
+export @rule, @acrule, RuleSet
 
 # Rule type and @rule macro
 include("rule.jl")

--- a/src/api.jl
+++ b/src/api.jl
@@ -26,7 +26,7 @@ function simplify(x;
         Fixpoint(rewriter)
     end
 
-    PassThrough(f)(to_symbolic(x))
+    PassThrough(f)(x)
 end
 
 Base.@deprecate simplify(x, ctx; kwargs...)  simplify(x; rewriter=ctx, kwargs...)
@@ -40,8 +40,8 @@ the corresponding value.
 function substitute(expr, dict; fold=true)
     rs = Prewalk(PassThrough(@rule ~x::(x->haskey(dict, x)) => dict[~x]))
     if fold
-        rs(to_symbolic(expr)) |> SymbolicUtils.fold
+        rs(expr) |> SymbolicUtils.fold
     else
-        rs(to_symbolic(expr))
+        rs(expr)
     end
 end

--- a/src/api.jl
+++ b/src/api.jl
@@ -26,7 +26,7 @@ function simplify(x;
         Fixpoint(rewriter)
     end
 
-    PassThrough(f)(x)
+    PassThrough(f)(to_symbolic(x))
 end
 
 Base.@deprecate simplify(x, ctx; kwargs...)  simplify(x; rewriter=ctx, kwargs...)
@@ -40,8 +40,8 @@ the corresponding value.
 function substitute(expr, dict; fold=true)
     rs = Prewalk(PassThrough(@rule ~x::(x->haskey(dict, x)) => dict[~x]))
     if fold
-        rs(expr) |> SymbolicUtils.fold
+        rs(to_symbolic(expr)) |> SymbolicUtils.fold
     else
-        rs(expr)
+        rs(to_symbolic(expr))
     end
 end

--- a/src/matchers.jl
+++ b/src/matchers.jl
@@ -7,13 +7,13 @@
 #
 function matcher(val::Any)
     function literal_matcher(next, data, bindings)
-        !isempty(data) && isequal(car(data), val) ? next(bindings, 1) : nothing
+        islist(data) && isequal(car(data), val) ? next(bindings, 1) : nothing
     end
 end
 
 function matcher(slot::Slot)
     function slot_matcher(next, data, bindings)
-        isempty(data) && return
+        !islist(data) && return
         val = get(bindings, slot.name, nothing)
         if val !== nothing
             if isequal(val, car(data))
@@ -29,10 +29,10 @@ end
 
 # returns n == offset, 0 if failed
 function trymatchexpr(data, value, n)
-    if isempty(value)
+    if !islist(value)
         return n
     elseif islist(value) && islist(data)
-        if isempty(data)
+        if !islist(data)
             # didn't fully match
             return nothing
         end
@@ -42,14 +42,14 @@ function trymatchexpr(data, value, n)
             value = cdr(value)
             data = cdr(data)
 
-            if isempty(value)
+            if !islist(value)
                 return n
-            elseif isempty(data)
+            elseif !islist(data)
                 return nothing
             end
         end
 
-        return isempty(value) ? n : nothing
+        return !islist(value) ? n : nothing
     elseif isequal(value, data)
         return n + 1
     end
@@ -87,12 +87,12 @@ function matcher(term::Term)
     matchers = (matcher(operation(term)), map(matcher, arguments(term))...,)
     function term_matcher(success, data, bindings)
 
-        isempty(data) && return nothing
-        !(car(data) isa Term) && return nothing
+        !islist(data) && return nothing
+        !(istree(car(data))) && return nothing
 
         function loop(term, bindings′, matchers′) # Get it to compile faster
-            if isempty(matchers′)
-                if  isempty(term)
+            if !islist(matchers′)
+                if  !islist(term)
                     return success(bindings′, 1)
                 end
                 return nothing

--- a/src/rewriters.jl
+++ b/src/rewriters.jl
@@ -26,7 +26,7 @@ rewriters.
 
 """
 module Rewriters
-using SymbolicUtils: @timer, is_operation, istree, operation, arguments, node_count
+using SymbolicUtils: @timer, is_operation, istree, operation, similarterm, arguments, node_count
 
 export Empty, IfElse, If, Chain, RestartedChain, Fixpoint, Postwalk, Prewalk, PassThrough
 
@@ -148,7 +148,7 @@ function (p::Walk{ord, C, false})(x) where {ord, C}
             x = p.rw(x)
         end
         if istree(x)
-            x = operation(x)(map(t->PassThrough(p)(t), arguments(x))...)
+            x = similarterm(x, operation(x), map(PassThrough(p), arguments(x)))
         end
         return ord === :post ? p.rw(x) : x
     else
@@ -171,7 +171,7 @@ function (p::Walk{ord, C, true})(x) where {ord, C}
                 end
             end
             args = map((t,a) -> passthrough(t isa Task ? fetch(t) : t, a), _args, arguments(x))
-            t = operation(x)(args...)
+            t = similarterm(x, operation(x), args)
         end
         return ord === :post ? p.rw(t) : t
     else

--- a/src/rewriters.jl
+++ b/src/rewriters.jl
@@ -26,8 +26,7 @@ rewriters.
 
 """
 module Rewriters
-using SymbolicUtils: @timer, is_operation, istree, symtype, Term, operation, arguments,
-                     node_count
+using SymbolicUtils: @timer, is_operation, istree, operation, arguments, node_count
 
 export Empty, IfElse, If, Chain, RestartedChain, Fixpoint, Postwalk, Prewalk, PassThrough
 
@@ -149,9 +148,7 @@ function (p::Walk{ord, C, false})(x) where {ord, C}
             x = p.rw(x)
         end
         if istree(x)
-            x = Term{symtype(x)}(operation(x),
-                                 map(t->PassThrough(p)(t),
-                                     arguments(x)))
+            x = operation(x)(map(t->PassThrough(p)(t), arguments(x))...)
         end
         return ord === :post ? p.rw(x) : x
     else
@@ -174,7 +171,7 @@ function (p::Walk{ord, C, true})(x) where {ord, C}
                 end
             end
             args = map((t,a) -> passthrough(t isa Task ? fetch(t) : t, a), _args, arguments(x))
-            t = Term{symtype(x)}(operation(x), args)
+            t = operation(x)(args...)
         end
         return ord === :post ? p.rw(t) : t
     else

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -306,7 +306,7 @@ Base.show(io::IO, acr::ACRule) = print(io, "ACRule(", acr.rule, ")")
 
 function (acr::ACRule)(term)
     r = Rule(acr)
-    if !(term isa Term)
+    if !istree(term)
         r(term)
     else
         f =  operation(term)
@@ -321,9 +321,11 @@ function (acr::ACRule)(term)
         itr = acr.sets(eachindex(args), acr.arity)
 
         for inds in itr
-            result = r(Term{T}(f, @views args[inds]))
+            result = r(f((@views args[inds])...))
             if !isnothing(result)
-                return @timer "acrule" Term{T}(f, [result, (args[i] for i in eachindex(args) if i ∉ inds)...])
+                # Assumption: inds are unique
+                length(args) == length(inds) && return result
+                return f(result, (args[i] for i in eachindex(args) if i ∉ inds)...)
             end
         end
     end

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -321,11 +321,11 @@ function (acr::ACRule)(term)
         itr = acr.sets(eachindex(args), acr.arity)
 
         for inds in itr
-            result = r(f((@views args[inds])...))
+            result = r(similarterm(term, f, @views args[inds]))
             if !isnothing(result)
                 # Assumption: inds are unique
                 length(args) == length(inds) && return result
-                return f(result, (args[i] for i in eachindex(args) if i ∉ inds)...)
+                return similarterm(term, f, [result, (args[i] for i in eachindex(args) if i ∉ inds)...])
             end
         end
     end

--- a/src/simplify_rules.jl
+++ b/src/simplify_rules.jl
@@ -2,8 +2,8 @@ using .Rewriters
 
 let
     PLUS_RULES = [
-        @rule(+(~~x::isnotflat(+)) => flatten_term(+, ~~x))
-        @rule(+(~~x::!(issortedₑ)) => sort_args(+, ~~x))
+        @rule(~x::isnotflat(+) => flatten_term(+, ~x))
+        @rule(~x::needs_sorting(+) => sort_args(+, ~x))
         @ordered_acrule(~a::isnumber + ~b::isnumber => ~a + ~b)
 
         @acrule(*(~~x) + *(~β, ~~x) => *(1 + ~β, (~~x)...))
@@ -19,8 +19,8 @@ let
     ]
 
     TIMES_RULES = [
-        @rule(*(~~x::isnotflat(*)) => flatten_term(*, ~~x))
-        @rule(*(~~x::!(issortedₑ)) => sort_args(*, ~~x))
+        @rule(~x::isnotflat(*) => flatten_term(*, ~x))
+        @rule(~x::needs_sorting(*) => sort_args(*, ~x))
 
         @ordered_acrule(~a::isnumber * ~b::isnumber => ~a * ~b)
         @rule(*(~~x::hasrepeats) => *(merge_repeats(^, ~~x)...))

--- a/src/types.jl
+++ b/src/types.jl
@@ -67,8 +67,21 @@ Base.isequal(x::Symbolic, y::Symbolic) = false
 Convert `x` to a `Symbolic` type, using the `istree`, `operation`, `arguments`,
 and optionally `symtype` if available.
 """
-function to_symbolic end
-Base.@deprecate to_symbolic(x) x
+to_symbolic(x::Symbolic) = x
+
+function to_symbolic(x)
+    if !istree(x)
+        return x
+    end
+
+    op = to_symbolic(operation(x))
+
+    if symtype(x) === Any
+        Term(op, map(to_symbolic, arguments(x)))
+    else
+        Term{symtype(x)}(op, map(to_symbolic, arguments(x)))
+    end
+end
 
 Base.one( s::Symbolic) = one( symtype(s))
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -67,7 +67,8 @@ Base.isequal(x::Symbolic, y::Symbolic) = false
 Convert `x` to a `Symbolic` type, using the `istree`, `operation`, `arguments`,
 and optionally `symtype` if available.
 """
-to_symbolic(x) = x
+function to_symbolic end
+Base.@deprecate to_symbolic(x) x
 
 Base.one( s::Symbolic) = one( symtype(s))
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -67,21 +67,7 @@ Base.isequal(x::Symbolic, y::Symbolic) = false
 Convert `x` to a `Symbolic` type, using the `istree`, `operation`, `arguments`,
 and optionally `symtype` if available.
 """
-to_symbolic(x::Symbolic) = x
-
-function to_symbolic(x)
-    if !istree(x)
-        return x
-    end
-
-    op = to_symbolic(operation(x))
-
-    if symtype(x) === Any
-        Term(op, map(to_symbolic, arguments(x)))
-    else
-        Term{symtype(x)}(op, map(to_symbolic, arguments(x)))
-    end
-end
+to_symbolic(x) = x
 
 Base.one( s::Symbolic) = one( symtype(s))
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -296,6 +296,16 @@ function term(f, args...; type = nothing)
     Term{T}(f, [args...])
 end
 
+"""
+    similarterm(t, f, args)
+
+Create a term that is similar in type to `t`.
+If `t` is a `Term` will create a `Term` with the same `symtype`
+Otherwise simply calls `f(args...)` by default.
+"""
+similarterm(t, f, args) = f(args...)
+similarterm(t::Term, f, args) = Term{symtype(t)}(f, args)
+
 node_count(t) = istree(t) ? reduce(+, node_count(x) for x in  arguments(t), init=0) + 1 : 1
 
 #--------------------

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -61,10 +61,14 @@ end
 @inline take_n(ll::LL, n) = isempty(ll) || n == 0 ? empty(ll) : @views ll.v[ll.i:n+ll.i-1] # @views handles Tuple
 @inline take_n(ll, n) = @views ll[1:n]
 
-drop_n(ll, n) = n === 0 ? ll : drop_n(cdr(ll), n-1)
-
-@inline drop_n(ll, n) = istree(ll) ? drop_n(arguments(ll), n-1) : error("Can't drop $n items from $ll")
-@inline drop_n(ll::AbstractArray, n) = drop_n(LL(ll, 1), n)
+@inline function drop_n(ll, n)
+    if n === 0
+        return ll
+    else
+        istree(ll) ? drop_n(arguments(ll), n-1) : drop_n(cdr(ll), n-1)
+    end
+end
+@inline drop_n(ll::Union{Tuple, AbstractArray}, n) = drop_n(LL(ll, 1), n)
 @inline drop_n(ll::LL, n) = LL(ll.v, ll.i+n)
 
 pow(x,y) = y==0 ? 1 : y<0 ? inv(x)^(-y) : x^y

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1,10 +1,9 @@
 using SymbolicUtils, Test
-using SymbolicUtils: Term, Sym, to_symbolic, istree, operation, arguments, symtype
+using SymbolicUtils: Term, Sym, istree, operation, arguments, symtype
 
 SymbolicUtils.istree(ex::Expr) = ex.head == :call
 SymbolicUtils.operation(ex::Expr) = ex.args[1]
 SymbolicUtils.arguments(ex::Expr) = ex.args[2:end]
-SymbolicUtils.to_symbolic(s::Symbol) = Sym(s)
 
 for f ∈ [:+, :-, :*, :/, :^]
     @eval begin
@@ -16,16 +15,8 @@ end
 
 ex = 1 + (:x - 2)
 
-@eqtest to_symbolic(ex) == Term{Any}(+, [1, Term{Any}(-, [Sym{Any}(:x), 2])])
-@eqtest simplify(ex) == to_symbolic(ex) # Not simplified because symtype Any
+@test simplify(ex) == ex # Not simplified because symtype Any
 
+SymbolicUtils.symtype(::Expr) = Real
 
-SymbolicUtils.symtype(::Symbol) = Real
-
-@eqtest simplify(ex) == to_symbolic(-1 + :x)
-
-to_expr(t::Term) = Expr(:call, operation(t), to_expr.(arguments(t))...) 
-to_expr(s::Sym) = s.name
-to_expr(x) = x
-
-@test to_expr(simplify(ex)) == Expr(:call, +, -1, :x)
+@test simplify(ex) == -1 + :x

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -15,9 +15,10 @@ end
 
 ex = 1 + (:x - 2)
 
-@test simplify(ex) == ex # Not simplified because symtype Any
+SymbolicUtils.to_symbolic(ex::Expr) = ex
+
+@test simplify(ex) == ex
 
 SymbolicUtils.symtype(::Expr) = Real
-
 @test simplify(ex) == -1 + :x
 @test simplify(:a * (:b + -1 * :c) + -1 * (:b * :a + -1 * :c * :a), polynorm=true) == 0

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -20,3 +20,4 @@ ex = 1 + (:x - 2)
 SymbolicUtils.symtype(::Expr) = Real
 
 @test simplify(ex) == -1 + :x
+@test simplify(:a * (:b + -1 * :c) + -1 * (:b * :a + -1 * :c * :a), polynorm=true) == 0


### PR DESCRIPTION
(part of #90)