### PR TITLE
Simplify printing of Term(identity, x)

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -845,6 +845,8 @@ function show_term(io::IO, t)
         show_pow(io, args)
     elseif f === (getindex)
         show_ref(io, f, args)
+    elseif f === (identity)
+        show(io, args[1])
     else
         show_call(io, f, args)
     end


### PR DESCRIPTION
It can be helpful to encode a quantity `q` that should not be evaluated as `Term(identity, q)`.  This is the idea behind JuliaSymbolics/Symbolics.jl#638, which allows irrationals like `π` to be treated symbolically, rather than (typically) as `Float64` in symbolic expressions.  But that means that `identity(π)` appears everywhere we would normally just write `π`.  This PR simply adds another case to `show_term`, to check if the function is `identity`, and just shows the argument instead.