### PR TITLE
Renamed `Pow` function for clarity

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -509,7 +509,7 @@ end
 
 @inline denominators(x) = isdiv(x) ? numerators(x.den) : Any[1]
 
-function (::Type{<:Pow{T}})(a, b; metadata=NO_METADATA) where {T}
+function Pow{T}(a, b; metadata=NO_METADATA) where {T}
     _iszero(b) && return 1
     _isone(b) && return a
     Pow{T}(; base=a, exp=b, arguments=[], metadata)


### PR DESCRIPTION
The modification eliminates the use of the `(::Type{<:Pow{T}})` syntax to improve clarity.