### PR TITLE
NaNMath.pow fix

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -20,7 +20,7 @@ const monadic = [deg2rad, rad2deg, transpose, asind, log1p, acsch,
 
 const diadic = [max, min, hypot, atan, NaNMath.atanh, mod, rem, copysign,
                 besselj, bessely, besseli, besselk, hankelh1, hankelh2,
-                polygamma, beta, logbeta]
+                polygamma, beta, logbeta, NaNMath.pow]
 const previously_declared_for = Set([])
 
 const basic_monadic = [-, +]

--- a/test/code.jl
+++ b/test/code.jl
@@ -86,6 +86,9 @@ nanmath_st.rewrites[:nanmath] = true
               end)
     @test toexpr(SetArray(true, a, [x(t), AtIndex(9, b), c])).head == :macrocall
 
+
+    @test toexpr(NaNMath.pow(a, b)) == :($(NaNMath.pow)(a, b))
+
     f = GlobalRef(NaNMath, :sin)
     test_repr(toexpr(LiteralExpr(:(let x=1, y=2
                                        $(sin(a+b))


### PR DESCRIPTION
NaNMath.pow needs a dispatch to prevent stack overflow with symbolic arguments.