### PR TITLE
Simplify `NaNMath.pow` substitution

### DIFF
--- a/src/code.jl
+++ b/src/code.jl
@@ -139,18 +139,8 @@ function function_to_expr(op::Union{typeof(*),typeof(+)}, O, st)
 end
 
 function function_to_expr(op::typeof(^), O, st)
-    args = arguments(O)
-    if length(args) == 2 && args[2] isa Real && args[2] < 0
-        ex = args[1]
-        if args[2] == -1
-            return toexpr(Term(inv, Any[ex]), st)
-        else
-            args = Any[Term(inv, Any[ex]), -args[2]]
-            op = get(st.rewrites, :nanmath, false) ? op : NaNMath.pow
-            return toexpr(Term(op, args), st)
-        end
-    end
     get(st.rewrites, :nanmath, false) === true || return nothing
+    args = arguments(O)
     return toexpr(Term(NaNMath.pow, args), st)
 end
 


### PR DESCRIPTION
Line 149 was wrong, but it seems it was not caught by the tests since this simplification is applied already when the expression is constructed. Which made me wonder whether we could remove this branch completely from the `NaNMath.pow` substitution.