### PR TITLE
Nested associative-commutative pattern matching

### DIFF
--- a/src/matchers.jl
+++ b/src/matchers.jl
@@ -6,13 +6,18 @@
 # 3. Callback: takes arguments Dictionary × Number of elements matched
 #
 function matcher(val::Any)
-    iscall(val) && return term_matcher(val)
+    matcher(val, false)
+end
+
+# `fullac_flag == true` enables fully nested associative-commutative pattern matching
+function matcher(val::Any, fullac_flag)
+    iscall(val) && return term_matcher(val, fullac_flag)
     function literal_matcher(next, data, bindings)
         islist(data) && isequal(car(data), val) ? next(bindings, 1) : nothing
     end
 end
 
-function matcher(slot::Slot)
+function matcher(slot::Slot, fullac_flag) # fullac_flag unused but needed to keep the interface uniform
     function slot_matcher(next, data, bindings)
         !islist(data) && return
         val = get(bindings, slot.name, nothing)
@@ -56,7 +61,7 @@ function trymatchexpr(data, value, n)
     end
 end
 
-function matcher(segment::Segment)
+function matcher(segment::Segment, fullac_flag) # fullac_flag unused but needed to keep the interface uniform
     function segment_matcher(success, data, bindings)
         val = get(bindings, segment.name, nothing)
 
@@ -84,8 +89,8 @@ function matcher(segment::Segment)
     end
 end
 
-function term_matcher(term)
-    matchers = (matcher(operation(term)), map(matcher, arguments(term))...,)
+function term_matcher(term, fullac_flag = false)
+    matchers = (matcher(operation(term), fullac_flag), map(a -> matcher(a, fullac_flag), arguments(term))...,)
     function term_matcher(success, data, bindings)
 
         !islist(data) && return nothing
@@ -103,6 +108,23 @@ function term_matcher(term)
             end
         end
 
-        loop(car(data), bindings, matchers) # Try to eat exactly one term
+        if !(fullac_flag && iscall(term) && operation(term) in ((+), (*)))
+            loop(car(data), bindings, matchers) # Try to eat exactly one term
+        else # try all permutations of `car(data)` to see if a match is possible
+            data1 = car(data)
+            args = arguments(data1)
+            op = operation(data1)
+            data_arg_perms = permutations(args)
+            result = nothing
+            T = symtype(data)
+            for perm in data_arg_perms
+                data_permuted = Term{T}(op, perm)
+                result = loop(data_permuted, bindings, matchers) # Try to eat exactly one term
+                if !(result isa Nothing)
+                    break
+                end
+            end
+            return result
+        end
     end
 end

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -43,6 +43,14 @@ end
     @eqtest @rule(+(~~x,~y,~~x) => (~~x, ~y, ~~x))(term(+,6,type=Any)) == ([], 6, [])
 end
 
+@testset "Full associative-commutative matching" begin
+    @eqtest (@rule ~a + ~a*~b => ~a * (1+~b) fullac)(a + a*b) == a * (1+b)
+    @eqtest (@rule ~a + ~a*~b => ~a * (1+~b) fullac)(b + a*b) == b * (1+a) # fails with @acrule
+    @eqtest (@rule ~a*~b + ~a => ~a * (1+~b) fullac)(b + a*b) == b * (1+a) # fails with @acrule
+    @eqtest (@rule ~a*~b + ~a*~c => ~a * (~b+~c) fullac)(a*b + a*c) == a * (b+c)
+    @eqtest (@rule ~a*~b + ~a*~c => ~a * (~b+~c) fullac)(a*b + b*c) == b * (a+c) # fails with @acrule
+end
+
 using SymbolicUtils: @capture
 
 @testset "Capture form" begin


### PR DESCRIPTION
This PR enables full (nested) associative-commutative pattern matching for all sub-expressions with `+` or `*` operations, when the user passes an option `fullac` to the `@rule` macro. This solves the problem that `@acrule` only applies associativity-commutativity at the top level.

The algorithm is currently simplistic, meant to be a "minimum viable product" rather than an optimized implementation. The pattern matcher tries up to $n!$ permutations of arguments for any sub-expression with the operation `+` or `*`, when attempting to find matches. The core algorithm is implemented in `matcher.jl` in the function `function term_matcher(term, fullac_flag = false)`.

Here are examples which show capabilities beyond those of `@acrule`:
```
(@rule ~a + ~a*~b => ~a * (1+~b) fullac)(b + a*b) # result: b * (1+a)
(@rule ~a*~b + ~a*~c => ~a * (~b+~c) fullac)(a*b + b*c) # result: b * (a+c)
```