### PR TITLE
allow kws in `(f::Symbolic{<:FnType})(args...)` 

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -898,7 +898,7 @@ promote_symtype(f, Ts...) = Any
 
 struct FnType{X<:Tuple,Y} end
 
-(f::Symbolic{<:FnType})(args...) = Term{promote_symtype(f, symtype.(args)...)}(f, Any[args...])
+(f::Symbolic{<:FnType})(args...; kwargs...) = Term{promote_symtype(f, symtype.(args)...)}(f, [args...]; kwargs...)
 
 function (f::Symbolic)(args...)
     error("Sym $f is not callable. " *


### PR DESCRIPTION
MTK `convert_system` uses `operation(s)(new_iv)`, which loses the metadata. 