### PR TITLE
lazy evaluation of rational powers

### DIFF
--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -52,6 +52,14 @@ end
     @test simplify(Term(zero, [a])) == 0
     @test simplify(Term(zero, [b + 1])) == 0
     @test simplify(Term(zero, [x + 2])) == 0
+
+    @eqtest simplify(Term(sqrt, [2])) == Term(sqrt, [2])
+    @eqtest simplify(Term(^, [2, 1//2])) == Term(^, [2, 1//2])
+    @eqtest simplify(Term(^, [2x, 1//2])) == Term(^, [2, 1//2]) * x^(1//2)
+    @test simplify(Term(^, [2, 3])) ≈ 8
+    @test simplify(Term(^, [1//3, 3])) == 1//27
+    @test simplify(Term(^, [2, 0.5])) ≈ 2^0.5
+    @test simplify(Term(^, [2.5, 0.25])) ≈ 2.5^(0.25)
 end
 
 @testset "LiteralReal" begin


### PR DESCRIPTION
Rational powers are currently eagerly evaluated, so that, for example, 
```
using SymbolicUtils
@syms x
(2x) ^ (1//2) == 1.414… * x^(1//2)
simplify(term(^, 2, 1//2)) == 1.414…
```
and so on. While this might be intentional, it often causes precision loss and makes many analytical expressions rather ugly.

This PR adds branches to `basicsymbolic` and `^` to prevent evaluation of powers if the base is a literal number and the exponent is a rational. Integer or float exponents still get evaluated.
With this PR, we therefore have behavior like
```
(2x) ^ (1//2) ==  2^(1//2) * x^(1//2)
simplify(term(^, 2, 1//2)) == 2^(1//2)
simplify(term(^, 1//3, 2)) == 1//9
simplify(term(^, 2, 0.5)) == 1.414…
```

However, there is a small quirk. Currently `(2x) ^ 2` results in `(4//1) * x^2`, i.e. the integer prefactor is converted to a rational, due to the behavior of the `unstable_pow` function. I am not sure if this is intentional and I did not follow this conversion in the code in this PR. This means with this PR and a rational exponent, we have `(2x) ^ (2//1) == 4 * x^(2//1)`. I guess if this PR gets merged, this behavior should be made consistent, one way or another.

I am curious if this all sounds like a reasonable change, or if there other reasons why immediate evaluation of all powers is preferable — please let me know what you think!