### PR TITLE
Fix `toterm` bug that omits coeff.

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -397,7 +397,8 @@ function toterm(t::BasicSymbolic{T}) where T
     if E === SYM || E === TERM
         return t
     elseif E === ADD || E === MUL
-        args = []
+        args = Any[]
+        push!(args, t.coeff)
         for (k, coeff) in t.dict
             push!(args, coeff == 1 ? k : Term{T}(E === MUL ? (^) : (*), Any[coeff, k]))
         end


### PR DESCRIPTION
Simple fix.

Before
```julia-repo
>julia @syms a; SymbolicUtils.toterm(a+1)
a

>julia @syms a; SymbolicUtils.toterm(2a)
a
```

Now the function works as intended.
