### PR TITLE
`promote_symtype` for `Base.literal_pow`

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -133,6 +133,9 @@ function Base.literal_pow(::typeof(^), x::Symbolic, ::Val{p}) where {p}
     T = symtype(x)
     T <: Number ? Base.:^(x, p) : error_f_symbolic(rem2pi, T)
 end
+function promote_symtype(::typeof(Base.literal_pow), _, ::Type{T}, ::Type{Val{S}}) where{T<:Number,S}
+    return promote_symtype(^, T, typeof(S))
+end
 
 promote_symtype(::Any, T) = promote_type(T, Real)
 for f in monadic


### PR DESCRIPTION
Add a special method to infer the symtype of a `Base.literal_pow` expression. Should fix https://github.com/JuliaSymbolics/Symbolics.jl/issues/455