### PR TITLE
Don't specialize.

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -97,8 +97,11 @@ end
 promote_symtype(::typeof(rem2pi), T::Type{<:Number}, mode) = T
 Base.rem2pi(x::Symbolic{<:Number}, mode::Base.RoundingMode) = term(rem2pi, x, mode)
 
+# transpose in Julia infers the output type with `promote_op`, hence we need to trick the compiler
+Base.transpose(a::Symbolic{<:Number}) = a
 for f in monadic
     @eval promote_symtype(::$(typeof(f)), T::Type{<:Number}) = promote_type(T, Real)
+    f === transpose && continue
     @eval (::$(typeof(f)))(a::Symbolic{<:Number})   = term($f, a)
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -280,7 +280,7 @@ end
 
 function ConstructionBase.constructorof(s::Type{<:Term{T}}) where {T}
     function (f, args, meta, hash)
-        Term{T, typeof(meta)}(f, args, meta, hash)
+        Term{T}(f, args, meta, hash)
     end
 end
 
@@ -914,7 +914,7 @@ end
 
 function ConstructionBase.constructorof(::Type{<:Pow{X}}) where {X}
     (base, exp, m) ->
-    Pow{promote_symtype(^, symtype(base), symtype(exp)), typeof(base), typeof(exp), typeof(m)}(base,exp,m)
+    Pow{promote_symtype(^, symtype(base), symtype(exp))}(base,exp,m)
 end
 
 function (::Type{<:Pow{T}})(a, b; metadata=NO_METADATA) where {T}

--- a/test/fuzzlib.jl
+++ b/test/fuzzlib.jl
@@ -206,9 +206,9 @@ function gen_expr(lvl=5)
     elseif rand() < 0.5
         f = rand((+, *))
         n = rand(1:5)
-        args = [gen_expr(lvl-1) for i in 1:n]
+        args = Any[gen_expr(lvl-1) for i in 1:n]
 
-        Term{Number}(f, first.(args)), f(last.(args)...)
+        Term{Number}(f, first.(args)), mapreduce(last, f, args)
     else
         f = rand((-,/))
         l = gen_expr(lvl-1)
@@ -216,9 +216,8 @@ function gen_expr(lvl=5)
         if f === (/) && r[2] isa Number && iszero(r[2])
             return gen_expr(lvl)
         end
-        args = [l, r]
 
-        Term{Number}(f, first.(args)), f(last.(args)...)
+        Term{Number}(f, [first(l), first(r)]), f(last(l), last(r))
     end
 end
 


