### PR TITLE
activate doc tests for rewrite.md

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
           version: '1.10'

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.10'
+          version: '1'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1'
+          version: '1.10'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -26,7 +26,7 @@ jobs:
           - {user: SciML, repo: ModelOrderReduction.jl, group: All}
           
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}

--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - uses: julia-actions/setup-julia@v1
               with:
                 version: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - run: |

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,12 +1,13 @@
 using Documenter, SymbolicUtils
 
 include("pages.jl")
+DocMeta.setdocmeta!(SymbolicUtils, :DocTestSetup, :(using SymbolicUtils); recursive=true)
 
 makedocs(
     sitename="SymbolicUtils.jl",
     authors="Shashi Gowda",
     modules=[SymbolicUtils],
-    clean=true,doctest=false,
+    clean=true, doctest=true,
     warnonly=Documenter.except(
         :doctest,
         :linkcheck,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,7 @@ DocMeta.setdocmeta!(
 )
 
 # Only test one Julia version to avoid differences due to changes in printing.
-if v"1.6" ≤ VERSION < v"1.7-beta3.0"
+if v"1.10" ≤ VERSION < v"1.11-"
     doctest(SymbolicUtils)
 else
     @warn "Skipping doctests"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,12 +12,7 @@ DocMeta.setdocmeta!(
     recursive=true
 )
 
-# Only test one Julia version to avoid differences due to changes in printing.
-if v"1.10" ≤ VERSION < v"1.11-"
-    doctest(SymbolicUtils)
-else
-    @warn "Skipping doctests"
-end
+doctest(SymbolicUtils)
 SymbolicUtils.show_simplified[] = false
 
 include("utils.jl")


### PR DESCRIPTION
This activate doc tests for current julia version 1.10 and executes them when building the documentation.

It also updates the doctests in `rewrite.md` to work with Documenter.jl.

This should fix #385.