### PR TITLE
fix error message in assertlike

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -9,7 +9,7 @@ const previously_declared_for = Set([])
 assert_like(f, T) = nothing
 function assert_like(f, T, a, b...)
     islike(a, T) || throw(ArgumentError("The function $f cannot be applied to $a which is not a $T-like object." *
-                                           "Define `isnumberlike(::$(typeof(a))) = true` to enable this."))
+                                        "Define `islike(::$(typeof(a)), ::Type{$T}) = true` to enable this."))
     assert_like(f, T, b...)
 end
 


### PR DESCRIPTION
In https://github.com/JuliaSymbolics/SymbolicUtils.jl/issues/134#issuecomment-721700399, it was pointed out that the error message points to `isnumberlike` instead of `islike`. Closes #134 