### PR TITLE
Fix typo in literal_pow overload

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -139,7 +139,7 @@ function Base.inv(x::Symbolic)
 end
 function Base.literal_pow(::typeof(^), x::Symbolic, ::Val{p}) where {p}
     T = symtype(x)
-    T <: Number ? Base.:^(x, p) : error_f_symbolic(rem2pi, T)
+    T <: Number ? Base.:^(x, p) : error_f_symbolic(^, T)
 end
 function promote_symtype(::typeof(Base.literal_pow), _, ::Type{T}, ::Type{Val{S}}) where{T<:Number,S}
     return promote_symtype(^, T, typeof(S))


### PR DESCRIPTION
When you hit the error condition in `literal_pow` you get an error with rem2pi in it. That is a copy-paste-edit mistake from a few lines up:

```julia
function Base.rem2pi(x::Symbolic, mode::Base.RoundingMode)
    T = symtype(x)
    T <: Number ? term(rem2pi, x, mode) : error_f_symbolic(rem2pi, T)
end
```

was probably copied into 

```julia
function Base.literal_pow(::typeof(^), x::Symbolic, ::Val{p}) where {p}
    T = symtype(x)
    T <: Number ? Base.:^(x, p) : error_f_symbolic(rem2pi, T)
end
```

This PR just fixes the typo.