### PR TITLE
Add missing @inbounds in DestructuredArgs

### DIFF
--- a/src/code.jl
+++ b/src/code.jl
@@ -136,10 +136,11 @@ end
     elems
     inds
     name
+    inbounds::Bool
 end
 
-function DestructuredArgs(elems, name=gensym("arg"); inds=eachindex(elems))
-    DestructuredArgs(elems, inds, name)
+function DestructuredArgs(elems, name=gensym("arg"); inds=eachindex(elems), inbounds=false)
+    DestructuredArgs(elems, inds, name, inbounds)
 end
 
 """
@@ -164,8 +165,10 @@ cflatten(x) = Iterators.flatten(x) |> collect
 function get_assignments(d::DestructuredArgs, st)
     name = toexpr(d, st)
     map(d.inds, d.elems) do i, a
-        a ← (i isa Symbol ? :($name.$i) : :($name[$i]))
-    end
+        ex = (i isa Symbol ? :($name.$i) : :($name[$i]))
+        ex = d.inbounds ? :(@inbounds($ex)) : ex
+        a ← ex
+    end   
 end
 
 @matchable struct Let

--- a/test/code.jl
+++ b/test/code.jl
@@ -45,6 +45,12 @@ test_repr(a, b) = @test repr(Base.remove_linenums!(a)) == repr(Base.remove_linen
                         $(+)(a, b, var"x(t)", x($(+)(1, t)))
                     end
                 end))
+
+    ex = toexpr(Func([DestructuredArgs([x, x(t)], :state, inbounds=true)], [], x(t+1) + x(t)))
+    for e ∈ ex.args[2].args[3].args[1].args
+        @test e.args[2].head == :macrocall
+    end
+
     test_repr(toexpr(SetArray(false, a, [x(t), AtIndex(9, b), c])),
               quote
                   a[1] = x(t)


### PR DESCRIPTION
Fix for https://github.com/JuliaSymbolics/Symbolics.jl/issues/177

I still need to prepare code changes and a PR to use the `inbounds` flag in
- `Symbolics.jl`
- `ModelingToolkit.jl`

Please let me know if I'm forgetting any other project that have to be updated from this change.

Note that the unit test is a little bit awkward. I tried to find a better way of doing it, but the macro expansion adds the source of the macro, making it hard to use the `test_repr` pattern that is in place. Please let me know if there is a better alternative to what I did.