### PR TITLE
Rewrite `^` with `NaNMath.pow` in nanmath-mode

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicUtils"
 uuid = "d1185830-fcd6-423d-90d6-eec64667417b"
 authors = ["Shashi Gowda"]
-version = "3.7.2"
+version = "3.7.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"


### PR DESCRIPTION
On the master branch:

```julia
julia> using Symbolics

julia> @variables x y;

julia> Base.remove_linenums!(build_function(x^y, [x, y]))
:(function (ˍ₋arg1,)
      begin
          (^)(ˍ₋arg1[1], ˍ₋arg1[2])
      end
  end)
```

With this PR:

```julia
julia> using Symbolics

julia> @variables x y;

julia> Base.remove_linenums!(build_function(x^y, [x, y]))
:(function (ˍ₋arg1,)
      begin
          (NaNMath.pow)(ˍ₋arg1[1], ˍ₋arg1[2])
      end
  end)
```