### PR TITLE
Simplify printing

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -791,7 +791,6 @@ function show_call(io, f, args)
     else
         if issym(f)
             print(io, string(nameof(f)))
-            return
         else
             Base.show(io, f)
         end

--- a/src/types.jl
+++ b/src/types.jl
@@ -790,7 +790,8 @@ function show_call(io, f, args)
         end
     else
         if issym(f)
-            Base.show_unquoted(io, nameof(f))
+            print(io, string(nameof(f)))
+            return
         else
             Base.show(io, f)
         end
@@ -834,7 +835,7 @@ showraw(t) = showraw(stdout, t)
 
 function Base.show(io::IO, v::BasicSymbolic)
     if issym(v)
-        Base.show_unquoted(io, v.name)
+        print(io, v.name)
     else
         show_term(io, v)
     end


### PR DESCRIPTION
With the changes downstream, this makes `var"mysymbol.x"` just print as `mysymbol.x`, which makes all of the use cases look so much nicer and gets rid of unicode.

```julia
julia> rc_model
Model rc_model with 1 equations
Unknowns (1):
  capacitor.v
Parameters (3):
  resistor.R [defaults to 2.0]
  capacitor.C [defaults to 1.0]
⋮
Incidence matrix:1×2 SparseArrays.SparseMatrixCSC{Num, Int64} with 2 stored entries:
 ×  ×

julia> equations(rc_model)
1-element Vector{Equation}:
 Differential(t)(capacitor.v) ~ capacitor.i / capacitor.C

julia> unknowns(rc_model)
1-element Vector{SymbolicUtils.BasicSymbolic{Real}}:
 capacitor.v

julia> parameters(rc_model)
3-element Vector{SymbolicUtils.BasicSymbolic{Real}}:
 resistor.R
 capacitor.C
 source.V

julia> observed(rc_model)
19-element Vector{Equation}:
 source.v ~ source.V
 capacitor.p.v ~ capacitor.v
 capacitor.n.v ~ -0.0
 ground.g.v ~ 0.0
 ⋮
 source.p.i ~ source.i
 capacitor.p.i ~ -capacitor.n.i
 source.n.i ~ -source.p.i
```
