### PR TITLE
hopefully fix getemetadata default

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -69,7 +69,7 @@ function getmetadata(s::Symbolic, ctx)
 end
 
 function getmetadata(s::Symbolic, ctx, default)
-    s.metadata isa Ref ? get(s.metadata[], ctx, default) : default
+    s.metadata isa AbstractDict ? get(s.metadata, ctx, default) : default
 end
 
 # pirated for Setfield purposes:


### PR DESCRIPTION
At the risk of completely misunderstanding what this function is supposed to do, the current behavior will always return the default value if the metadata is a Dict, as is the result of calling setmetadata on a symbol without any previous metadata. I don't see any code that sets the metadata to a Ref, but I could be completely wrong.