### PR TITLE
Fix DataDrivenDiffEq.jl downstream test

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -21,7 +21,7 @@ jobs:
           - {user: SciML, repo: ModelingToolkit.jl, group: All}
           - {user: SciML, repo: Catalyst.jl, group: All}
           - {user: SciML, repo: NeuralPDE.jl, group: NNPDE}
-          - {user: SciML, repo: DataDrivenDiffEq.jl, group: Standard}
+          - {user: SciML, repo: DataDrivenDiffEq.jl, group: Core}
           - {user: JuliaSymbolics, repo: Symbolics.jl, group: All}
           - {user: SciML, repo: ModelOrderReduction.jl, group: All}
           


### PR DESCRIPTION
"Standard" group no longer exists in DataDrivenDiffEq.jl, "Core" looks like a good replacement.