### PR TITLE
remove piracy on isequal

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -185,8 +185,6 @@ isdiv(x)  = isa_SymType(Val(:Div), x)
 ### Base interface
 ###
 
-Base.isequal(::Symbolic, x) = false
-Base.isequal(x, ::Symbolic) = false
 Base.isequal(::Symbolic, ::Symbolic) = false
 coeff_isequal(a, b) = isequal(a, b) || ((a isa AbstractFloat || b isa AbstractFloat) && (a==b))
 function Base.isequal(a::BasicSymbolic{T}, b::BasicSymbolic{S}) where {T,S}


### PR DESCRIPTION
Base expects `isequal` to fallback to `==`. Changing that forces some unnecessary method invalidations, since the new and old definitions seem to be the same.