### PR TITLE
Add `Symbolic` number constructor and conversion

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -570,6 +570,57 @@ function basic_similarterm(t, f, args, stype; metadata=nothing)
     end
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Construct a [`Symbolic`](@ref) object from a number `x`.
+
+This function is used to create a symbolic representation of a number.
+
+```jldoctest
+julia> a = SymbolicUtils.Symbolic(3.14)
+3.14
+
+julia> typeof(a)
+SymbolicUtils.BasicSymbolic{Float64}
+
+julia> b = SymbolicUtils.Symbolic{Real}(6.28)
+6.28
+
+julia> typeof(b)
+SymbolicUtils.BasicSymbolic{Real}
+```
+"""
+function Symbolic{T}(x::Number) where {T}
+    Term{T}(identity, [convert(T, x)])
+end
+function Symbolic(x::T) where {T<:Number}
+    Symbolic{T}(x)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Convert a number `x` to a [`Symbolic`](@ref) object.
+
+This function is used to convert a number to a symbolic representation.
+It is called, for example, when assigning to an array (converts to the array's
+element type) or assigning to a field of an object (converts to the declared type
+of the field).
+
+# Examples
+```jldoctest
+julia> a = convert(SymbolicUtils.BasicSymbolic{Real}, 3.14)
+3.14
+
+julia> typeof(a)
+SymbolicUtils.BasicSymbolic{Real}
+```
+"""
+function Base.convert(::Type{<:Symbolic{T}}, x::Number) where {T}
+    Symbolic{T}(x)
+end
+
 ###
 ### Metadata
 ###

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -315,3 +315,44 @@ end
     end
     @test repr(sin(x) + sin(x)) == "sin(x) + sin(x)"
 end
+
+@testset "Symbolic Number Constructor and Conversion" begin
+    @testset "Int" begin
+        @test Symbolic(1) isa Symbolic{Int}
+        expected = Term{Int}(identity, [1])
+        @test isequal(Symbolic(1), expected)
+        @test isequal(convert(Symbolic{Int}, 1), expected)
+        @test isequal(convert(BasicSymbolic{Int}, 1), expected)
+    end
+
+    @testset "Float64" begin
+        @test Symbolic(1.0) isa Symbolic{Float64}
+        expected = Term{Float64}(identity, [1.0])
+        @test isequal(Symbolic(1.0), expected)
+        @test isequal(convert(Symbolic{Float64}, 1.0), expected)
+        @test isequal(convert(BasicSymbolic{Float64}, 1.0), expected)
+    end
+
+    @testset "Rational" begin
+        @test Symbolic(1//2) isa Symbolic{Rational{Int}}
+        expected = Term{Rational{Int}}(identity, [1//2])
+        @test isequal(Symbolic(1//2), expected)
+        @test isequal(convert(Symbolic{Rational{Int}}, 1//2), expected)
+        @test isequal(convert(BasicSymbolic{Rational{Int}}, 1//2), expected)
+    end
+
+    @testset "Complex" begin
+        @test Symbolic(1 + 2im) isa Symbolic{Complex{Int}}
+        expected = Term{Complex{Int}}(identity, [1 + 2im])
+        @test isequal(Symbolic(1 + 2im), expected)
+        @test isequal(convert(Symbolic{Complex{Int}}, 1 + 2im), expected)
+        @test isequal(convert(BasicSymbolic{Complex{Int}}, 1 + 2im), expected)
+    end
+
+    @testset "Assigning Number to Array" begin
+        @syms x y
+        arr = [x, y]
+        @test_nowarn arr[1] = 2
+        @test_nowarn arr[2] = 1.0
+    end
+end


### PR DESCRIPTION
- fix https://github.com/JuliaSymbolics/Symbolics.jl/issues/853
- fix https://github.com/JuliaSymbolics/SymbolicUtils.jl/issues/601

This pull request adds a constructor and a conversion function for `Symbolic` objects representing numbers.

#### Key changes:

- `Symbolic` constructor:

  - The `Symbolic(x::T) where {T<:Number}` constructor now creates a `Term` object from a number `x`, inferring the type of the `Symbolic` object from the type of `x`.
  - The `Symbolic{T}(x::Number) where {T}` constructor now creates a `Term` object with the specified type `T`, converting `x` to that type if necessary.

- convert function:

  - The `convert(::Type{<:Symbolic{T}}, x::Number) where {T}` function now converts a number `x` to a `Term` object of the specified type `T`.

- Tests:

  - The test suite now includes tests for the `Symbolic` constructor and convert function, ensuring correct behavior for various numeric types, including `Int`, `Float64`, `Rational`, and `Complex`.
  - The test suite also includes a test case demonstrating how the convert function works when assigning a number to an array of `Symbolic`.

These changes provide a more convenient and flexible way to create and work with symbolic representations of numbers, and hide the internal `Symbolic` subtype system from external users.