### PR TITLE
Small page/manual link fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ a Computer Algebra System (CAS). If you're looking for a complete CAS, similar t
 [Symbolics.jl](https://github.com/JuliaSymbolics/Symbolics.jl). If you want to build a crazy CAS for your weird
 Octonian algebras, you've come to the right place.
 
-[Symbols in SymbolicUtils](https://juliasymbolics.github.io/SymbolicUtils.jl/#creating_symbolic_expressions) carry type information. Operations on them propagate this information. [A rule-based rewriting language](https://juliasymbolics.github.io/SymbolicUtils.jl/#rule-based_rewriting) can be used to find subexpressions that satisfy arbitrary conditions and apply arbitrary transformations on the matches. The library also contains a set of useful [simplification](https://juliasymbolics.github.io/SymbolicUtils.jl/#simplification) rules for expressions of numeric symbols and numbers. These can be remixed and extended for special purposes.
+[Symbols in SymbolicUtils](https://symbolicutils.juliasymbolics.org/#creating_symbolic_expressions) carry type information. Operations on them propagate this information. [A rule-based rewriting language](https://symbolicutils.juliasymbolics.org/rewrite/#rule-based_rewriting) can be used to find subexpressions that satisfy arbitrary conditions and apply arbitrary transformations on the matches. The library also contains a set of useful [simplification](https://juliasymbolics.github.io/SymbolicUtils.jl/#simplification) rules for expressions of numeric symbols and numbers. These can be remixed and extended for special purposes.
 
 
-If you are a Julia package develper in need of a rule rewriting system for your own types, have a look at the [interfacing guide](https://juliasymbolics.github.io/SymbolicUtils.jl/interface/).
+If you are a Julia package develper in need of a rule rewriting system for your own types, have a look at the [interfacing guide](https://symbolicutils.juliasymbolics.org/interface/).
 
 [**Go to the manual**](https://juliasymbolics.github.io/SymbolicUtils.jl/)
 

--- a/page/_layout/page_foot.html
+++ b/page/_layout/page_foot.html
@@ -1,5 +1,5 @@
 <div class="page-foot">
   <div class="copyright">
-    &copy; {{ fill authors }}. {{isnotpage /tag/*}}Last modified: {{ fill fd_mtime }}.{{end}} Website built with <a href="https://github.com/tlienart/Franklin.jl">Franklin.jl</a>.
+    &copy; {{ fill authors }}. {{isnotpage /tag/*}}Last modified: {{ fill fd_mtime }}.{{end}} Website built with <a href="https://github.com/tlienart/Franklin.jl">Franklin.jl</a> and <a href="https://github.com/tlienart/PkgPage.jl">PkgPage.jl</a>.
   </div>
 </div>

--- a/page/index.md
+++ b/page/index.md
@@ -18,11 +18,11 @@ where appropriate -->
 **Features:**
 
 - Fast expressions
-- A [combinator library](#composing_rewriters) for making rewriters.
-- A [rule-based rewriting language](#rule-based_rewriting).
+- A [combinator library](/rewrite/#composing_rewriters) for making rewriters.
+- A [rule-based rewriting language](/rewrite/#rule-based_rewriting).
 - Type promotion:
-  - Symbols (`Sym`s) carry type information. ([read more](#symbolic_expressions))
-  - Compound expressions composed of `Sym`s propagate type information. ([read more](#symbolic_expressions))
+  - Symbols (`Sym`s) carry type information. ([read more](#creating_symbolic_expressions))
+  - Compound expressions composed of `Sym`s propagate type information. ([read more](#expression_interface))
 - Set of extendable [simplification rules](#simplification).
 
 


### PR DESCRIPTION
Hi, I've decided to try to do something useful as I was going through manual 😃 

I fixed the links in the readme and at the index page of the manual (they didn't work). I also changed links from `juliasymbolics.github.io/SymbolicUtils.jl` to `https://symbolicutils.juliasymbolics.org`. Not sure whether it's the right way. I see the pages are in `PkgPage.jl` and it said to edit index.md directly.

I think it will be easier for first time contributors (such as me) if it was written what are the docs/pages built in. It says "Website built with Franklin.jl." at the bottom of the page, but I've found that PkgPage.jl is used only after looking at CI and gh-pages branch. So I added PkgPage.jl with link to "Website built with..." part in the footer.