### PR TITLE
Resolve duplicate docstring references

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -4,6 +4,7 @@
 ```@docs
 SymbolicUtils.@syms
 SymbolicUtils.Sym
+SymbolicUtils.issym
 SymbolicUtils.symtype
 SymbolicUtils.Term
 SymbolicUtils.Add

--- a/docs/src/manual/interface.md
+++ b/docs/src/manual/interface.md
@@ -10,11 +10,3 @@ In particular, you should define methods from TermInterface.jl for an expression
 with SymbolicUtils.jl
 
 You can read the documentation of [TermInterface.jl](https://github.com/JuliaSymbolics/TermInterface.jl) on the [Github repository](https://github.com/JuliaSymbolics/TermInterface.jl).
-
-## SymbolicUtils.jl only methods
-
-```@docs
-symtype
-issym
-promote_symtype
-```


### PR DESCRIPTION
This PR addresses an issue where the `@docs` blocks for `symtype` and `promote_symtype` in `interface.md` were not being rendered due to duplication with those in `api.md`.

![Screenshot 2024-10-21 144531](https://github.com/user-attachments/assets/659ec308-c545-4cf6-a15a-7326163fd0ce)

Changes:

- Removed the duplicate `@docs` blocks for `symtype` and `promote_symtype` from `interface.md`.
- Moved the `@docs` block for `issym` from `interface.md` to `api.md` to keep related documentation together.