### PR TITLE
Included dispatch to toexpr that creates Tuples correctly

### DIFF
--- a/src/code.jl
+++ b/src/code.jl
@@ -188,6 +188,10 @@ function toexpr(O, st)
     end
 end
 
+function toexpr(O::Tuple, st)
+    :(($(toexpr.(O, (st,))...),))
+end
+
 # Call elements of vector arguments by their name.
 @matchable struct DestructuredArgs
     elems

--- a/test/code.jl
+++ b/test/code.jl
@@ -183,6 +183,8 @@ nanmath_st.rewrites[:nanmath] = true
               :(SparseVector(10, $(spvec.nzind), [a])))
     test_repr(toexpr(MakeTuple((a, b, a+b))),
               :((a,b,$(+)(a,b))))
+    test_repr(toexpr((a, b, a+b)),
+              :((a,b,$(+)(a,b))))
 
     @test SpawnFetch{Multithreaded}([()->1,()->2],vcat)|>toexpr|>eval == [1,2]
     @test @elapsed(SpawnFetch{Multithreaded}([:(()->sleep(2)),


### PR DESCRIPTION
This dispatch allows `Symbolics.build_function` to build functions when the targets are Tuples. It includes a test.

This closes the issue [46 in Symbolics](https://github.com/JuliaSymbolics/Symbolics.jl/issues/46). I also made some comments there about it.