### PR TITLE
adjoint(y::Symbolic{<:Number})

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -160,36 +160,13 @@ for f in [identity, one, zero, *, +, -]
 end
 
 promote_symtype(::typeof(Base.real), T::Type{<:Number}) = Real
+Base.real(s::Symbolic{<:Number}) = islike(s, Real) ? s : term(real, s)
 promote_symtype(::typeof(Base.conj), T::Type{<:Number}) = T
+Base.conj(s::Symbolic{<:Number}) = islike(s, Real) ? s : term(conj, s)
 promote_symtype(::typeof(Base.imag), T::Type{<:Number}) = Real
-function Base.real(s::Symbolic{<:Number}) 
-    if iscall(s) 
-        f = operation(s)
-        args = map(real, arguments(s))
-        return f(args...)
-    else
-        islike(s, Real) ? s : term(real, s)
-    end
-end
-function Base.conj(s::Symbolic{<:Number}) 
-    if iscall(s) 
-        f = operation(s)
-        args = map(conj, arguments(s))
-        return f(args...)
-    else
-        islike(s, Real) ? s : term(conj, s)
-    end
-end
-function Base.imag(s::Symbolic{<:Number}) 
-    if iscall(s) 
-        f = operation(s)
-        args = map(imag, arguments(s))
-        return f(args...)
-    else
-        islike(s, Real) ? zero(symtype(s)) : term(imag, s)
-    end
-end
+Base.imag(s::Symbolic{<:Number}) = islike(s, Real) ? zero(symtype(s)) : term(imag, s)
 Base.adjoint(s::Symbolic{<:Number}) = conj(s)
+
 
 ## Booleans
 

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -160,11 +160,36 @@ for f in [identity, one, zero, *, +, -]
 end
 
 promote_symtype(::typeof(Base.real), T::Type{<:Number}) = Real
-Base.real(s::Symbolic{<:Number}) = islike(s, Real) ? s : term(real, s)
 promote_symtype(::typeof(Base.conj), T::Type{<:Number}) = T
-Base.conj(s::Symbolic{<:Number}) = islike(s, Real) ? s : term(conj, s)
 promote_symtype(::typeof(Base.imag), T::Type{<:Number}) = Real
-Base.imag(s::Symbolic{<:Number}) = islike(s, Real) ? zero(symtype(s)) : term(imag, s)
+function Base.real(s::Symbolic{<:Number}) 
+    if iscall(s) 
+        f = operation(s)
+        args = map(real, arguments(s))
+        return f(args...)
+    else
+        islike(s, Real) ? s : term(real, s)
+    end
+end
+function Base.conj(s::Symbolic{<:Number}) 
+    if iscall(s) 
+        f = operation(s)
+        args = map(conj, arguments(s))
+        return f(args...)
+    else
+        islike(s, Real) ? s : term(conj, s)
+    end
+end
+function Base.imag(s::Symbolic{<:Number}) 
+    if iscall(s) 
+        f = operation(s)
+        args = map(imag, arguments(s))
+        return f(args...)
+    else
+        islike(s, Real) ? zero(symtype(s)) : term(imag, s)
+    end
+end
+Base.adjoint(s::Symbolic{<:Number}) = conj(s)
 
 ## Booleans
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -360,6 +360,8 @@ end
 
 @testset "Adjoint" begin
     @syms x::Real y
-    @test isequal(adjoint(x), x)
+    ax = adjoint(x)
+    @test isequal(ax, x)
+    @test ax === x
     @test isequal(adjoint(y), conj(y)) 
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -354,14 +354,3 @@ end
     end
     @test repr(sin(x) + sin(x)) == "sin(x) + sin(x)"
 end
-
-@testset "real and complex" begin
-    @syms x y z::Real
-    @test isequal(conj(x*y*z), conj(x)*conj(y)*z)
-    @test isequal(conj(x*y*z + y), conj(x)*conj(y)*z + conj(y))
-    @test isequal(real(x*y*z + y), real(x)*real(y)*z + real(y))
-    @test isequal(imag(x*y*z + y), imag(y))
-    @test isequal(imag(x*y*z + y), imag(y))
-    @test isequal(conj(exp(1im*x)*y), conj(exp(1im*x))*conj(y))
-    @test isequal(adjoint(x*y*z), conj(x)*conj(y)*z)    
-end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -357,3 +357,9 @@ end
     end
     @test repr(sin(x) + sin(x)) == "sin(x) + sin(x)"
 end
+
+@testset "Adjoint" begin
+    @syms x::Real y
+    @test isequal(adjoint(x), x)
+    @test isequal(adjoint(y), conj(y)) 
+end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -354,3 +354,14 @@ end
     end
     @test repr(sin(x) + sin(x)) == "sin(x) + sin(x)"
 end
+
+@testset "real and complex" begin
+    @syms x y z::Real
+    @test isequal(conj(x*y*z), conj(x)*conj(y)*z)
+    @test isequal(conj(x*y*z + y), conj(x)*conj(y)*z + conj(y))
+    @test isequal(real(x*y*z + y), real(x)*real(y)*z + real(y))
+    @test isequal(imag(x*y*z + y), imag(y))
+    @test isequal(imag(x*y*z + y), imag(y))
+    @test isequal(conj(exp(1im*x)*y), conj(exp(1im*x))*conj(y))
+    @test isequal(adjoint(x*y*z), conj(x)*conj(y)*z)    
+end


### PR DESCRIPTION
I added the method  `adjoint(y::Symbolic{<:Number}) = conj(s)`. 
This is what Julia does for example with `adjoint(1im)`.