### PR DESCRIPTION
Thanks to @YingboMa who pair programmed with me on this.
On this PR:
```julia
┌ Info: expand fuzz
└   iter = 100
┌ Info: expand fuzz
└   iter = 200
┌ Info: expand fuzz
└   iter = 300
┌ Info: expand fuzz
└   iter = 400
┌ Info: expand fuzz
└   iter = 500
 75.783455 seconds (204.67 M allocations: 12.509 GiB, 4.75% gc time, 4.89% compilation time)
┌ Info: simplify_fractions fuzz
└   iter = 100
┌ Info: simplify_fractions fuzz
└   iter = 200
┌ Info: num fuzz
└   iter = 100
┌ Info: num fuzz
└   iter = 200
┌ Info: num fuzz
└   iter = 300
┌ Info: num fuzz
└   iter = 400
┌ Info: num fuzz
└   iter = 500
┌ Info: num fuzz
└   iter = 600
┌ Info: num fuzz
└   iter = 700
┌ Info: num fuzz
└   iter = 800
┌ Info: num fuzz
└   iter = 900
┌ Info: num fuzz
└   iter = 1000
┌ Info: num fuzz
└   iter = 1100
┌ Info: num fuzz
└   iter = 1200
┌ Info: num fuzz
└   iter = 1300
┌ Info: num fuzz
└   iter = 1400
┌ Info: num fuzz
└   iter = 1500
 44.888103 seconds (111.06 M allocations: 6.969 GiB, 4.38% gc time, 0.03% compilation time)
┌ Info: bool fuzz
└   iter = 100
┌ Info: bool fuzz
└   iter = 200
┌ Info: bool fuzz
└   iter = 300
┌ Info: bool fuzz
└   iter = 400
┌ Info: bool fuzz
└   iter = 500
 10.796814 seconds (14.07 M allocations: 827.394 MiB, 2.49% gc time, 90.58% compilation time)
  2.397659 seconds (5.47 M allocations: 324.619 MiB, 3.54% gc time, 98.17% compilation time)
  0.951542 seconds (1.85 M allocations: 109.776 MiB, 2.88% gc time, 43.19% compilation time)
  0.397590 seconds (494.99 k allocations: 28.885 MiB, 7.00% gc time, 92.91% compilation time)
  0.466091 seconds (1.07 M allocations: 61.897 MiB, 44.04% compilation time)
Test Summary: |  Pass  Total
Fuzz test     | 13685  13685
Test Summary:        | Pass  Total
create_array adjoint |   55     55
258.679492 seconds (652.72 M allocations: 39.319 GiB, 4.26% gc time, 6.51% compilation time)
Test.DefaultTestSet("create_array adjoint", Any[], 55, false, false)
```
Before:
```julia
┌ Info: expand fuzz
└   iter = 100
┌ Info: expand fuzz
└   iter = 200
┌ Info: expand fuzz
└   iter = 300
┌ Info: expand fuzz
└   iter = 400
┌ Info: expand fuzz
└   iter = 500
165.876081 seconds (397.69 M allocations: 23.969 GiB, 4.54% gc time, 3.38% compilation time)
┌ Info: simplify_fractions fuzz
└   iter = 100
┌ Info: simplify_fractions fuzz
└   iter = 200
┌ Info: num fuzz
└   iter = 100
┌ Info: num fuzz
└   iter = 200
┌ Info: num fuzz
└   iter = 300
┌ Info: num fuzz
└   iter = 400
┌ Info: num fuzz
└   iter = 500
┌ Info: num fuzz
└   iter = 600
┌ Info: num fuzz
└   iter = 700
┌ Info: num fuzz
└   iter = 800
┌ Info: num fuzz
└   iter = 900
┌ Info: num fuzz
└   iter = 1000
┌ Info: num fuzz
└   iter = 1100
┌ Info: num fuzz
└   iter = 1200
┌ Info: num fuzz
└   iter = 1300
┌ Info: num fuzz
└   iter = 1400
┌ Info: num fuzz
└   iter = 1500
 72.779004 seconds (156.13 M allocations: 9.671 GiB, 3.98% gc time, 0.48% compilation time)
┌ Info: bool fuzz
└   iter = 100
┌ Info: bool fuzz
└   iter = 200
┌ Info: bool fuzz
└   iter = 300
┌ Info: bool fuzz
└   iter = 400
┌ Info: bool fuzz
└   iter = 500
 10.059934 seconds (14.73 M allocations: 865.991 MiB, 4.70% gc time, 91.26% compilation time)
  4.797554 seconds (11.22 M allocations: 673.276 MiB, 4.03% gc time, 98.48% compilation time)
  7.576491 seconds (16.41 M allocations: 985.511 MiB, 4.07% gc time, 28.68% compilation time)
  7.804001 seconds (16.31 M allocations: 981.325 MiB, 3.67% gc time, 98.43% compilation time)
  8.654091 seconds (16.33 M allocations: 982.696 MiB, 2.98% gc time, 37.41% compilation time)
Test Summary: |  Pass  Total
Fuzz test     | 13685  13685
Test Summary:        | Pass  Total
create_array adjoint |   55     55
433.257566 seconds (1.01 G allocations: 60.573 GiB, 4.20% gc time, 7.61% compilation time)
Test.DefaultTestSet("create_array adjoint", Any[], 55, false, false)
```