### PR TITLE
Enhancement: avoid applying canonicalizing rules on canonical form

### DIFF
--- a/src/simplify_rules.jl
+++ b/src/simplify_rules.jl
@@ -7,14 +7,12 @@ the argument to the predicate satisfies `istree` and `operation(x) == f`
 is_operation(f) = @nospecialize(x) -> istree(x) && (operation(x) == f)
 
 let
-    PLUS_RULES = [
+    CANONICALIZE_PLUS = [
         @rule(~x::isnotflat(+) => flatten_term(+, ~x))
         @rule(~x::needs_sorting(+) => sort_args(+, ~x))
         @ordered_acrule(~a::is_literal_number + ~b::is_literal_number => ~a + ~b)
 
         @acrule(*(~~x) + *(~β, ~~x) => *(1 + ~β, (~~x)...))
-        @acrule(*(~α, ~~x) + *(~β, ~~x) => *(~α + ~β, (~~x)...))
-        @acrule(*(~~x, ~α) + *(~~x, ~β) => *(~α + ~β, (~~x)...))
 
         @acrule(~x + *(~β, ~x) => *(1 + ~β, ~x))
         @acrule(*(~α::is_literal_number, ~x) + ~x => *(~α + 1, ~x))
@@ -24,7 +22,12 @@ let
         @rule(+(~x) => ~x)
     ]
 
-    TIMES_RULES = [
+    PLUS_DISTRIBUTE = [
+        @acrule(*(~α, ~~x) + *(~β, ~~x) => *(~α + ~β, (~~x)...))
+        @acrule(*(~~x, ~α) + *(~~x, ~β) => *(~α + ~β, (~~x)...))
+    ]
+
+    CANONICALIZE_TIMES = [
         @rule(~x::isnotflat(*) => flatten_term(*, ~x))
         @rule(~x::needs_sorting(*) => sort_args(*, ~x))
 
@@ -40,7 +43,7 @@ let
     ]
 
 
-    POW_RULES = [
+    CANONICALIZE_POW = [
         @rule(^(*(~~x), ~y::_isinteger) => *(map(a->pow(a, ~y), ~~x)...))
         @rule((((~x)^(~p::_isinteger))^(~q::_isinteger)) => (~x)^((~p)*(~q)))
         @rule(^(~x, ~z::_iszero) => 1)
@@ -120,12 +123,13 @@ let
 
     function number_simplifier()
         rule_tree = [If(istree, Chain(ASSORTED_RULES)),
-                     If(is_operation(+),
-                        Chain(PLUS_RULES)),
-                     If(is_operation(*),
-                        Chain(TIMES_RULES)),
-                     If(is_operation(^),
-                        Chain(POW_RULES))] |> RestartedChain
+                     If(x -> !isadd(x) && is_operation(+)(x),
+                        Chain(CANONICALIZE_PLUS)),
+                     If(is_operation(+), Chain(PLUS_DISTRIBUTE)), # This would be useful even if isadd
+                     If(x -> !ismul(x) && is_operation(*)(x),
+                        Chain(CANONICALIZE_TIMES)),
+                     If(x -> !ispow(x) && is_operation(^)(x),
+                        Chain(CANONICALIZE_POW))] |> RestartedChain
 
         rule_tree
     end

--- a/src/simplify_rules.jl
+++ b/src/simplify_rules.jl
@@ -50,6 +50,9 @@ let
         @rule(^(~x, ~z::_iszero) => 1)
         @rule(^(~x, ~z::_isone) => ~x)
         @rule(inv(~x) => 1/(~x))
+    ]
+
+    POW_RULES = [
         @rule(^(~x::_isone, ~z) => 1)
     ]
 
@@ -127,11 +130,13 @@ let
                      If(x -> !isadd(x) && is_operation(+)(x),
                         Chain(CANONICALIZE_PLUS)),
                      If(is_operation(+), Chain(PLUS_DISTRIBUTE)), # This would be useful even if isadd
-                     If(is_operation(*), MUL_DISTRIBUTE), # Same
                      If(x -> !ismul(x) && is_operation(*)(x),
                         Chain(CANONICALIZE_TIMES)),
+                     If(is_operation(*), MUL_DISTRIBUTE),
                      If(x -> !ispow(x) && is_operation(^)(x),
-                        Chain(CANONICALIZE_POW))] |> RestartedChain
+                        Chain(CANONICALIZE_POW)),
+                     If(is_operation(^), Chain(POW_RULES)),
+                    ] |> RestartedChain
 
         rule_tree
     end

--- a/src/simplify_rules.jl
+++ b/src/simplify_rules.jl
@@ -35,12 +35,13 @@ let
         @rule(*(~~x::hasrepeats) => *(merge_repeats(^, ~~x)...))
 
         @acrule((~y)^(~n) * ~y => (~y)^(~n+1))
-        @ordered_acrule((~x)^(~n) * (~x)^(~m) => (~x)^(~n + ~m))
 
         @ordered_acrule((~z::_isone  * ~x) => ~x)
         @ordered_acrule((~z::_iszero *  ~x) => ~z)
         @rule(*(~x) => ~x)
     ]
+
+    MUL_DISTRIBUTE = @ordered_acrule((~x)^(~n) * (~x)^(~m) => (~x)^(~n + ~m))
 
 
     CANONICALIZE_POW = [
@@ -126,6 +127,7 @@ let
                      If(x -> !isadd(x) && is_operation(+)(x),
                         Chain(CANONICALIZE_PLUS)),
                      If(is_operation(+), Chain(PLUS_DISTRIBUTE)), # This would be useful even if isadd
+                     If(is_operation(*), MUL_DISTRIBUTE), # Same
                      If(x -> !ismul(x) && is_operation(*)(x),
                         Chain(CANONICALIZE_TIMES)),
                      If(x -> !ispow(x) && is_operation(^)(x),


### PR DESCRIPTION
fixes #347 

Before
```julia
julia> @btime simplify(z*x)
  41.083 μs (511 allocations: 27.11 KiB)
x*z

julia> @btime simplify(z*x+z*y)
  252.292 μs (3063 allocations: 159.59 KiB)
z*(x + y)
```
After
```julia
julia> @btime simplify(z*x)
  27.458 μs (294 allocations: 16.25 KiB)
x*z

julia> @btime simplify(z*x+z*y)
  151.834 μs (1724 allocations: 92.55 KiB)
z*(x + y)
```