### PR TITLE
Add some PassThroughs to Walk rewriters

### DIFF
--- a/src/rewriters.jl
+++ b/src/rewriters.jl
@@ -133,12 +133,12 @@ function (p::Walk{ord, C, F, false})(x) where {ord, C, F}
     @assert ord === :pre || ord === :post
     if istree(x)
         if ord === :pre
-            x = p.rw(x)
+            x = PassThrough(p.rw)(x)
         end
         if istree(x)
             x = p.similarterm(x, operation(x), map(PassThrough(p), arguments(x)))
         end
-        return ord === :post ? p.rw(x) : x
+        return ord === :post ? PassThrough(p.rw)(x) : x
     else
         return p.rw(x)
     end
@@ -148,7 +148,7 @@ function (p::Walk{ord, C, F, true})(x) where {ord, C, F}
     @assert ord === :pre || ord === :post
     if istree(x)
         if ord === :pre
-            x = p.rw(x)
+            x = PassThrough(p.rw)(x)
         end
         if istree(x)
             _args = map(arguments(x)) do arg
@@ -161,7 +161,7 @@ function (p::Walk{ord, C, F, true})(x) where {ord, C, F}
             args = map((t,a) -> passthrough(t isa Task ? fetch(t) : t, a), _args, arguments(x))
             t = p.similarterm(x, operation(x), args)
         end
-        return ord === :post ? p.rw(t) : t
+        return ord === :post ? PassThrough(p.rw)(t) : t
     else
         return p.rw(x)
     end

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -14,6 +14,10 @@ using SymbolicUtils: getdepth, Rewriters, Term
 
     @eqtest rset(ex) == (((2 * w) + (2 * w)) + (2 * α)) + (2 * β)
     @eqtest Rewriters.Fixpoint(rset)(ex) == ((2 * (2 * w)) + (2 * α)) + (2 * β)
+
+    r3 = @rule(sqrt(~x) => (~x)^(1/2))
+    @eqtest Rewriters.Prewalk(r3)(z*sqrt(z)) == z^(3/2)
+    @eqtest Rewriters.Postwalk(r3)(z*sqrt(z)) == z^(3/2)
 end
 
 @testset "Numeric" begin


### PR DESCRIPTION
Following a discussion on Slack, this makes `Prewalk`/`Postwalk` behave more
intuitively by adding some `PassThrough`s. I'm submitting this as a PR and not
an issue because I have some code, but I'm not sure that this is the right
approach. Consider:
```
julia> r1 = @rule sqrt(~x) => (~x)^(1/2)
sqrt(~x) => (~x) ^ (1 / 2)

julia> Prewalk(r1)(sqrt(n)*n)
n^1.5

julia> Prewalk(r1)(exp(n)*n)
n*exp(n)

julia> Prewalk(r1)(n)

```
So, as you can see, it handles expressions differently based on `istree`. I'm
not sure if this is an issue. It would be easy to make the last case consistent
with the first two (i.e. return `n`). It would be somewhat more computationally
expensive to make it always return `nothing` if the expression has not changed.
