### PR TITLE
Replace `get!` with `get` to avoid unnecessary initialization of state values

### DIFF
--- a/src/code.jl
+++ b/src/code.jl
@@ -743,7 +743,7 @@ end
 
 function cse_state!(state, t)
     !iscall(t) && return t
-    state[t] = Base.get!(state, t, 0) + 1
+    state[t] = Base.get(state, t, 0) + 1
     foreach(x->cse_state!(state, x), unsorted_arguments(t))
 end
 


### PR DESCRIPTION
The original code used `get!` which would initialize `state[t]` to `0` if it didn't exist before incrementing. This is unnecessary as the value is only used for incrementing. Using `get` with a default value of `0` achieves the same result without potential performance overhead.

See the source code for `get`:
https://github.com/JuliaLang/julia/blob/0b4590a5507d3f3046e5bafc007cacbbfc9b310b/base/dict.jl#L545
and for `get!`:
https://github.com/JuliaLang/julia/blob/0b4590a5507d3f3046e5bafc007cacbbfc9b310b/base/dict.jl#L473