### PR TITLE
Fix missing `metadata` when operation and resulting `BasicSymbolic` subtype mismatch

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -588,13 +588,13 @@ function basicsymbolic(f, args, stype, metadata)
     elseif all(x->symtype(x) <: Number, args)
         if f === (+)
             res = +(args...)
-            if isadd(res)
+            if isadd(res) || isterm(res)
                 @set! res.metadata = metadata
             end
             res
         elseif f == (*)
             res = *(args...)
-            if ismul(res)
+            if ismul(res) || isterm(res)
                 @set! res.metadata = metadata
             end
             res

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -227,6 +227,21 @@ end
 
     # test that maketerm sets metadata correctly
     metadata = Base.ImmutableDict{DataType, Any}(Ctx1, "meta_1")
+    metadata2 = Base.ImmutableDict{DataType, Any}(Ctx2, "meta_2")
+    
+    d = b * c
+    @set! d.metadata = metadata2
+
+    s = SymbolicUtils.maketerm(typeof(a + d), +, [a, d], metadata)
+    @test isterm(s)
+    @test hasmetadata(s, Ctx1)
+    @test getmetadata(s, Ctx1) == "meta_1"
+
+    s = SymbolicUtils.maketerm(typeof(a * d), *, [a, d], metadata)
+    @test isterm(s)
+    @test hasmetadata(s, Ctx1)
+    @test getmetadata(s, Ctx1) == "meta_1"
+
     s = SymbolicUtils.maketerm(typeof(a^b), ^, [a * b, 3], metadata)
     @test !hasmetadata(s, Ctx1)
 


### PR DESCRIPTION
This PR addresses an issue in the `basicsymbolic` function where it incorrectly assumes that the `+` and `*` operations always result in `Add` and `Mul` objects, respectively. 
https://github.com/JuliaSymbolics/SymbolicUtils.jl/blob/2ec473efe9f01bf9730d5108afc2e5908c6f0cf9/src/types.jl#L589-L600

Currently, when arguments possess metadata, the operations might return a `Term` object instead, as seen in 
https://github.com/JuliaSymbolics/SymbolicUtils.jl/blob/2ec473efe9f01bf9730d5108afc2e5908c6f0cf9/src/types.jl#L1082-L1083
https://github.com/JuliaSymbolics/SymbolicUtils.jl/blob/2ec473efe9f01bf9730d5108afc2e5908c6f0cf9/src/types.jl#L1136-L1138

This inconsistency was causing problems in https://github.com/Vaibhavdixit02/SymbolicAnalysis.jl/pull/43#issuecomment-2282773079

This PR corrects this problem by explicitly handling the `Term` case. This ensures the `maketerm` function behaves consistently and correctly handles arguments with metadata. 
