### PR TITLE
better ordering of terms

### DIFF
--- a/src/ordering.jl
+++ b/src/ordering.jl
@@ -52,5 +52,18 @@ function lexlt(degs1, degs2)
     return false # they are equal
 end
 
-<ₑ(a::BasicSymbolic, b::BasicSymbolic) = monomial_lt(get_degrees(a),
-                                                     get_degrees(b))
+_arglen(a) = istree(a) ? length(unsorted_arguments(a)) : 0
+function <ₑ(a::BasicSymbolic, b::BasicSymbolic)
+    da, db = get_degrees(a), get_degrees(b)
+    fw = monomial_lt(da, db)
+    bw = monomial_lt(db, da)
+    if fw === bw && !isequal(a, b)
+        if _arglen(a) == _arglen(b)
+            return hash(a) < hash(b)
+        else
+            return _arglen(a) < _arglen(b)
+        end
+    else
+        return fw
+    end
+end

--- a/src/ordering.jl
+++ b/src/ordering.jl
@@ -19,7 +19,7 @@
 # find symbols and their corresponding degrees
 function get_degrees(expr)
     if issym(expr)
-        (nameof(expr) => 1,)
+        ((Symbol(expr),) => 1,)
     elseif istree(expr)
         op = operation(expr)
         args = arguments(expr)
@@ -34,8 +34,11 @@ function get_degrees(expr)
             ds = map(get_degrees, args)
             _, idx = findmax(x->sum(last.(x), init=0), ds)
             return ds[idx]
+        elseif operation(expr) == (getindex)
+            args = arguments(expr)
+            return ((Symbol.(args)...,) => 1,)
         else
-            return (Symbol("zzzzzzz", hash(expr)) => 1,)
+            return ((Symbol("zzzzzzz", hash(expr)),) => 1,)
         end
     else
         return ()

--- a/src/ordering.jl
+++ b/src/ordering.jl
@@ -8,120 +8,49 @@
 <ₑ(a::Symbolic, b::Number) = false
 <ₑ(a::Number,   b::Symbolic) = true
 
-arglength(a) = length(arguments(a))
-function <ₑ(a, b)
-    if isterm(a) && (b isa Symbolic && !isterm(b))
-        return false
-    elseif isterm(b) && (a isa Symbolic && !isterm(a))
-        return true
-    elseif (isadd(a) || ismul(a)) && (isadd(b) || ismul(b))
-        return cmp_mul_adds(a, b)
-    elseif issym(a) && issym(b)
-        nameof(a) < nameof(b)
-    elseif !istree(a) && !istree(b)
-        T = typeof(a)
-        S = typeof(b)
-        return T===S ? (T <: Number ? isless(a, b) : hash(a) < hash(b)) : nameof(T) < nameof(S)
-    elseif istree(b) && !istree(a)
-        return true
-    elseif istree(a) && istree(b)
-        return cmp_term_term(a,b)
-    else
-        return !(b <ₑ a)
-    end
-end
-
-function cmp_mul_adds(a, b)
-    (isadd(a) && ismul(b)) && return true
-    (ismul(a) && isadd(b)) && return false
-    a_args = unsorted_arguments(a)
-    b_args = unsorted_arguments(b)
-    length(a_args) < length(b_args) && return true
-    length(a_args) > length(b_args) && return false
-    a_args = arguments(a)
-    b_args = arguments(b)
-    for (x, y) in zip(a_args, b_args)
-        x <ₑ y && return true
-    end
-    return false
-end
-
-function <ₑ(a::Symbol, b::Symbol)
-    # Enforce the order [+,-,\,/,^,*]
-    if b === :*
-        a in (:^, :/, :\, :-, :+)
-    elseif b === :^
-        a in (:/, :\, :-, :+) && return true
-    elseif b === :/
-        a in (:\, :-, :+) && return true
-    elseif b === :\
-        a in (:-, :+) && return true
-    elseif b === :-
-        a === :+ && return true
-    elseif a in (:*, :^, :/, :-, :+)
-        false
-    else
-        a < b
-    end
-end
-
-<ₑ(a::Function, b::Function) = nameof(a) <ₑ nameof(b)
-
-<ₑ(a::Type, b::Type) = nameof(a) <ₑ nameof(b)
-
-function cmp_term_term(a, b)
-    la = arglength(a)
-    lb = arglength(b)
-
-    if la == 0 && lb == 0
-        return operation(a) <ₑ operation(b)
-    elseif la === 0
-        return operation(a) <ₑ b
-    elseif lb === 0
-        return a <ₑ operation(b)
-    end
-
-    na = operation(a)
-    nb = operation(b)
-
-    if 0 < arglength(a) <= 2 && 0 < arglength(b) <= 2
-        # e.g. a < sin(a) < b ^ 2 < b
-        @goto compare_args
-    end
-
-    if na !== nb
-        return na <ₑ nb
-    elseif arglength(a) != arglength(b)
-        return arglength(a) < arglength(b)
-    else
-        @label compare_args
-        aa, ab = arguments(a), arguments(b)
-        if length(aa) !== length(ab)
-            return length(aa) < length(ab)
+###### A variation on degree lexicographic order ########
+# find symbols and their corresponding degrees
+function get_degrees(expr)
+    if issym(expr)
+        (nameof(expr) => 1,)
+    elseif istree(expr)
+        op = operation(expr)
+        args = arguments(expr)
+        if operation(expr) == (^) && args[2] isa Number
+            return map(get_degrees(args[1])) do (base, pow)
+                (base => pow * args[2])
+            end
+        elseif operation(expr) == (*)
+            return mapreduce(get_degrees,
+                             (x,y)->(x...,y...,), args)
+        elseif operation(expr) == (+)
+            ds = map(get_degrees, args)
+            _, idx = findmax(x->sum(last.(x), init=0), ds)
+            return ds[idx]
         else
