### PR TITLE
fix: avoid `ConstructionBase.setproperties` ambiguity

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -89,7 +89,7 @@ const SIMPLIFIED = 0x01 << 0
 #@inline is_of_type(x::BasicSymbolic, type::UInt8) = (x.bitflags & type) != 0x00
 #@inline issimplified(x::BasicSymbolic) = is_of_type(x, SIMPLIFIED)
 
-function ConstructionBase.setproperties_object(obj::BasicSymbolic{T}, patch)::BasicSymbolic{T} where T
+function ConstructionBase.setproperties(obj::BasicSymbolic{T}, patch::NamedTuple)::BasicSymbolic{T} where T
     nt = getproperties(obj)
     nt_new = merge(nt, patch)
     Unityper.rt_constructor(obj){T}(;nt_new...)


### PR DESCRIPTION
Fixes [this](https://github.com/SciML/ModelingToolkit.jl/actions/runs/10447617309/job/28926807757?pr=2945#step:6:627) ambiguity. The [`ConstructionBase` docs](https://juliaobjects.github.io/ConstructionBase.jl/stable/#ConstructionBase.setproperties) explicitly recommend adding a method to `setproperties` (`setproperties_object` is undocumented internals) and type-annotating `patch::NamedTuple`.