### PR TITLE
Fix faulty istree deprecation

### DIFF
--- a/src/SymbolicUtils.jl
+++ b/src/SymbolicUtils.jl
@@ -19,8 +19,7 @@ using TermInterface
 import TermInterface: iscall, isexpr, issym, symtype, head, children,
                       operation, arguments, metadata, maketerm
 
-const istree = iscall
-Base.@deprecate_binding istree iscall
+Base.@deprecate istree iscall
 export istree, operation, arguments, sorted_arguments, similarterm, iscall
 # Sym, Term,
 # Add, Mul and Pow


### PR DESCRIPTION
This should essentially fix https://github.com/SciML/ModelingToolkit.jl/issues/2827 . The issue was that istree has been marked as deprecated, but istree is also the same function as iscall, causing Aqua to fail.