### PR TITLE
Switch Sym printer to use Julia's syntax printer

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -146,7 +146,7 @@ Base.hash(s::Sym{T}, u::UInt) where {T} = hash(T, hash(s.name, u))
 
 Base.isequal(v1::Sym{T}, v2::Sym{T}) where {T} = v1 === v2
 
-Base.show(io::IO, v::Sym) = print(io, v.name)
+Base.show(io::IO, v::Sym) = Base.show_unquoted(io, v.name)
 
 #---------------------------
 #---------------------------


### PR DESCRIPTION
Since SymbolicUtils puns on julia's syntax, it should probably use the Julia
symbol printer to make sure that non-identifier symbols can be entered back.

Before:
```
julia> @syms var"f(x)"
(f(x),)
```

After:
```
julia> @syms var"f(x)"
(var"f(x)",)
```