-            terms = zip(Iterators.filter(!is_literal_number, aa), Iterators.filter(!is_literal_number, ab))
-
-            for (x,y) in terms
-                if x <ₑ y
-                    return true
-                elseif y <ₑ x
-                    return false
-                end
-            end
-
-            # compare the numbers
-            nums = zip(Iterators.filter(is_literal_number, aa),
-                       Iterators.filter(is_literal_number, ab))
-
-            for (x,y) in nums
-                if x <ₑ y
-                    return true
-                elseif y <ₑ x
-                    return false
-                end
-            end
-
+            return (Symbol("zzzzzzz", hash(expr)) => 1,)
         end
-        return na <ₑ nb # all args are equal, compare the name
+    else
+        return ()
     end
 end
+
+function monomial_lt(degs1, degs2)
+    d1 = sum(last, degs1, init=0)
+    d2 = sum(last, degs2, init=0)
+    d1 != d2 ? d1 < d2 : lexlt(degs1, degs2)
+end
+
+function lexlt(degs1, degs2)
+    for (a, b) in zip(degs1, degs2)
+        if a[1] == b[1] && a[2] != b[2]
+            return a[2] > b[2]
+        elseif a[1] != b[1]
+            return a < b
+        end
+    end
+    return false # they are equal
+end
+
+<ₑ(a::BasicSymbolic, b::BasicSymbolic) = monomial_lt(get_degrees(a),
+                                                     get_degrees(b))

--- a/src/types.jl
+++ b/src/types.jl
@@ -687,7 +687,7 @@ function get_degrees(expr)
             _, idx = findmax(x->sum(last.(x)), ds)
             return ds[idx]
         else
-            return (Symbol("zzzzzzzzzzzzzzzz") => Inf,)
+            return (Symbol("zzzzzzz", objectid(expr)) => typemax(Int),)
         end
     else
         return (Symbol("") => 0,)

--- a/src/types.jl
+++ b/src/types.jl
@@ -675,48 +675,6 @@ function remove_minus(t)
     Any[-args[1], args[2:end]...]
 end
 
-# find symbols and their corresponding degrees
-function get_degrees(expr)
-    if issym(expr)
-        (nameof(expr) => 1,)
-    elseif istree(expr)
-        op = operation(expr)
-        args = arguments(expr)
-        if operation(expr) == (^) && args[2] isa Number
-            return map(get_degrees(args[1])) do (base, pow)
-                (base => pow * args[2])
-            end
-        elseif operation(expr) == (*)
-            return mapreduce(get_degrees,
-                             (x,y)->(x...,y...,), args)
-        elseif operation(expr) == (+)
-            ds = map(get_degrees, args)
-            _, idx = findmax(x->sum(last.(x), init=0), ds)
-            return ds[idx]
-        else
-            return (Symbol("zzzzzzz", hash(expr)) => 1,)
-        end
-    else
-        return ()
-    end
-end
-
-function monomial_lt(degs1, degs2)
-    d1 = sum(last, degs1, init=0)
-    d2 = sum(last, degs2, init=0)
-    d1 != d2 ? d1 < d2 : lexlt(degs1, degs2)
-end
-
-function lexlt(degs1, degs2)
-    for (a, b) in zip(degs1, degs2)
-        if a[1] == b[1] && a[2] != b[2]
-            return a[2] > b[2]
-        elseif a[1] != b[1]
-            return a < b
-        end
-    end
-    return false # they are equal
-end
 
 function show_add(io, args)
     for (i, t) in enumerate(args)

