### PR TITLE
Do not rewrite `^(_, ::Int)` with `NaNMath.pow`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicUtils"
 uuid = "d1185830-fcd6-423d-90d6-eec64667417b"
 authors = ["Shashi Gowda"]
-version = "3.8.1"
+version = "3.8.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/code.jl
+++ b/src/code.jl
@@ -146,12 +146,15 @@ function function_to_expr(op::typeof(^), O, st)
             return toexpr(Term(inv, Any[ex]), st)
         else
             args = Any[Term(inv, Any[ex]), -args[2]]
-            op = get(st.rewrites, :nanmath, false) ? op : NaNMath.pow
+            op = get(st.rewrites, :nanmath, false) === true && !(args[2] isa Int) ? NaNMath.pow : op
             return toexpr(Term(op, args), st)
         end
     end
-    get(st.rewrites, :nanmath, false) === true || return nothing
-    return toexpr(Term(NaNMath.pow, args), st)
+    if get(st.rewrites, :nanmath, false) === true && !(args[2] isa Int)
+        return toexpr(Term(NaNMath.pow, args), st)
+    else
+        return nothing
+    end
 end
 
 function function_to_expr(::typeof(SymbolicUtils.ifelse), O, st)

--- a/test/code.jl
+++ b/test/code.jl
@@ -100,9 +100,14 @@ nanmath_st.rewrites[:nanmath] = true
     @test toexpr(NaNMath.pow(a, b), nanmath_st) == :($(NaNMath.pow)(a, b))
 
     @test toexpr(a^2) == :($(^)(a, 2))
-    @test toexpr(a^2, nanmath_st) == :($(NaNMath.pow)(a, 2))
+    @test toexpr(a^2, nanmath_st) == :($(^)(a, 2))
     @test toexpr(NaNMath.pow(a, 2)) == :($(NaNMath.pow)(a, 2))
     @test toexpr(NaNMath.pow(a, 2), nanmath_st) == :($(NaNMath.pow)(a, 2))
+
+    @test toexpr(a^3.1) == :($(^)(a, 3.1))
+    @test toexpr(a^3.1, nanmath_st) == :($(NaNMath.pow)(a, 3.1))
+    @test toexpr(NaNMath.pow(a, 3.1)) == :($(NaNMath.pow)(a, 3.1))
+    @test toexpr(NaNMath.pow(a, 3.1), nanmath_st) == :($(NaNMath.pow)(a, 3.1))
 
     @test toexpr(a^-1) == :($(/)(1, a))
     @test toexpr(a^-1, nanmath_st) == :($(/)(1, a))
@@ -110,9 +115,14 @@ nanmath_st.rewrites[:nanmath] = true
     @test toexpr(NaNMath.pow(a, -1), nanmath_st) == :($(NaNMath.pow)(a, -1))
 
     @test toexpr(a^-2) == :($(/)(1, $(^)(a, 2)))
-    @test toexpr(a^-2, nanmath_st) == :($(/)(1, $(NaNMath.pow)(a, 2)))
+    @test toexpr(a^-2, nanmath_st) == :($(/)(1, $(^)(a, 2)))
     @test toexpr(NaNMath.pow(a, -2)) == :($(NaNMath.pow)(a, -2))
     @test toexpr(NaNMath.pow(a, -2), nanmath_st) == :($(NaNMath.pow)(a, -2))
+
+    @test toexpr(a^-2.4) == :($(/)(1, $(^)(a, 2.4)))
+    @test toexpr(a^-2.4, nanmath_st) == :($(/)(1, $(NaNMath.pow)(a, 2.4)))
+    @test toexpr(NaNMath.pow(a, -2.4)) == :($(NaNMath.pow)(a, -2.4))
+    @test toexpr(NaNMath.pow(a, -2.4), nanmath_st) == :($(NaNMath.pow)(a, -2.4))
 
     f = GlobalRef(NaNMath, :sin)
     test_repr(toexpr(LiteralExpr(:(let x=1, y=2


### PR DESCRIPTION
Fixes #685 by not rewriting `^(_, ::Int)` which is safe even for negative numbers.