### PR TITLE
Add a doctest

### DIFF
--- a/.github/workflows/DeployPage.yml
+++ b/.github/workflows/DeployPage.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install Julia
       uses: julia-actions/setup-julia@v1
       with:
-        version: 1.5
+        version: 1 # Latest stable Julia version.
     # NOTE
     # Adjust the `input=""` on the last line to indicate where
     # the source of the package page is (`page/` by default).

--- a/Project.toml
+++ b/Project.toml
@@ -42,6 +42,7 @@ julia = "1.3"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -49,4 +50,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Test", "Random", "PkgBenchmark", "BenchmarkTools", "Pkg", "Zygote"]
+test = ["BenchmarkTools", "Documenter", "Pkg", "PkgBenchmark", "Random", "Test", "Zygote"]

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -1,0 +1,3 @@
+# docs/src
+
+This folder is required by Documenter.jl even if we only run doctests.

--- a/page/utils.jl
+++ b/page/utils.jl
@@ -13,6 +13,8 @@ function hfun_doc(params)
         doc = eval(Meta.parse("using SymbolicUtils; @doc SymbolicUtils.$fname"))
     end
     txt = Markdown.plain(doc)
+    # jldoctest blocks don't get syntax highlighting in Franklin.jl.
+    txt = replace(txt, "```jldoctest" => "```")
     # possibly further processing here
     body = Franklin.fd2html(txt, internal=true)
     return """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -167,8 +167,19 @@ function merge_repeats(merge, xs)
     return merged
 end
 
+"""
+    flatten_term(⋆, x)
 
-# Numbers to the back
+Return a flattened expression with the numbers at the back.
+
+# Example
+```jldoctest
+julia> @syms x y;
+
+julia> SymbolicUtils.flatten_term(+, y + y + x)
+x + 2y
+```
+"""
 function flatten_term(⋆, x)
     args = arguments(x)
     # flatten nested ⋆

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,22 @@
+using Documenter
+using Pkg
 using Test
 using SymbolicUtils
 import IfElse: ifelse
+
+DocMeta.setdocmeta!(
+    SymbolicUtils,
+    :DocTestSetup,
+    :(using SymbolicUtils);
+    recursive=true
+)
+
+# Only test one Julia version to avoid differences due to changes in printing.
+if v"1.6" ≤ VERSION < v"1.7-beta3.0"
+    doctest(SymbolicUtils)
+else
+    @warn "Skipping doctests"
+end
 
 # == / != syntax is nice, let's use it in tests
 macro eqtest(expr)
@@ -12,6 +28,7 @@ macro eqtest(expr)
     end |> esc
 end
 SymbolicUtils.show_simplified[] = false
+
 
 include("basics.jl")
 include("order.jl")


### PR DESCRIPTION
This is just a suggestion. In the Julia library, Documenter.jl is used to verify all the documentation via doctests. This means that Documenter's doctest logic should be quite robust. Since this package has a lot of examples in the docstrings, maybe it is a good idea to run doctests to avoid broken documentation.

EDIT: For example, other packages which also use doctests are [DataFrames.jl](https://github.com/JuliaData/DataFrames.jl) and [MCMCChains.jl](https://github.com/TuringLang/MCMCChains.jl).