### PR TITLE
WIP: metadata system

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -125,9 +125,11 @@ means the variable is a function with the type signature X -> Y where
 """
 struct Sym{T} <: Symbolic{T}
     name::Symbol
+    metadata::Dict{Type, Any}
 end
 
 const Variable = Sym # old name
+Sym{T}(x) where {T} = Sym{T}(x, Dict{Type,Any}())
 Sym(x) = Sym{symtype(x)}(x)
 
 Base.nameof(v::Sym) = v.name
@@ -264,15 +266,19 @@ See [promote_symtype](#promote_symtype)
 struct Term{T} <: Symbolic{T}
     f::Any
     arguments::Any
+    metadata::Dict{Type, Any}
 end
 
 istree(t::Term) = true
 
+Term{T}(f, args) where {T} = Term{T}(f, args, Dict{Type,Any}())
 Term(f, args) = Term{rec_promote_symtype(f, map(symtype, args)...)}(f, args)
 
 operation(x::Term) = x.f
 
 arguments(x::Term) = x.arguments
+
+metadata(t::Symbolic, T::Type) = get(t.metadata, T, nothing)
 
 function Base.hash(t::Term{T}, salt::UInt) where {T}
     hash(arguments(t), hash(operation(t), hash(T, salt)))

--- a/src/types.jl
+++ b/src/types.jl
@@ -136,6 +136,8 @@ Base.nameof(v::Sym) = v.name
 
 Base.isequal(v1::Sym{T}, v2::Sym{T}) where {T} = v1 === v2
 
+Base.hash(s::Sym{T}, salt::UInt) where {T} = hash(T, hash(s.name, salt))
+
 Base.show(io::IO, v::Sym) = print(io, v.name)
 
 #---------------------------

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,7 @@ include("rewrite.jl")
 include("rulesets.jl")
 include("nf.jl")
 include("interface.jl")
-include("fuzz.jl")
 if haskey(ENV, "TRAVIS")
     include("benchmark.jl")
 end
+include("fuzz.jl")


### PR DESCRIPTION
`Term` and `Sym` should maintain a dictionary which given a type will give you a single value which is the metadata associated with the object for that "context" type.

I will try to optimize this with `ImmutableDict`, but this is the general idea I'm going for.

Any comments @MasonProtter @YingboMa @ChrisRackauckas ?

Something like this is required to store array shapes to implement symbolic arrays.