### PR TITLE
Fix domain error in Mul with literal base and power

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -729,7 +729,7 @@ operation(a::Mul) = *
 
 function arguments(a::Mul)
     a.sorted_args_cache[] !== nothing && return a.sorted_args_cache[]
-    args = sort!([k^v for (k,v) in a.dict], lt=<ₑ)
+    args = sort!([Pow(k, v) for (k,v) in a.dict], lt=<ₑ)
     a.sorted_args_cache[] = isone(a.coeff) ? args : vcat(a.coeff, args)
 end
 


### PR DESCRIPTION
Fixes this use case:
```
julia> using Symbolics

julia> @variables x
(x,)

julia> R = [1/x -1/x ; 1 1]
2×2 Matrix{Num}:
 x^-1  -(x^-1)
    1        1

julia> simplify.(inv(R))
2×2 Matrix{Num}:
 x*(1 - (2^-1))  2^-1
      -x*(2^-1)  2^-1

julia> simplify.(simplify.(inv(R)) * R)
2×2 Matrix{Num}:
 1  2^-1 - (1 - (2^-1))
 0                    1
```
It would be nice if that last simplify could deal with the literals...

Fixes #244.