### PR TITLE
Allow StaticArrays 0.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ IfElse = "0.1"
 LabelledArrays = "1.5"
 NaNMath = "0.3"
 SpecialFunctions = "0.10, 1.0"
-StaticArrays = "1.0"
+StaticArrays = "0.12, 1.0"
 TimerOutputs = "0.5"
 julia = "1.3"
 


### PR DESCRIPTION
Soss has some dependencies that haven't yet updated their `StaticArrays` compat to 1.0. Could we loosen this a little?