### PR TITLE
Make print_tree show coefficients for Add and Mul

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -902,7 +902,17 @@ struct TreePrint
     x
 end
 AbstractTrees.children(x::Term) = arguments(x)
-AbstractTrees.children(x::Union{Add, Mul}) = map(y->TreePrint(x isa Add ? (:*) : (:^), y), collect(pairs(x.dict)))
+function AbstractTrees.children(x::Union{Add, Mul})
+    children = Any[x.coeff]
+    for (key, coeff) in pairs(x.dict)
+        if coeff == 1
+            push!(children, key)
+        else
+            push!(children, TreePrint(x isa Add ? (:*) : (:^), (key, coeff)))
+        end
+    end
+    return children
+end
 AbstractTrees.children(x::Union{Pow}) = [x.base, x.exp]
 AbstractTrees.children(x::TreePrint) = [x.x[1], x.x[2]]
 


### PR DESCRIPTION
Also makes printing less verbose when the coefficient/power on a given term is one.
Before:
```
3 + x + 5y
+
├─ (*)
│  ├─ x
│  └─ 1
└─ (*)
   ├─ y
   └─ 5

2x*(y^-1)
*
├─ (^)
│  ├─ x
│  └─ 1
└─ (^)
   ├─ y
   └─ -1
```
After:
```
3 + x + 5y
+
├─ 3
├─ x
└─ (*)
   ├─ y
   └─ 5

2x*(y^-1)
*
├─ 2
├─ x
└─ (^)
   ├─ y
   └─ -1
```