--- a/src/types.jl
+++ b/src/types.jl
@@ -684,22 +684,28 @@ function get_degrees(expr)
                                   (x,y)->(x...,y...,), args))
         elseif operation(expr) == (+)
             ds = map(get_degrees, args)
-            _, idx = findmax(x->sum(last.(x)), ds)
+            _, idx = findmax(x->sum(last.(x), init=0), ds)
             return ds[idx]
         else
             return (Symbol("zzzzzzz", objectid(expr)) => typemax(Int),)
         end
     else
-        return (Symbol("") => 0,)
+        return ()
     end
 end
 
 function lt_deglex(degs1, degs2)
-    d1 = sum(last, degs1)
-    d2 = sum(last, degs2)
+    d1 = sum(last, degs1, init=0)
+    d2 = sum(last, degs2, init=0)
     d1 != d2 ? d1 < d2 : degs1 < degs2
 end
 
+"""
+Decides whether printing of polynomial expressions should sort
+the arguments by degree-lexical order.
+
+Set `SymbolicUtils.sorted_pretty_print[] = false` to disable.
+"""
 const sorted_pretty_print = Ref{Bool}(true)
 
 function show_add(io, args)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -193,7 +193,7 @@ end
     @test repr(b+a) == "a + b"
     @test repr(b-a) == "-a + b"
     @test repr(2a+1+3a^2) == "1 + 2a + 3(a^2)"
-    @test repr(2a+1+3a^2+2b+3b^2+4a*b) == "1 + 2a + 2b + 4a*b + 3(a^2) + 3(b^2)"
+    @test repr(2a+1+3a^2+2b+3b^2+4a*b) == "1 + 2a + 2b + 3(a^2) + 4a*b + 3(b^2)"
 end
 
 @testset "inspect" begin
@@ -203,8 +203,8 @@ end
     @test_reference "inspect_output/ex.txt" sprint(io->SymbolicUtils.inspect(io, ex))
     @test_reference "inspect_output/ex-md.txt" sprint(io->SymbolicUtils.inspect(io, ex, metadata=true))
     @test_reference "inspect_output/ex-nohint.txt" sprint(io->SymbolicUtils.inspect(io, ex, hint=false))
-    @test SymbolicUtils.pluck(ex, 8) == 2
-    @test_reference "inspect_output/sub10.txt" sprint(io->SymbolicUtils.inspect(io, SymbolicUtils.pluck(ex, 10)))
+    @test SymbolicUtils.pluck(ex, 12) == 2
+    @test_reference "inspect_output/sub10.txt" sprint(io->SymbolicUtils.inspect(io, SymbolicUtils.pluck(ex, 9)))
     @test_reference "inspect_output/sub14.txt" sprint(io->SymbolicUtils.inspect(io, SymbolicUtils.pluck(ex, 14)))
 end
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -188,6 +188,14 @@ end
     @test repr((-1)^a) == "(-1)^a"
 end
 
+@testset "polynomial printing" begin
+    @syms a b c
+    @test repr(b+a) == "a + b"
+    @test repr(b-a) == "-a + b"
+    @test repr(2a+1+3a^2) == "1 + 2a + 3(a^2)"
+    @test repr(2a+1+3a^2+2b+3b^2+4a*b) == "1 + 2a + 2b + 4a*b + 3(a^2) + 3(b^2)"
+end
+
 @testset "inspect" begin
     @syms x y z
     y = SymbolicUtils.setmetadata(y, Integer, 42) # Set some metadata

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -196,8 +196,10 @@ end
     @test repr(2a+1+3a^2+2b+3b^2+4a*b) == "1 + 2a + 2b + 3(a^2) + 4a*b + 3(b^2)"
 
     @syms a b[1:3] c d[1:3]
