### PR TITLE
replace deprecated `similarvariable` by `similar_variable`

### DIFF
--- a/src/polyform.jl
+++ b/src/polyform.jl
@@ -146,7 +146,7 @@ function polyize(x, pvar2sym, sym2term, vtype, pow, Fs, recurse)
         if haskey(active_inv(pvar2sym), x)
             return pvar2sym(x)
         end
-        pvar = MP.similarvariable(vtype, nameof(x))
+        pvar = MP.similar_variable(vtype, nameof(x))
         pvar2sym[pvar] = x
         return pvar
     end


### PR DESCRIPTION
I found this in https://github.com/ranocha/BSeries.jl/pull/153 since the CI run failed in some `@test_nowarn` statements with the message

```
┌ Warning: `similarvariable` is deprecated, use `similar_variable` instead.
│   caller = polyize(x::SymbolicUtils.BasicSymbolic{Real}, pvar2sym::Bijections.Bijection{Any, Any}, sym2term::Dict{SymbolicUtils.BasicSymbolic, Any}, vtype::Type, pow::Function, Fs::Type, recurse::Bool) at polyform.jl:149
└ @ SymbolicUtils ~/.julia/packages/SymbolicUtils/Oyu8Z/src/polyform.jl:149
Symbolic coefficients: Test Failed at /cache/build/default-amdci5-2/julialang/julia-release-1-dot-9/usr/share/julia/stdlib/v1.9/Test/src/Test.jl:863
```