### PR TITLE
Import `maketerm` in SymbolicUtils.Code to resolve `UndefVarError`

### DIFF
--- a/src/code.jl
+++ b/src/code.jl
@@ -9,7 +9,7 @@ export toexpr, Assignment, (←), Let, Func, DestructuredArgs, LiteralExpr,
 import ..SymbolicUtils
 import ..SymbolicUtils.Rewriters
 import SymbolicUtils: @matchable, BasicSymbolic, Sym, Term, iscall, operation, arguments, issym,
-                      symtype, similarterm, unsorted_arguments, metadata, isterm, term
+                      symtype, similarterm, unsorted_arguments, metadata, isterm, term, maketerm
 
 ##== state management ==##
 


### PR DESCRIPTION
This pull request addresses a failing test case encountered in the Symbolics.jl integration test CI https://github.com/JuliaSymbolics/SymbolicUtils.jl/actions/runs/9640298551/job/26624028476?pr=615#step:6:987 in PR https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/615 due to an undefined `maketerm` function at https://github.com/JuliaSymbolics/SymbolicUtils.jl/blob/43797eb43b33b8d6b0374eac8cd6f87f94bcf79d/src/code.jl#L766

The CI test was failing with an `UndefVarError: maketerm not defined` error. This occurred because the `maketerm` function, although used, was not explicitly imported within the SymbolicUtils.Code module.

This pull request resolves the issue by explicitly importing the `maketerm` function within the SymbolicUtils.Code module. This ensures that the function is accessible and prevents the `UndefVarError` from occurring during testing.