-    @test repr(a + b[3] + b[1] + d[2] + c) == "a + b[1] + b[3] + c + d[2]"
-    @test repr(expand((c + b[3] - d[1])^3)) == "b[3]^3 + 3(b[3]^2)*c - 3(b[3]^2)*d[1] + 3b[3]*(c^2) - 6b[3]*c*d[1] + 3b[3]*(d[1]^2) + c^3 - 3(c^2)*d[1] + 3c*(d[1]^2) - (d[1]^3)"
+    get(x, i) = term(getindex, x, i, type=Number)
+    b1, b3, d1, d2 = get(b,1),get(b,3), get(d,1), get(d,2)
+    @test repr(a + b3 + b1 + d2 + c) == "a + b[1] + b[3] + c + d[2]"
+    @test repr(expand((c + b3 - d1)^3)) == "b[3]^3 + 3(b[3]^2)*c - 3(b[3]^2)*d[1] + 3b[3]*(c^2) - 6b[3]*c*d[1] + 3b[3]*(d[1]^2) + c^3 - 3(c^2)*d[1] + 3c*(d[1]^2) - (d[1]^3)"
 end
 
 @testset "inspect" begin

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -189,11 +189,15 @@ end
 end
 
 @testset "polynomial printing" begin
-    @syms a b c
+    @syms a b c x[1:3]
     @test repr(b+a) == "a + b"
     @test repr(b-a) == "-a + b"
     @test repr(2a+1+3a^2) == "1 + 2a + 3(a^2)"
     @test repr(2a+1+3a^2+2b+3b^2+4a*b) == "1 + 2a + 2b + 3(a^2) + 4a*b + 3(b^2)"
+
+    @syms a b[1:3] c d[1:3]
+    @test repr(a + b[3] + b[1] + d[2] + c) == "a + b[1] + b[3] + c + d[2]"
+    @test repr(expand((c + b[3] - d[1])^3)) == "b[3]^3 + 3(b[3]^2)*c - 3(b[3]^2)*d[1] + 3b[3]*(c^2) - 6b[3]*c*d[1] + 3b[3]*(d[1]^2) + c^3 - 3(c^2)*d[1] + 3c*(d[1]^2) - (d[1]^3)"
 end
 
 @testset "inspect" begin

--- a/test/inspect_output/ex-md.txt
+++ b/test/inspect_output/ex-md.txt
@@ -1,20 +1,20 @@
  1 DIV
  2 ├─ MUL(scalar = 1, powers = (z => 1, 1 + 2x + 3y => 2))
- 3 │  ├─ SYM(z)
- 4 │  └─ POW
- 5 │     ├─ ADD(scalar = 1, coeffs = (y => 3, x => 2))
- 6 │     │  ├─ 1
- 7 │     │  ├─ MUL(scalar = 2, powers = (x => 1,))
- 8 │     │  │  ├─ 2
- 9 │     │  │  └─ SYM(x)
-10 │     │  └─ MUL(scalar = 3, powers = (y => 1,))
-11 │     │     ├─ 3
-12 │     │     └─ SYM(y) metadata=(Integer => 42,)
-13 │     └─ 2
+ 3 │  ├─ POW
+ 4 │  │  ├─ ADD(scalar = 1, coeffs = (y => 3, x => 2))
+ 5 │  │  │  ├─ 1
+ 6 │  │  │  ├─ MUL(scalar = 2, powers = (x => 1,))
+ 7 │  │  │  │  ├─ 2
+ 8 │  │  │  │  └─ SYM(x)
+ 9 │  │  │  └─ MUL(scalar = 3, powers = (y => 1,))
+10 │  │  │     ├─ 3
+11 │  │  │     └─ SYM(y) metadata=(Integer => 42,)
+12 │  │  └─ 2
+13 │  └─ SYM(z)
 14 └─ ADD(scalar = 0, coeffs = (z => 1, x => 2))
-15    ├─ SYM(z)
-16    └─ MUL(scalar = 2, powers = (x => 1,))
-17       ├─ 2
-18       └─ SYM(x)
+15    ├─ MUL(scalar = 2, powers = (x => 1,))
+16    │  ├─ 2
+17    │  └─ SYM(x)
+18    └─ SYM(z)
 
 Hint: call SymbolicUtils.pluck(expr, line_number) to get the subexpression starting at line_number

--- a/test/inspect_output/ex-nohint.txt
+++ b/test/inspect_output/ex-nohint.txt
@@ -1,18 +1,18 @@
  1 DIV
  2 ├─ MUL(scalar = 1, powers = (z => 1, 1 + 2x + 3y => 2))
