### PR TITLE
Updates and adjustments for manual, especially rewriters section

### DIFF
--- a/page/index.md
+++ b/page/index.md
@@ -74,7 +74,7 @@ As their types are different:
 
 (see [this post](https://discourse.julialang.org/t/ann-symbolicutils-jl-groundwork-for-a-symbolic-ecosystem-in-julia/38455/13?u=shashi) for why they are all not just subtypes of `Number`)
 
-Julia automatically simplifies
+SymbolicUtils automatically simplifies
 
 ```julia:creating1
 2w + 3w - 3z + α
@@ -86,7 +86,7 @@ and reorders
 (z + w)*(α + β)
 ```
 
-expressions of `Symbolic{<:Any}` (which include `Sym{Number}` and `Sym{Real}`) when they are created. It also does constant elimination (including rational numbers)
+expressions of `Symbolic{<:Number}` (which includes `Sym{Real}`) when they are created. It also does constant elimination (including rational numbers)
 
 ```julia:creating3
 5 + 2w - 3z + α - (β + 5//3) + 3w - 2 + 3//2 * β
@@ -151,7 +151,7 @@ SymbolicUtils contains [a rule-based rewriting language](/rewrite/#rule-based_re
 
 By default `*` and `+` operations apply the most basic simplification upon construction of the expression.
 
-Commutativity and associativity are assumed over `+` and `*` operations on `Symbolic{<:Any}` at the moment.
+Commutativity and associativity are assumed over `+` and `*` operations on `Symbolic{<:Number}`.
 
 ```julia:simplify1
 2 * (w+w+α+β + sin(z)^2 + cos(z)^2 - 1)

--- a/page/index.md
+++ b/page/index.md
@@ -74,6 +74,15 @@ As their types are different:
 
 (see [this post](https://discourse.julialang.org/t/ann-symbolicutils-jl-groundwork-for-a-symbolic-ecosystem-in-julia/38455/13?u=shashi) for why they are all not just subtypes of `Number`)
 
+You can do basic arithmetic on symbols to get symbolic expressions:
+
+```julia:expr
+expr1 = α*sin(w)^2 + β*cos(z)^2
+expr2 = α*cos(z)^2 + β*sin(w)^2
+
+expr1 + expr2
+```
+
 SymbolicUtils automatically simplifies
 
 ```julia:creating1
@@ -86,22 +95,13 @@ and reorders
 (z + w)*(α + β)
 ```
 
-expressions of `Symbolic{<:Number}` (which includes `Sym{Real}`) when they are created. It also does constant elimination (including rational numbers)
+expressions of type `Symbolic{<:Number}` (which includes `Sym{Real}`) when they are created. It also does constant elimination (including rational numbers)
 
 ```julia:creating3
 5 + 2w - 3z + α - (β + 5//3) + 3w - 2 + 3//2 * β
 ```
 
 It's worth remembering that the expression may be transformed with respect to the input when it's created.
-
-You can do basic arithmetic on symbols to get symbolic expressions:
-
-```julia:expr
-expr1 = α*sin(w)^2 + β*cos(z)^2
-expr2 = α*cos(z)^2 + β*sin(w)^2
-
-expr1 + expr2
-```
 
 
 **Function-like symbols**

--- a/page/index.md
+++ b/page/index.md
@@ -65,13 +65,40 @@ Note however that they are not subtypes of these types!
 @show α isa Real
 ```
 
+As their types are different:
+
+```julia:symtype3
+@show typeof(w)
+@show typeof(α)
+```
+
 (see [this post](https://discourse.julialang.org/t/ann-symbolicutils-jl-groundwork-for-a-symbolic-ecosystem-in-julia/38455/13?u=shashi) for why they are all not just subtypes of `Number`)
+
+Julia automatically simplifies
+
+```julia:creating1
+2w + 3w - 3z + α
+```
+
+and reorders
+
+```julia:creating2
+(z + w)*(α + β)
+```
+
+expressions of `Symbolic{<:Any}` (which include `Sym{Number}` and `Sym{Real}`) when they are created. It also does constant elimination (including rational numbers)
+
+```julia:creating3
+5 + 2w - 3z + α - (β + 5//3) + 3w - 2 + 3//2 * β
+```
+
+It's worth remembering that the expression may be transformed with respect to the input when it's created.
 
 You can do basic arithmetic on symbols to get symbolic expressions:
 
 ```julia:expr
-expr1 = α*sin(w)^2 +  β*cos(z)^2
-expr2 = α*cos(z)^2 +  β*sin(w)^2
+expr1 = α*sin(w)^2 + β*cos(z)^2
+expr2 = α*cos(z)^2 + β*sin(w)^2
 
 expr1 + expr2
 ```
@@ -88,19 +115,18 @@ using SymbolicUtils
 f(z) + g(1, α) + sin(w)
 ```
 
+This does not work since `z` is a `Number`, not a `Real`.
 
 ```julia:sym3
 g(1, z)
 ```
 
-
-This does not work since `z` is a `Number`, not a `Real`.
+This works because `g` "returns" a `Real`.
 
 ```julia:sym4
 g(2//5, g(1, β))
 ```
 
-This works because `g` "returns" a `Real`.
 
 
 ## Expression interface
@@ -123,15 +149,21 @@ SymbolicUtils contains [a rule-based rewriting language](/rewrite/#rule-based_re
 
 ## Simplification
 
-By default `*` and `+` operations apply the most basic simplification upon construction.
+By default `*` and `+` operations apply the most basic simplification upon construction of the expression.
+
+Commutativity and associativity are assumed over `+` and `*` operations on `Symbolic{<:Any}` at the moment.
+
+```julia:simplify1
+2 * (w+w+α+β + sin(z)^2 + cos(z)^2 - 1)
+```
 
 The `simplify` function applies a built-in set of rules to rewrite expressions in order to simplify it.
 
-```julia:simplify1
+```julia:simplify2
 simplify(2 * (w+w+α+β + sin(z)^2 + cos(z)^2 - 1))
 ```
 
-The rules in the default simplify applies simple constant elemination, trigonometric identities.
+The rules in the default simplify applies simple constant elimination and trigonometric identities.
 
 If you read the previous section on the rules DSL, you should be able to read and understand the [rules](https://github.com/JuliaSymbolics/SymbolicUtils.jl/blob/master/src/simplify_rules.jl) that are used by `simplify`.
 

--- a/page/index.md
+++ b/page/index.md
@@ -18,8 +18,8 @@ where appropriate -->
 **Features:**
 
 - Fast expressions
-- A [combinator library](/rewrite/#composing_rewriters) for making rewriters.
 - A [rule-based rewriting language](/rewrite/#rule-based_rewriting).
+- A [combinator library](/rewrite/#composing_rewriters) for making rewriters.
 - Type promotion:
   - Symbols (`Sym`s) carry type information. ([read more](#creating_symbolic_expressions))
   - Compound expressions composed of `Sym`s propagate type information. ([read more](#expression_interface))

--- a/page/rewrite.md
+++ b/page/rewrite.md
@@ -2,7 +2,7 @@
 
 ## Rule-based rewriting
 
-Rewrite rules match and transform an expression. A rule is written using either the `@rule` macro or the `@acrule` macro. It creates callable `Rule` object.
+Rewrite rules match and transform an expression. A rule is written using either the `@rule` macro or the `@acrule` macro. It creates a callable `Rule` object.
 
 ### Basics of rule-based term rewriting in SymbolicUtils
 
@@ -207,7 +207,7 @@ rcas = RestartedChain([acpyid, sqexpand])
 rcas((cos(x) + sin(x))^2)
 ```
 
-It restarts the chain after each successful application of the rule, so after `sqexpand` is hit it (re)starts again and successfully applies `acpyid` to resulting expression.
+It restarts the chain after each successful application of a rule, so after `sqexpand` is hit it (re)starts again and successfully applies `acpyid` to resulting expression.
 
 You can also use `Fixpoint` to apply the rules until there are no changes.
 

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -179,11 +179,11 @@ cos((1 + a))
 A rule with 2 segment variables
 
 ```julia
-julia> r = @rule ~x - ~y => ~x + (-(~y))
-~x - ~y => ~x + -(~y)
+julia> r = @rule sin(~x + ~y) => sin(~x)*cos(~y) + cos(~x)*sin(~y)
+sin(~x + ~y) => sin(~x) * cos(~y) + cos(~x) * sin(~y)
 
-julia> r(a-2b)
-(a + (-(2 * b)))
+julia> r(sin(a + b))
+cos(a)*sin(b) + sin(a)*cos(b)
 ```
 
 A rule that matches two of the same expressions:


### PR DESCRIPTION
Hi, reading manual and getting myself familiar with SymbolicUtils I've tried to update and fix it a bit. 😉 

- I've added some info about automatic simplification of  in index.md;
- Updated docstring in rule.jl to make sense considering current autosimplification rules;
- Updated and extended rewrite.md file with adjustments for autosimplification, a bit more of verbosity for new users and few more examples.

I've planned to add "walking the tree" section in rewriters, but this PR is already taking too long, so decided to put it off to some other PR.

Please let me know if this makes sense and whether some corrections are necessary.

This should close #258.

PS Please feel free to squash the commits on merge (if it happens), they're a bit untidy, but I didn't know whether any corrections are needed, so decided not to.