### PR TITLE
`broadcastable` for `Symbolics`.

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -194,3 +194,9 @@ Base.length(x::Symbolic{<:Number}) = 1
 Base.ndims(x::Symbolic{T}) where {T} = Base.ndims(T)
 Base.ndims(::Type{<:Symbolic{T}}) where {T} = Base.ndims(T)
 Base.broadcastable(x::Symbolic{T}) where {T<:Number} = Ref(x)
+function Base.broadcastable(x::Symbolic)
+    if istree(x) && operation(x) == Ref && length(arguments(x)) == 1
+        return Ref(first(arguments(x)))
+    end
+    return Base.invoke(Base.broadcastable, Tuple{Any}, x)
+end


### PR DESCRIPTION
Suppose the issue in JuliaSymbolics/Symbolics.jl#455 is fixed, e.g., via #493.
Then `simplify(sum(x.^2))` fails.

The error results from a call to `broadcastable` on the arguments of `(x.^2).value.term`.
E.g., the first argument is a `Term{Any}` with `Ref` as operation and `^` as its sole argument.
I have added a `broadcastable` for any `Symbolic` that catches this case and falls back to unspecialized `broadcastable` otherwise. 

Because of the discussion in #409 I am not certain whether this solution is clever.
It's also the reason for the separate pull request. 