### PR TITLE
Updated TermInterface.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -40,7 +40,7 @@ NaNMath = "0.3"
 Setfield = "0.7"
 SpecialFunctions = "0.10, 1.0"
 StaticArrays = "0.12, 1.0"
-TermInterface = "0.1.8"
+TermInterface = "0.2"
 TimerOutputs = "0.5"
 julia = "1.3"
 

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1,12 +1,6 @@
 using SymbolicUtils, Test
 using TermInterface
 
-TermInterface.istree(ex::Expr) = ex.head == :call
-TermInterface.operation(ex::Expr) = ex.args[1]
-TermInterface.arguments(ex::Expr) = ex.args[2:end]
-TermInterface.similarterm(x::Type{Expr}, head, args, symtype=nothing; metadata=nothing) = 
-    Expr(:call, head, args...)
-
 TermInterface.issym(s::Symbol) = true
 Base.nameof(s::Symbol) = s
 


### PR DESCRIPTION
Added `exprhead` that is used by MT's pattern matcher to match against the `<:Pattern` types. Fundamental in order to make the e-graph rewriting of symbolics to work.
Added `unsorted_arguments` to TermInterface

Now default interface for `Expr` is polished. TODO: add documentation saying that using `Expr` as Symbolic types is not probably a good idea.