### PR TITLE
More robust subtype check

### DIFF
--- a/test/basics.jl
+++ b/test/basics.jl
@@ -212,3 +212,10 @@ end
     @syms a b c
     @test isequal(a + b, a + b + 0.01 - 0.01)
 end
+
+@testset "subtyping" begin
+    T = FnType{Tuple{T,S,Int} where {T,S}, Real}
+    s = Sym{T}(:t)
+    @syms a b c::Int
+    @test isequal(arguments(s(a, b, c)), [a, b, c])
+end


### PR DESCRIPTION
Sometimes Julia turn `Tuple{Any}` into `Tuple{T} where T`, so we cannot reliably use `T.parameters` to query type parameters.
```julia
julia> SymbolicUtils.Sym{T}
Sym{SymbolicUtils.FnType{Tuple{Any}, Real}, M} where M

julia> SymbolicUtils.Sym{T}(:t) |> dump
Sym{SymbolicUtils.FnType{Tuple{T} where T, Real}, Nothing}
  name: Symbol t
  metadata: Nothing nothing
```