### PR TITLE
Terms constructed by substitution should be the same as terms constructed by evaluation

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -134,8 +134,12 @@ for (f, Domain) in [(==) => Number, (!=) => Number,
     end
 end
 
-Base.:!(s::Symbolic{Bool}) = Term{Bool}(!, [s])
-Base.:~(s::Symbolic{Bool}) = Term{Bool}(!, [s])
+for f in [!, ~]
+    @eval begin
+        promote_symtype(::$(typeof(f)), ::Type{<:Bool}) = Bool
+        (::$(typeof(f)))(s::Symbolic{Bool}) = Term{Bool}(!, [s])
+    end
+end
 
 
 # An ifelse node, ifelse is a built-in unfortunately

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -97,7 +97,7 @@ for f in monadic
     if f in [real]
         continue
     end
-    @eval promote_symtype(::$(typeof(f)), T::Type{<:Number}) = Number
+    @eval promote_symtype(::$(typeof(f)), T::Type{<:Number}) = promote_type(T, Real)
     @eval (::$(typeof(f)))(a::Symbolic)   = term($f, a)
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -299,7 +299,7 @@ end
 
 function term(f, args...; type = nothing)
     if type === nothing
-        T = rec_promote_symtype(f, symtype.(args)...)
+        T = rec_promote_symtype(f, map(symtype, args)...)
     else
         T = type
     end
@@ -313,7 +313,7 @@ Create a term that is similar in type to `t` such that `symtype(similarterm(f,
 args...)) === symtype(f(args...))`.
 """
 similarterm(t, f, args) = f(args...)
-similarterm(::Term, f, args) = Term(f, args)
+similarterm(::Term, f, args) = term(f, args...)
 
 node_count(t) = istree(t) ? reduce(+, node_count(x) for x in  arguments(t), init=0) + 1 : 1
 


### PR DESCRIPTION
We need `symtype(similarterm(f, args...)) === symtype(f(args...))` to
make sure that terms constructed by substitution are the same as terms
constructed by evaluation.

This PR also fixes `isequal(::Add, ::Symbolic)`-like checks.