### PR TITLE
Refactor: Simplify `@syms` macro implementation

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -951,8 +951,6 @@ macro syms(xs...)
     defs = map(xs) do x
         n, t = _name_type(x)
         T = esc(t)
-        nt = _name_type(x)
-        n, t = nt.name, nt.type
         :($(esc(n)) = Sym{$T}($(Expr(:quote, n))))
     end
     Expr(:block, defs...,


### PR DESCRIPTION
This PR removes redundant call to `_name_type` within the `@syms` macro definition.