### PR TITLE
speed up hash on Term

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -278,8 +278,11 @@ operation(x::Term) = x.f
 
 arguments(x::Term) = x.arguments
 
+## This is much faster than hash of an array of Any
+hashvec(xs, z) = foldr(hash, xs, init=z)
+
 function Base.hash(t::Term{T}, salt::UInt) where {T}
-    hash(arguments(t), hash(operation(t), hash(T, salt)))
+    hashvec(arguments(t), hash(operation(t), hash(T, salt)))
 end
 
 function Base.isequal(t1::Term, t2::Term)


### PR DESCRIPTION
With this,
```julia
julia> @btime hash($(a+1))
  105.839 ns (5 allocations: 80 bytes)
0xba5e19c850a1204d
```
Without this,
```julia
julia> @btime hash($(a+1))
  506.854 ns (10 allocations: 192 bytes)
0xe566d1194511d3f0
```