### PR TITLE
default for `polynorm` should be `true`, fixed

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -12,7 +12,7 @@ Simplify an expression (`x`) by applying `rewriter` until there are no changes.
 `polynorm=true` applies `polynormalize` in the beginning of each fixpoint iteration.
 """
 function simplify(x;
-                  polynorm=false,
+                  polynorm=true,
                   threaded=false,
                   thread_subtree_cutoff=100,
                   rewriter=nothing)


### PR DESCRIPTION
I did not bump the version number bcaws I do not know how you are using it, or if more than one change goes into the next step.