### PR TITLE
Clarify where `success` is defined

### DIFF
--- a/src/rule.jl
+++ b/src/rule.jl
@@ -138,10 +138,9 @@ function (r::Rule)(term)
     rhs = r.rhs
 
     try
-        return r.matcher((term,), EMPTY_DICT) do bindings, n
-            # n == 1 means that exactly one term of the input (term,) was matched
-            n == 1 ? (@timer "RHS" rhs(bindings)) : nothing
-        end
+        # n == 1 means that exactly one term of the input (term,) was matched
+        success(bindings, n) = n == 1 ? (@timer "RHS" rhs(bindings)) : nothing
+        return r.matcher(success, (term,), EMPTY_DICT)
     catch err
         throw(RuleRewriteError(r, term))
     end


### PR DESCRIPTION
I've been searching where `success(bindings′, 1)` was coming from inside `src/matchers.jl` for almost an hour. Only by accident, I figured out where it was defined. This PR makes the definition of `success` more explicit and therefore easier to find.