### PR TITLE
add @slots macro to improve readability of rules

### DIFF
--- a/src/SymbolicUtils.jl
+++ b/src/SymbolicUtils.jl
@@ -35,7 +35,7 @@ include("rewriters.jl")
 using .Rewriters
 
 using Combinatorics: permutations, combinations
-export @rule, @acrule, RuleSet, @capture
+export @rule, @acrule, RuleSet, @capture, @slots
 
 # Rule type and @rule macro
 include("rule.jl")


### PR DESCRIPTION
My proposed, backwards-compatible rule syntax extension discussed in #344. This PR allows users to write, e.g., a chain of rules like:

```
@slots x y z a b c Chain([
    (@rule x^2 + 2xy + y^2 -> (x + y)^2),
    (@rule x^ay^b -> (xy)^ay^(b-a)),
    (@rule +(x...) -> sum(x)),
])
```

We could write a single rule as

`@rule a b a + b -> add(a, b)`

or 

`@slots a b @rule a + b -> add(a, b)`

This is accomplished by making 4 changes:
1. `@capture` and `@rule` take an optional (prefixed) list of symbols to turn into slots, e.g. `@rule a b a + b -> add(a, b)`
2. `@slots syms... expr` adds the list of symbols `syms` to the beginning of each macrocall `@rule` `@capture` or `@slots` in the expression `expr`.
3. If a slot in a pattern would be the argument to a `...` expression, it is interpreted as a segment.
4. Matched variables are injected directly as variables into the environment of the rhs of an `@rule`.

This change is backwards-compatible, as it still recognizes the `~a` and `~~a` syntax. The only instance where this would be breaking is if the user expected to be able to use the variable `a` in the rhs when `a` is also a slot or segment in the lhs. We could avoid this by only injecting variables declared with the new syntax, but I think it's a rare case anyway.

This PR is missing docs and tests, but I am happy to add those if there is interest.