### PR TITLE
Remove method ambiguity in `isequal(::Symbolic, ::Missing)`.

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -225,6 +225,8 @@ isdiv(x)  = isa_SymType(Val(:Div), x)
 
 Base.isequal(::Symbolic, x) = false
 Base.isequal(x, ::Symbolic) = false
+Base.isequal(::Symbolic, ::Missing) = false
+Base.isequal(::Missing, ::Symbolic) = false
 Base.isequal(::Symbolic, ::Symbolic) = false
 coeff_isequal(a, b) = isequal(a, b) || ((a isa AbstractFloat || b isa AbstractFloat) && (a==b))
 function _allarequal(xs, ys)::Bool


### PR DESCRIPTION
According to the linter Aqua.jl, SymbolicsUtils has method ambiguities associated with `isequal` and `promote_symtype`:
```
julia> Aqua.test_ambiguities(SymbolicUtils)
50 ambiguities found. To get a list, set `broken = false`.
Ambiguity #1
isequal(x, ::SymbolicUtils.Symbolic) @ SymbolicUtils ~/.julia/dev/SymbolicUtils/src/types.jl:227
isequal(::Missing, ::Any) @ Base missing.jl:81

Possible fix, define
  isequal(::Missing, ::SymbolicUtils.Symbolic)

Ambiguity #2
isequal(::SymbolicUtils.Symbolic, x) @ SymbolicUtils ~/.julia/dev/SymbolicUtils/src/types.jl:226
isequal(::Any, ::Missing) @ Base missing.jl:82

Possible fix, define
  isequal(::SymbolicUtils.Symbolic, ::Missing)

# 48 more ambiguities omitted, associated with `promte_symtype`.
```

This PR removes the ambiguities associated with `isequal` by defining the specific methods,
```
Base.isequal(::Missing, ::SymbolicUtils.BasicSymbolic{Real}) = false
Base.isequal(::SymbolicUtils.BasicSymbolic{Real}, ::Missing) = false
```
