### PR TITLE
Call `BasicSymbolic` arithmetic operations to construct `similarterm`

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -535,15 +535,12 @@ function TermInterface.similarterm(t::Type{<:BasicSymbolic{<:Number}}, f, args, 
     if T === nothing
         T = _promote_symtype(f, args)
     end
-    if f === (+)
-        Add(T, makeadd(1, 0, args...)...; metadata=metadata)
-    elseif f == (*)
-        Mul(T, makemul(1, args...)...; metadata=metadata)
-    elseif f == (/)
-        @assert length(args) == 2
-        Div{T}(args...; metadata=metadata)
-    elseif f == (^) && length(args) == 2
-        Pow{T}(makepow(args...)...; metadata=metadata)
+    if f in (+, *) || (f in (/, ^) && length(args) == 2)
+        res = f(args...)
+        if res isa Symbolic
+            @set! res.metadata = metadata
+        end
+        return res
     else
         Term{T}(f, args, metadata=metadata)
     end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -191,6 +191,12 @@ end
     @syms a b c
     @test isequal(SymbolicUtils.similarterm((b + c), +, [a,  (b+c)]).dict, Dict(a=>1,b=>1,c=>1))
     @test isequal(SymbolicUtils.similarterm(b^2, ^, [b^2,  1//2]), b)
+
+    # test that similarterm doesn't hard-code BasicSymbolic subtype
+    # and is consistent with BasicSymbolic arithmetic operations
+    @test isequal(SymbolicUtils.similarterm(a / b, *, [a / b, c]), (a / b) * c)
+    @test isequal(SymbolicUtils.similarterm(a * b, *, [0, c]), 0)
+    @test isequal(SymbolicUtils.similarterm(a^b, ^, [a * b, 3]), (a * b)^3)
 end
 
 toterm(t) = Term{symtype(t)}(operation(t), arguments(t))

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -197,6 +197,12 @@ end
     @test isequal(SymbolicUtils.similarterm(a / b, *, [a / b, c]), (a / b) * c)
     @test isequal(SymbolicUtils.similarterm(a * b, *, [0, c]), 0)
     @test isequal(SymbolicUtils.similarterm(a^b, ^, [a * b, 3]), (a * b)^3)
+
+    # test that similarterm sets metadata correctly
+    metadata = Base.ImmutableDict{DataType, Any}(Ctx1, "meta_1")
+    s = SymbolicUtils.similarterm(a^b, ^, [a * b, 3]; metadata = metadata)
+    @test hasmetadata(s, Ctx1)
+    @test getmetadata(s, Ctx1) == "meta_1"
 end
 
 toterm(t) = Term{symtype(t)}(operation(t), arguments(t))


### PR DESCRIPTION
# resolve https://github.com/JuliaSymbolics/SymbolicUtils.jl/issues/462
# resolve https://github.com/JuliaSymbolics/Symbolics.jl/issues/704

In the docstring of `similarterm`, it says that the return type may be different than `t`.

https://github.com/JuliaSymbolics/SymbolicUtils.jl/blob/6964c768e76dcbc48ee7b1d58fae481d46caa5a0/src/types.jl#L509-L514

However, the type is directly hard-coded according to `f` in the code.

https://github.com/JuliaSymbolics/SymbolicUtils.jl/blob/6964c768e76dcbc48ee7b1d58fae481d46caa5a0/src/types.jl#L530-L550