### PR TITLE
Fix metadata prop

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -553,14 +553,38 @@ function basicsymbolic(f, args, stype, metadata)
         T = _promote_symtype(f, args)
     end
     if T <: LiteralReal
-        Term{T}(f, args, metadata=metadata)
-    elseif T <: Number && (f in (+, *) || (f in (/, ^) && length(args) == 2)) && all(x->symtype(x) <: Number, args)
-        res = f(args...)
-        if res isa Symbolic
-            @set! res.metadata = metadata
+        @goto FALLBACK
+    elseif all(x->symtype(x) <: Number, args)
+        if f === (+)
+            res = +(args...)
+            if isadd(res)
+                @set! res.metadata = metadata
+            end
+            res
+        elseif f == (*)
+            res = *(args...)
+            if ismul(res)
+                @set! res.metadata = metadata
+            end
+            res
+        elseif f == (/)
+            @assert length(args) == 2
+            res = args[1] / args[2]
+            if isdiv(res)
+                @set! res.metadata = metadata
+            end
+            res
+        elseif f == (^) && length(args) == 2
+            res = args[1] ^ args[2]
+            if ispow(res)
+                @set! res.metadata = metadata
+            end
+            res
+        else
+            @goto FALLBACK
         end
-        return res
     else
+        @label FALLBACK
         Term{T}(f, args, metadata=metadata)
     end
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -228,6 +228,9 @@ end
     # test that maketerm sets metadata correctly
     metadata = Base.ImmutableDict{DataType, Any}(Ctx1, "meta_1")
     s = SymbolicUtils.maketerm(typeof(a^b), ^, [a * b, 3], Number, metadata)
+    @test !hasmetadata(s, Ctx1)
+
+    s = SymbolicUtils.maketerm(typeof(a^b), *, [a * b, 3], Number, metadata)
     @test hasmetadata(s, Ctx1)
     @test getmetadata(s, Ctx1) == "meta_1"
 end


### PR DESCRIPTION
`-(-x)` will simplify back to `x` and setting metadata on the simplified result is illegal.

Fixes https://github.com/SciML/ModelingToolkit.jl/issues/2855