### PR TITLE
Fix broken link on documentation homepage

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -9,7 +9,7 @@
 - Type promotion:
   - Symbols (`Sym`s) carry type information. ([read more](#creating_symbolic_expressions))
   - Compound expressions composed of `Sym`s propagate type information. ([read more](#expression_interface))
-- Set of extendable [simplification rules](#simplification).
+- Set of extendable [simplification rules](#Simplification).
 
 
 ## Creating symbolic expressions


### PR DESCRIPTION
Fragments are case sensitive.