### PR TITLE
Add `@numrule` for rules matching `[-, /, \, \\] expressions`

### DIFF
--- a/src/SymbolicUtils.jl
+++ b/src/SymbolicUtils.jl
@@ -27,7 +27,7 @@ include("rewriters.jl")
 using .Rewriters
 
 using Combinatorics: permutations, combinations
-export @rule, @acrule, RuleSet
+export @rule, @acrule, @numrule, RuleSet
 
 # Rule type and @rule macro
 include("rule.jl")

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -20,6 +20,19 @@ end
     @test @rule( ~x => ~x)(2) === 2
 end
 
+@testset "Number matcher" begin
+    @test @numrule(-~x => ~x)(-a) === a
+    @test @numrule(~x-~y => ~x)(a-b) === a
+    @test @numrule(1/~x => ~x)(1/a) === a
+    @test @numrule(1/~x => ~x)(a\1) === a
+    @test @numrule(~x\1 => ~x)(1/a) === a
+    @test @numrule(~x\1 => ~x)(a\1) === a
+    @test @numrule(~x//2 => ~x)(a//2) === a
+    # there is a difference in representations between numeric // and
+    # symbolic
+    @test @numrule(~x//~y => ~x)(a//b) === a
+end
+
 @testset "Term matcher" begin
     @test @rule(sin(~x) => ~x)(sin(a)) === a
     @eqtest @rule(sin(~x) => ~x)(sin(a^2)) == a^2


### PR DESCRIPTION
fix #241 adding `@numrule` as proposed by @shashi 