### PR TITLE
Chore: Update upload-artifact action to v4 in benchmark_pr.yml

### DIFF
--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -44,7 +44,7 @@ jobs:
                 mkdir -p plots
                 benchpkgplot ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --npart=10 --format=png --input-dir=results/ --output-dir=plots/
             - name: Upload plot as artifact
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               with:
                 name: plots
                 path: plots


### PR DESCRIPTION
This pull request updates the `upload-artifact` action in `.github/workflows/benchmark_pr.yml` from the deprecated v2 to v4.