### PR TITLE
adds div and simplifications for div, mod and rem

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -14,7 +14,7 @@ const monadic = [deg2rad, rad2deg, transpose, asind, log1p, acsch,
                  trigamma, invdigamma, polygamma, airyai, airyaiprime, airybi,
                  airybiprime, besselj0, besselj1, bessely0, bessely1]
 
-const diadic = [max, min, hypot, atan, mod, rem, copysign,
+const diadic = [max, min, hypot, atan, div, rem, mod, copysign,
                 besselj, bessely, besseli, besselk, hankelh1, hankelh2,
                 polygamma, beta, logbeta]
 const previously_declared_for = Set([])

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -46,6 +46,18 @@ function has_trig_exp(term)
     end
 end
 
+function has_div_rem_mod(term)
+    !istree(term) && return false
+    fns = (div, rem, mod)
+    op = operation(term)
+
+    if Base.@nany 3 i->fns[i] === op
+        return true
+    else
+        return any(has_div_rem_mod, arguments(term))
+    end
+end
+
 function fold(t)
     if istree(t)
         tt = map(fold, arguments(t))
@@ -72,6 +84,8 @@ _iszero(x) = x isa Number && iszero(x)
 _isone(x) = x isa Number && isone(x)
 _isinteger(x) = (x isa Number && isinteger(x)) || (x isa Symbolic && symtype(x) <: Integer)
 _isreal(x) = (x isa Number && isreal(x)) || (x isa Symbolic && symtype(x) <: Real)
+_areintegers(xs) = all(_isinteger, xs)
+_isnonzerointeger(x) = x isa Number && isinteger(x) && !iszero(x)
 
 issortedₑ(args) = issorted(args, lt=<ₑ)
 needs_sorting(f) = x -> is_operation(f)(x) && !issortedₑ(arguments(x))

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -155,6 +155,9 @@ end
     @test isequal(substitute(sin(a+b), Dict(a=>1)), sin(b+1))
     @test substitute(a+b, Dict(a=>1, b=>3)) == 4
     @test substitute(exp(a), Dict(a=>2)) ≈ exp(2)
+    @test substitute(mod(a, b), Dict(a=>5, b=>2)) == 1
+    @test substitute(rem(a, b), Dict(a=>5, b=>2)) == 1
+    @test substitute(div(a, b), Dict(a=>5, b=>2)) == 2
 end
 
 @testset "occursin" begin

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -133,6 +133,7 @@ end
     @eqtest simplify(div(17*x*y + z + 12x + 7x * z, 2)) == 6x + 3x*z + 8x*y + div(z + x*(y + z), 2)
     @eqtest simplify(div(2*x + 2w, 2)) == div(2w + 2x, 2)
     @eqtest simplify(5div(21*x*y + z + 13x + 7x * z, 5) + rem(21*x*y + z + 13x + 7x * z, 5)) == z + 13x + 7x*z + 21x*y
+    @eqtest simplify(div(2*x + y, 2) + sin(x)^2 + cos(x)^2 + 1) == 2 + x + div(y, 2)
 end
 
 @testset "Depth" begin

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -103,6 +103,38 @@ end
     @eqtest simplify(exp(a) * a * exp(b)) == simplify(a*exp(a+b))
 end
 
+@testset "Div, Mod & Rem" begin
+    @syms x::Integer y::Integer z::Integer u::Real w
+    for n in (-7, -1, 1, 2), m in (-6, -1, 1, 3)
+        # single integer term
+        @test simplify(mod(n * m * x, m)) == 0
+        @test simplify(rem(n * m * x, m)) == 0
+        @eqtest simplify(div(n * m * x, m)) == n * x
+        @test simplify(mod(-n * m * x, m)) == 0
+        @test simplify(rem(-n * m * x, m)) == 0
+        @eqtest simplify(div(-n * m * x, m)) == -n * x
+        # single real term
+        @eqtest simplify(mod(n * m * u, m)) == mod(n * m * u, m)
+        @eqtest simplify(rem(n * m * u, m)) == rem(n * m * u, m)
+        @eqtest simplify(div(n * m * u, m)) == div(n * m * u, m)
+        # several terms
+        @test simplify(mod(n * m * x + 2 * n * m * y + n * m * x * y, m)) == 0
+        @test simplify(rem(n * m * x + 2 * n * m * y + n * m * x * y, m)) == 0
+        @eqtest simplify(div(n * m * x + 2 * n * m * y + m * x * y, m)) == simplify(n * x + 2 * n * y + x * y)
+        # div + rem
+        @eqtest simplify(m * div(n * x, m) + rem(n * x, m)) == n * x
+        @eqtest simplify(m * div(n * u, m) + rem(n * u, m)) == n * u
+        @eqtest simplify(m * div(0.5 * n * u, m) + rem(0.5 * n * u, m)) == 0.5 * n * u
+        @eqtest simplify(m * div(n * w, m) + rem(n * w, m)) == m * div(n * w, m) + rem(n * w, m)
+    end
+    # mixed
+    @eqtest simplify(mod(21*x*y + z + 13x + 7x * z, 5)) == mod(z + 3x + x*y + 2x*z, 5)
+    @eqtest simplify(rem(21*x*y + z + 13x + 7x * z, -3)) == simplify(rem(x + z + x * z, -3))
+    @eqtest simplify(div(17*x*y + z + 12x + 7x * z, 2)) == 6x + 3x*z + 8x*y + div(z + x*(y + z), 2)
+    @eqtest simplify(div(2*x + 2w, 2)) == div(2w + 2x, 2)
+    @eqtest simplify(5div(21*x*y + z + 13x + 7x * z, 5) + rem(21*x*y + z + 13x + 7x * z, 5)) == z + 13x + 7x*z + 21x*y
+end
+
 @testset "Depth" begin
     @syms x
     R = Rewriters.Postwalk(Rewriters.Chain([@rule(sin(~x) => cos(~x)),


### PR DESCRIPTION
I also added a bunch of tests, which highlight the simplifications added.

There are still some simplifications that can be included. I will work on those, but I think/hope this is a good start.

I haven't added anything to the documentation either. I can work on that later once I figure out how it is deployed.

Let me know if there is anything I should do differently. In particular regarding the way I added the rules to `default_simplifier`. I wanted to do minimal changes to that, but I suspect separating div/rem/mod from trig/exp simplifications might be best since they will certainly be less used. 

