### PR TITLE
Convert `inv` to literal pow

### DIFF
--- a/src/abstractalgebra.jl
+++ b/src/abstractalgebra.jl
@@ -65,10 +65,8 @@ let
                    @acrule(~x::ismpoly * ~y::ismpoly => ~x * ~y)
                    @rule(*(~x) => ~x)
                    @rule((~x::ismpoly)^(~a::isnonnegint) => (~x)^(~a))]
-    MPOLY_CLEANUP = Fixpoint(Postwalk(PassThrough(RestartedChain(mpoly_preprocess))))
+    global const MPOLY_CLEANUP = Fixpoint(Postwalk(PassThrough(RestartedChain(mpoly_preprocess))))
     MPOLY_MAKER = Fixpoint(Postwalk(PassThrough(RestartedChain(mpoly_rules))))
-
-    global MPOLY_CLEANUP
 
     global to_mpoly
     function to_mpoly(t, dicts=_dicts())

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -1,4 +1,4 @@
-const monadic = [deg2rad, rad2deg, transpose, -, conj, asind, log1p, acsch, acos, asec, acosh, acsc, cscd, log, tand, log10, csch, asinh, abs2, cosh, sin, cos, atan, cospi, cbrt, acosd, acoth, inv, acotd, asecd, exp, acot, sqrt, sind, sinpi, asech, log2, tan, exp10, sech, coth, asin, cotd, cosd, sinh, abs, csc, tanh, secd, atand, sec, acscd, cot, exp2, expm1, atanh, real]
+const monadic = [deg2rad, rad2deg, transpose, -, conj, asind, log1p, acsch, acos, asec, acosh, acsc, cscd, log, tand, log10, csch, asinh, abs2, cosh, sin, cos, atan, cospi, cbrt, acosd, acoth, acotd, asecd, exp, acot, sqrt, sind, sinpi, asech, log2, tan, exp10, sech, coth, asin, cotd, cosd, sinh, abs, csc, tanh, secd, atand, sec, acscd, cot, exp2, expm1, atanh, real]
 
 const diadic = [+, -, max, min, *, /, \, hypot, atan, mod, rem, ^, copysign]
 
@@ -135,3 +135,5 @@ function cond(_if::Symbolic{Bool}, _then, _else)
     Term{Union{symtype(_then), symtype(_else)}}(cond, Any[_if, _then, _else])
 end
 
+# Specially handle inv
+Base.inv(x::Symbolic) = x ^ -1

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -136,4 +136,4 @@ function cond(_if::Symbolic{Bool}, _then, _else)
 end
 
 # Specially handle inv
-Base.inv(x::Symbolic) = x ^ -1
+Base.inv(x::Symbolic) = Base.:^(x, -1)

--- a/src/simplify_rules.jl
+++ b/src/simplify_rules.jl
@@ -39,6 +39,7 @@ let
         @rule((((~x)^(~p::isliteral(Integer)))^(~q::isliteral(Integer))) => (~x)^((~p)*(~q)))
         @rule(^(~x, ~z::_iszero) => 1)
         @rule(^(~x, ~z::_isone) => ~x)
+        @rule(inv(~x) => ~x ^ -1)
     ]
 
     ASSORTED_RULES = [


### PR DESCRIPTION
Should accomplish the goal "make sure inv does not get introduced, only negative powers do." in https://github.com/JuliaSymbolics/SymbolicUtils.jl/issues/133

I also made a random `global` I noticed a `global const`. Does `MPOLY_CLEANUP` even need to be a `global`, or can it just be internal?