### PR TITLE
Simplify degenerate ifelse cases. Fix JuliaSymbolics/Symbolics.jl#170

### DIFF
--- a/src/simplify_rules.jl
+++ b/src/simplify_rules.jl
@@ -54,6 +54,7 @@ let
         @rule(real(~x::_isreal) => ~x)
         @rule(imag(~x::_isreal) => zero(symtype(~x)))
         @rule(ifelse(~x::is_literal_number, ~y, ~z) => ~x ? ~y : ~z)
+        @rule(ifelse(~x, ~y, ~y) => ~y)
     ]
 
     TRIG_EXP_RULES = [


### PR DESCRIPTION
The change was tested with the issue's reproducible sample
```julia
julia> @variables x
julia> ∂ₓ = Differential(x)
julia> expr = expand_derivatives(∂ₓ(∂ₓ(max(1,x))))
IfElse.ifelse(1 > x, 0, 0)
julia> simplify(expr)
```
and now we yield a `0` instead of `IfElse.ifelse(1 > x, 0, 0)`