- 3 │  ├─ SYM(z)
- 4 │  └─ POW
- 5 │     ├─ ADD(scalar = 1, coeffs = (y => 3, x => 2))
- 6 │     │  ├─ 1
- 7 │     │  ├─ MUL(scalar = 2, powers = (x => 1,))
- 8 │     │  │  ├─ 2
- 9 │     │  │  └─ SYM(x)
-10 │     │  └─ MUL(scalar = 3, powers = (y => 1,))
-11 │     │     ├─ 3
-12 │     │     └─ SYM(y)
-13 │     └─ 2
+ 3 │  ├─ POW
+ 4 │  │  ├─ ADD(scalar = 1, coeffs = (y => 3, x => 2))
+ 5 │  │  │  ├─ 1
+ 6 │  │  │  ├─ MUL(scalar = 2, powers = (x => 1,))
+ 7 │  │  │  │  ├─ 2
+ 8 │  │  │  │  └─ SYM(x)
+ 9 │  │  │  └─ MUL(scalar = 3, powers = (y => 1,))
+10 │  │  │     ├─ 3
+11 │  │  │     └─ SYM(y)
+12 │  │  └─ 2
+13 │  └─ SYM(z)
 14 └─ ADD(scalar = 0, coeffs = (z => 1, x => 2))
-15    ├─ SYM(z)
-16    └─ MUL(scalar = 2, powers = (x => 1,))
-17       ├─ 2
-18       └─ SYM(x)
+15    ├─ MUL(scalar = 2, powers = (x => 1,))
+16    │  ├─ 2
+17    │  └─ SYM(x)
+18    └─ SYM(z)

--- a/test/inspect_output/ex.txt
+++ b/test/inspect_output/ex.txt
@@ -1,20 +1,20 @@
  1 DIV
  2 ├─ MUL(scalar = 1, powers = (z => 1, 1 + 2x + 3y => 2))
- 3 │  ├─ SYM(z)
- 4 │  └─ POW
- 5 │     ├─ ADD(scalar = 1, coeffs = (y => 3, x => 2))
- 6 │     │  ├─ 1
- 7 │     │  ├─ MUL(scalar = 2, powers = (x => 1,))
- 8 │     │  │  ├─ 2
- 9 │     │  │  └─ SYM(x)
-10 │     │  └─ MUL(scalar = 3, powers = (y => 1,))
-11 │     │     ├─ 3
-12 │     │     └─ SYM(y)
-13 │     └─ 2
+ 3 │  ├─ POW
+ 4 │  │  ├─ ADD(scalar = 1, coeffs = (y => 3, x => 2))
+ 5 │  │  │  ├─ 1
+ 6 │  │  │  ├─ MUL(scalar = 2, powers = (x => 1,))
+ 7 │  │  │  │  ├─ 2
+ 8 │  │  │  │  └─ SYM(x)
+ 9 │  │  │  └─ MUL(scalar = 3, powers = (y => 1,))
+10 │  │  │     ├─ 3
+11 │  │  │     └─ SYM(y)
+12 │  │  └─ 2
+13 │  └─ SYM(z)
 14 └─ ADD(scalar = 0, coeffs = (z => 1, x => 2))
-15    ├─ SYM(z)
-16    └─ MUL(scalar = 2, powers = (x => 1,))
-17       ├─ 2
-18       └─ SYM(x)
+15    ├─ MUL(scalar = 2, powers = (x => 1,))
+16    │  ├─ 2
+17    │  └─ SYM(x)
+18    └─ SYM(z)
 
 Hint: call SymbolicUtils.pluck(expr, line_number) to get the subexpression starting at line_number

--- a/test/inspect_output/sub14.txt
+++ b/test/inspect_output/sub14.txt
@@ -1,7 +1,7 @@
 1 ADD(scalar = 0, coeffs = (z => 1, x => 2))
-2 ├─ SYM(z)
-3 └─ MUL(scalar = 2, powers = (x => 1,))
-4    ├─ 2
-5    └─ SYM(x)
+2 ├─ MUL(scalar = 2, powers = (x => 1,))
+3 │  ├─ 2
+4 │  └─ SYM(x)
+5 └─ SYM(z)
 
 Hint: call SymbolicUtils.pluck(expr, line_number) to get the subexpression starting at line_number

