### PR TITLE
Update methods.jl

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -84,7 +84,7 @@ for f in monadic
     if f in [real]
         continue
     end
-    @eval promote_symtype(::$(typeof(f)), T::Type{<:Number}) = Number
+    @eval promote_symtype(::$(typeof(f)), T::Type{<:Number}) = T
     @eval (::$(typeof(f)))(a::Symbolic)   = term($f, a)
 end
 


### PR DESCRIPTION
I'm new to the library so take this with a grain of salt, but it seems like this change fixes a problem.  Or at least I found the behavior counter intuitive.

Here's an example:
```julia
julia> @syms x::Real y::Real
(x, y)

julia> typeof(atan(y,x))
SymbolicUtils.Term{Real}

julia> typeof(sqrt(x))
SymbolicUtils.Term{Number}
```

In other words, it looks like diadic functions are maintaining the type of symbols, but monadic functions are promoting a Real to a Number, which could be for example a Complex number, which is not what I was wanting.

Thanks for your work on this library,
-Matt