### PR TITLE
SafeReal

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -88,7 +88,7 @@ end
 @number_methods(Pow, term(f, a), term(f, a, b), skipbasics)
 @number_methods(Div, term(f, a), term(f, a, b), skipbasics)
 
-for f in diadic
+for f in vcat(diadic, [+, -, *, \, /, ^])
     @eval promote_symtype(::$(typeof(f)),
                    T::Type{<:Number},
                    S::Type{<:Number}) = promote_type(T, S)
@@ -108,18 +108,6 @@ for f in diadic
                    T::Type{<:SafeReal},
                    S::Type{<:SafeReal})
         X = promote_type(Real, Real)
-        X == Real ? SafeReal : X
-    end
-end
-
-for f in [+, -, *, \, /, ^]
-    @eval promote_symtype(::$(typeof(f)),
-                   T::Type{<:Number},
-                   S::Type{<:Number}) = promote_type(T, S)
-    @eval function promote_symtype(::$(typeof(f)),
-                   T::Type{<:SafeReal},
-                   S::Type{<:Number})
-        X = promote_type(Real, S)
         X == Real ? SafeReal : X
     end
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -923,6 +923,9 @@ maybe_intcoeff(x::Rational) = isone(x.den) ? x.num : x
 maybe_intcoeff(x) = x
 
 function (::Type{Div{T}})(n, d, simplified=false; metadata=nothing) where {T}
+    if T<:Number && !(T<:SafeReal)
+        n, d = quick_cancel(n, d)
+    end
     _iszero(n) && return zero(typeof(n))
     _isone(d) && return n
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -698,6 +698,7 @@ function makeadd(sign, coeff, xs...)
     coeff, d
 end
 
+add_t(a::Number,b::Number) = promote_symtype(+, symtype(a), symtype(b))
 add_t(a,b) = promote_symtype(+, symtype(a), symtype(b))
 sub_t(a,b) = promote_symtype(-, symtype(a), symtype(b))
 sub_t(a) = promote_symtype(-, symtype(a))

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -238,7 +238,7 @@ end
 end
 
 @testset "div" begin
-    @syms x y
+    @syms x::SafeReal y::Real
     @test (2x/2y).num isa Sym
     @test (2x/3y).num.coeff == 2
     @test (2x/3y).den.coeff == 3
@@ -247,4 +247,13 @@ end
     @test (2.5x/3x).num.coeff == 2.5
     @test (2.5x/3x).den.coeff == 3
     @test (x/3x).den.coeff == 3
+
+    @syms x y
+    @test (2x/2y).num isa Sym
+    @test (2x/3y).num.coeff == 2
+    @test (2x/3y).den.coeff == 3
+    @test (2x/-3x) == -2//3
+    @test (2.5x/3x).num == 2.5
+    @test (2.5x/3x).den == 3
+    @test (x/3x) == 1//3
 end


### PR DESCRIPTION
Adds a SafeReal type which does not cancel numerators and denominators on construction (all other things behave as they did with Real).

I wasn't planning on some of this, but things fell into place:

Part of https://github.com/JuliaSymbolics/Symbolics.jl/issues/512
```julia
julia> using Symbolics

julia> using Symbolics: unwrap

julia> @variables x::SafeReal y::Real
2-element Vector{Num}:
 x
 y

julia> unwrap(x) |> typeof
SymbolicUtils.Sym{SafeReal, Base.ImmutableDict{DataType, Any}}

julia> unwrap(x + 1) |> typeof
SymbolicUtils.Add{SafeReal, Int64, Dict{Any, Number}, Nothing}


julia> unwrap((x + (1+im)).re) |> typeof
SymbolicUtils.Add{SafeReal, Int64, Dict{Any, Number}, Nothing}

julia> unwrap((x + (1+im)).im) |> typeof
Int64

julia> x/x
x / x

julia> y/y
1

julia> x/(x*y)
x / (x*y)

julia> typeof(unwrap(x/(x*y)))
SymbolicUtils.Div{SafeReal, SymbolicUtils.Sym{SafeReal, Base.ImmutableDict{DataType, Any}}, SymbolicUtils.Mul{SafeReal, Int64, Dict{Any, Number}, Nothing}, Nothing}

```