### PR TITLE
Fix: Correct Scope of Symbolic Variable in `where` Rule Test

### DIFF
--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -185,11 +185,10 @@ _g(y) = sin
     @test @rule($(_g(1))(a) => 2)(sin(a)) == 2
 end
 
-@syms a
-_f(x) = x === a
 @testset "where" begin
 
     @syms a b
+    _f(x) = x === a
     r = @rule ~x => ~x where {_f(~x)}
     @eqtest r(a) == a
     @test isnothing(r(b))


### PR DESCRIPTION
The original test for the `where` clause in rules incorrectly handled the scope of the symbolic variable `a`. Two distinct symbolic variables with the same name were created, leading to unexpected behavior when checking for object equality in the `_f` function.

This PR moves the definition of `_f` inside the `@testset` block, ensuring that it references the same symbolic variable `a` as the rule definition. This correction aligns the test with the intended behavior of the `where` clause.