### PR TITLE
Fix printing for term operators that could be both unary and binary

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -778,12 +778,14 @@ end
 
 function show_call(io, f, args)
     fname = istree(f) ? Symbol(repr(f)) : nameof(f)
-    binary = Base.isbinaryoperator(fname)
-    if binary
-        for (i, t) in enumerate(args)
-            i != 1 && print(io, " $fname ")
-            print_arg(io, t, paren=true)
-        end
+    len_args = length(args)
+    if Base.isunaryoperator(fname) && len_args == 1
+        print(io, "$fname")
+        print_arg(io, first(args), paren=true)
+    elseif Base.isbinaryoperator(fname) && len_args == 2
+        print_arg(io, first(args), paren=true)
+        print(io, " $fname ")
+        print_arg(io, last(args), paren=true)
     else
         if issym(f)
             Base.show_unquoted(io, nameof(f))


### PR DESCRIPTION
Fix #512

```julia
julia> VERSION
v"1.8.5"

(@v1.8) pkg> st -m Symbolics
Status `~/.julia/environments/v1.8/Manifest.toml`
  [0c5d862f] Symbolics v5.0.2

(@v1.8) pkg> st -m SymbolicUtils
Status `~/.julia/environments/v1.8/Manifest.toml`
  [d1185830] SymbolicUtils v1.0.3

julia> using Symbolics

julia> @variables y::LiteralReal
1-element Vector{Num}:
 y

julia> -y
y
```

A minus sign is missing in the printing result above.

The internal structure of `-y` is

```julia
julia> SymbolicUtils.isterm(Symbolics.value(-y))
true

julia> operation(Symbolics.value(-y))
- (generic function with 507 methods)

julia> arguments(Symbolics.value(-y))
1-element Vector{Any}:
 y
```

The printing function dispatched for `-y` is the following one:
https://github.com/JuliaSymbolics/SymbolicUtils.jl/blob/ba96757121155bc8925977a858d48ef8dd8a234c/src/types.jl#L779-L800

Here, the function [`show_call`](https://github.com/JuliaSymbolics/SymbolicUtils.jl/blob/ba96757121155bc8925977a858d48ef8dd8a234c/src/types.jl#L779) checks if the operation is [binary](https://github.com/JuliaSymbolics/SymbolicUtils.jl/blob/ba96757121155bc8925977a858d48ef8dd8a234c/src/types.jl#L781).

However, the `-` operator is special which could be both unary and binary. `show_call` doesn't consider the unary case and thus doesn't work in our test case.

This PR resolves this issue.

With this PR, the printing result is corrected

```julia
julia> using Symbolics

julia> @variables y::LiteralReal;

julia> -y
-y
```
