### PR TITLE
Remove compat with AbstractTrees 0.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 Unityper = "a7c27f48-0311-42f6-a7f8-2c11e75eb415"
 
 [compat]
-AbstractTrees = "0.3, 0.4"
+AbstractTrees = "0.4"
 Bijections = "0.1.2"
 ChainRulesCore = "1"
 Combinatorics = "1.0"


### PR DESCRIPTION
I ran into issues with SymbolicUtils.jl breaking other packages that I tried using. I just found out that this was because of another package holding back AbstractTrees.jl to 0.3. Since SymbolicUtils.jl seems not to work anymore with that version, the compat should also be removed.