### PR TITLE
Fix `maketerm` handling of `BasicSymbolic{Array}`

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -563,16 +563,17 @@ function TermInterface.maketerm(T::Type{<:BasicSymbolic}, head, args, metadata)
     # Where the result would have a symtype of Bool. 
     # Please see discussion in https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/609 
     # TODO this should be optimized.
-    new_st = if pst === Bool 
-        pst 
-    elseif pst === Any || (st === Number && pst <: st) 
+    new_st = if st <: AbstractArray
         st
-    else 
-        pst 
-    end 
+    elseif pst === Bool
+        pst
+    elseif pst === Any || (st === Number && pst <: st)
+        st
+    else
+        pst
+    end
     basicsymbolic(head, args, new_st, metadata)
 end
-
 
 function basicsymbolic(f, args, stype, metadata)
     if f isa Symbol

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -249,6 +249,11 @@ end
     @syms x::Int y::Int 
     new_expr = SymbolicUtils.maketerm(typeof(ref_expr), (+), [x, y], nothing)
     @test symtype(new_expr) == Int64
+
+    # Check that the Array type does not get changed to AbstractArray
+    new_expr = SymbolicUtils.maketerm(
+        SymbolicUtils.BasicSymbolic{Vector{Float64}}, sin, [1.0, 2.0], nothing)
+    @test symtype(new_expr) == Vector{Float64}
 end
 
 toterm(t) = Term{symtype(t)}(operation(t), arguments(t))


### PR DESCRIPTION
This PR addresses the test failure observed in https://github.com/JuliaSymbolics/Symbolics.jl/actions/runs/10335343905/job/28609768547?pr=1196#step:7:582 within PR https://github.com/JuliaSymbolics/Symbolics.jl/pull/1196.

Currently, `maketerm` doesn't correctly handle cases where the input `T` is a `BasicSymbolic{Array}`. This leads to the resulting type being incorrectly changed to `AbstractArray` due to https://github.com/JuliaSymbolics/Symbolics.jl/blob/933757bfd1d04f2097c8ad84140796fb19dc3d91/src/arrays.jl#L437. 

This PR modifies `maketerm` to properly handle `BasicSymbolic{Array}` inputs, ensuring the correct type is maintained. 

However, we should probably refactor [`maketerm`](https://github.com/JuliaSymbolics/SymbolicUtils.jl/blob/77951c90da8dc167817344ca15047744a73fd5e0/src/types.jl#L558) for symbolic arrays with [`array_term`](https://github.com/JuliaSymbolics/Symbolics.jl/blob/933757bfd1d04f2097c8ad84140796fb19dc3d91/src/arrays.jl#L384) in Symbolics.jl later.
