### PR TITLE
Fix: Resolve `@eqtest` method redefinition warning

### DIFF
--- a/test/polyform.jl
+++ b/test/polyform.jl
@@ -1,8 +1,6 @@
 using SymbolicUtils: PolyForm, Term, symtype
 using Test, SymbolicUtils
 
-include("utils.jl")
-
 @testset "div and polyform" begin
     @syms x y z
     @test_skip repr(PolyForm(x-y)) == "-y + x"


### PR DESCRIPTION
This PR resolves an issue where the `@eqtest` macro was being defined multiple times due to an extraneous `include("utils.jl")` line in the test suite.
