### PR TITLE
Fix printing of `^` with negative base

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -469,7 +469,13 @@ end
 function show_pow(io, args)
     base, ex = args
 
-    print_arg(io, base, paren=true)
+    if base isa Real && base < 0
+        print(io, "(")
+        print_arg(io, base)
+        print(io, ")")
+    else
+        print_arg(io, base, paren=true)
+    end
     print(io, "^")
     print_arg(io, ex, paren=true)
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -153,6 +153,8 @@ end
     @test repr((a + b) - (b + c)) == "a - c"
     @test repr(a + -1*(b + c)) == "a - b - c"
     @test repr(a + -1*b) == "a - b"
+    @test repr(-1^a) == "-(1^a)"
+    @test repr((-1)^a) == "(-1)^a"
 end
 
 @testset "similarterm with Add" begin


### PR DESCRIPTION
Fixes https://github.com/JuliaSymbolics/SymbolicUtils.jl/issues/149