--- a/test/order.jl
+++ b/test/order.jl
@@ -27,32 +27,8 @@ end
 @test istotal(b*a, a)
 @test istotal(a, b*a)
 @test !(b*a <ₑ b+a)
-@test a <ₑ Term(^, [1,-1])
+@test Term(^, [1,-1]) <ₑ a
 @test istotal(a, Term(^, [1,-1]))
-
-@testset "operator order" begin
-    fs = (*, ^, /, \, -, +)
-    for i in 1:length(fs)
-        f = fs[i]
-        @test f(a, b) <ₑ f(b, c)
-        @test istotal(f(a, b), f(b, c))
-        @test !(f(b, b) <ₑ f(b, b))
-        @test istotal(f(b, b), f(b, b))
-        @test !(f(b, c) <ₑ f(a, b))
-        @test istotal(f(b, c), f(a, b))
-
-        @test f(1, b) <ₑ f(2, b)
-        @test !(f(2, b) <ₑ f(1, b))
-        @test istotal(f(1, b), f(2, b))
-        @test istotal(f(2, b), f(1, b))
-        @test b <ₑ f(2,b) && !(f(2,b) <ₑ b)
-
-        for j in i+1:length(fs)
-            g = fs[j]
-            @test istotal(f(a, b), g(a, b))
-        end
-    end
-end
 
 @testset "callable variable order" begin
     @syms z() ρ()
@@ -84,7 +60,7 @@ end
 @testset "transitivity" begin
     # issue #160
     @syms σ x y z
-    expr = σ*sin(x + -1y)*(sin(z)^(-1))*(-1x + y)
-    args = arguments(expr)
+    expr = σ*sin(x + -1y)*(sin(z)^2)*(-1x + y)
+    args = sort(arguments(expr), lt=<ₑ)
     @test all(((a, b), )->a <ₑ b,  combinations(args, 2))
 end

--- a/test/order.jl
+++ b/test/order.jl
@@ -30,6 +30,29 @@ end
 @test Term(^, [1,-1]) <ₑ a
 @test istotal(a, Term(^, [1,-1]))
 
+@testset "operator order" begin
+    fs = (*, -, +)
+    for i in 1:length(fs)
+        f = fs[i]
+        @test f(a, b) <ₑ f(b, c)
+        @test istotal(f(a, b), f(b, c))
+        @test !(f(b, b) <ₑ f(b, b))
+        @test istotal(f(b, b), f(b, b))
+        @test !(f(b, c) <ₑ f(a, b))
+        @test istotal(f(b, c), f(a, b))
+
+        @test f(1, b) <ₑ f(2, b)
+        @test !(f(2, b) <ₑ f(1, b))
+        @test istotal(f(1, b), f(2, b))
+        @test istotal(f(2, b), f(1, b))
+        @test b <ₑ f(2,b) && !(f(2,b) <ₑ b)
+
+        for j in i+1:length(fs)
+            g = fs[j]
+            @test istotal(f(a, b), g(a, b))
+        end
+    end
+end
 @testset "callable variable order" begin
     @syms z() ρ()
 
@@ -61,6 +84,7 @@ end
     # issue #160
     @syms σ x y z
     expr = σ*sin(x + -1y)*(sin(z)^2)*(-1x + y)
+    # Note that arguments(expr) no more uses <ₑ
     args = sort(arguments(expr), lt=<ₑ)
     @test all(((a, b), )->a <ₑ b,  combinations(args, 2))
 end

--- a/test/polyform.jl
+++ b/test/polyform.jl
@@ -5,7 +5,7 @@ include("utils.jl")
 
 @testset "div and polyform" begin
     @syms x y z
-    @test repr(PolyForm(x-y)) == "x - y"
+    @test repr(PolyForm(x-y)) == "-y + x"
     @test repr(x/y*x/z) == "(x^2) / (y*z)"
     @test repr(simplify_fractions(((x-y+z)*(x+4z+1)) /
                                   (y*(2x - 3y + 3z) +


### PR DESCRIPTION
```julia
julia> expand((x+y-1)^4)
1 - 4x - 4y + 6(x^2) + 12x*y + 6(y^2) - 4(x^3) - 12(x^2)*y - 12x*(y^2) - 4(y^3) + x^4 + 4(x^3)*y + 6(x^2)*(y^2) + 4x*(y^3) + y^4
```

`arguments` no more uses `<ₑ`; `<ₑ` does still maintain a total order, is tested, and used for simplification in non-canonical cases.