### PR TITLE
Allow interpolating in LHS of the rules

### DIFF
--- a/src/matchers.jl
+++ b/src/matchers.jl
@@ -88,7 +88,7 @@ function matcher(term::Term)
     function term_matcher(success, data, bindings)
 
         !islist(data) && return nothing
-        !(istree(car(data))) && return nothing
+        !istree(car(data)) && return nothing
 
         function loop(term, bindings′, matchers′) # Get it to compile faster
             if !islist(matchers′)

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -69,6 +69,8 @@ function makepattern(expr, keys)
             else
                 :(term($(map(x->makepattern(x, keys), expr.args)...); type=Any))
             end
+        elseif expr.head === :$
+            return esc(expr.args[1])
         else
             error("Unsupported Expr of type $(expr.head) found in pattern")
         end

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -121,3 +121,12 @@ end
     expr1 = foldr((x,y)->rand([*, /])(x,y), rand([a,b,c,d], 100))
     SymbolicUtils.@timerewrite simplify(expr1)
 end
+
+
+@testset "interpolation" begin
+    f(y) = sin
+    @syms a
+
+    @test isnothing(@rule(f(1)(a) => 2)(sin(a)))
+    @test @rule($(f(1))(a) => 2)(sin(a)) == 2
+end


### PR DESCRIPTION
Came up  while matching this:

```julia
using ModelingToolkit
@parameters x t
@variables u(..)
Dx = Differential(x)
rhs = Dx(u(t, x))
r = @rule Differential(x)(u(t,x)) => "yes"
@show r(rhs.val) # nothing
```
But now you can do

```julia
r = @rule $(Differential(x))(u(t,x)) => "yes"
```

and it will match

@emmanuellujan