### PR TITLE
default to symtype(x) = typeof(x)

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -52,7 +52,7 @@ function symtype end
 
 symtype(x::Number) = typeof(x)
 
-symtype(x) = Any
+symtype(x) = typeof(x)
 
 symtype(::Symbolic{T}) where {T} = T
 


### PR DESCRIPTION
This tiny PR just changes

```julia
symtype(x) = Any
```

to

```julia
symtype(x) = typeof(x)
```

The current implementation leads to a loss of type information for many non-symbolic values. This propagates up the tree, leading to lots of expressions erroneously being considered `::Any`