### PR TITLE
Add rules to simplify exponentials.

### DIFF
--- a/src/simplify_rules.jl
+++ b/src/simplify_rules.jl
@@ -56,7 +56,7 @@ let
         @rule(ifelse(~x::is_literal_number, ~y, ~z) => ~x ? ~y : ~z)
     ]
 
-    TRIG_RULES = [
+    TRIG_EXP_RULES = [
         @acrule(sin(~x)^2 + cos(~x)^2 => one(~x))
         @acrule(sin(~x)^2 + -1        => cos(~x)^2)
         @acrule(cos(~x)^2 + -1        => sin(~x)^2)
@@ -68,6 +68,9 @@ let
         @acrule(cot(~x)^2 + -1*csc(~x)^2 => one(~x))
         @acrule(cot(~x)^2 +  1 => csc(~x)^2)
         @acrule(csc(~x)^2 + -1 => cot(~x)^2)
+
+        @acrule(exp(~x) * exp(~y) => _iszero(~x + ~y) ? 1 : exp(~x + ~y))
+        @rule(exp(~x)^(~y) => exp(~x * ~y))
     ]
 
     BOOLEAN_RULES = [
@@ -112,7 +115,7 @@ let
         rule_tree
     end
 
-    trig_simplifier(;kw...) = Chain(TRIG_RULES)
+    trig_exp_simplifier(;kw...) = Chain(TRIG_EXP_RULES)
 
     bool_simplifier() = Chain(BOOLEAN_RULES)
 
@@ -123,10 +126,10 @@ let
     global serial_expand_simplifier
 
     function default_simplifier(; kw...)
-        IfElse(has_trig,
+        IfElse(has_trig_exp,
                Postwalk(IfElse(x->symtype(x) <: Number,
                                Chain((number_simplifier(),
-                                      trig_simplifier())),
+                                      trig_exp_simplifier())),
                                If(x->symtype(x) <: Bool,
                                   bool_simplifier()))
                         ; kw...),

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -77,15 +77,15 @@ pow(x, y::Symbolic) = Base.:^(x,y)
 pow(x::Symbolic,y::Symbolic) = Base.:^(x,y)
 
 # Simplification utilities
-function has_trig(term)
+function has_trig_exp(term)
     !istree(term) && return false
-    fns = (sin, cos, tan, cot, sec, csc)
+    fns = (sin, cos, tan, cot, sec, csc, exp)
     op = operation(term)
 
-    if Base.@nany 6 i->fns[i] === op
+    if Base.@nany 7 i->fns[i] === op
         return true
     else
-        return any(has_trig, arguments(term))
+        return any(has_trig_exp, arguments(term))
     end
 end
 

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -88,6 +88,15 @@ end
     @eqtest simplify(1 + y + cot(x)^2) == csc(x)^2 + y
 end
 
+@testset "Exponentials" begin
+    @syms a::Real b::Real
+    @eqtest simplify(exp(a)*exp(b)) == simplify(exp(a+b))
+    @eqtest simplify(exp(a)*exp(a)) == simplify(exp(2a))
+    @test simplify(exp(a)*exp(-a)) == 1
+    @eqtest simplify(exp(a)^2) == simplify(exp(2a))
+    @eqtest simplify(exp(a) * a * exp(b)) == simplify(a*exp(a+b))
+end
+
 @testset "Depth" begin
     @syms x
     R = Rewriters.Postwalk(Rewriters.Chain([@rule(sin(~x) => cos(~x)),


### PR DESCRIPTION
This PR attempts to resolve https://github.com/JuliaSymbolics/SymbolicUtils.jl/issues/182#issuecomment-768843602. 

Without the `_iszero` check, the first added rule can result in `1.0` instead of `1` when the exponentials cancel. I'm fine with changing this if it is too fancy. The second added rule implements https://github.com/JuliaSymbolics/SymbolicUtils.jl/issues/182#issuecomment-766427681. I lumped `exp` in with the trig functions for the control flow of the default simplifier.