### PR TITLE
fix: fix `Code.cse` for different symbolic types

### DIFF
--- a/src/code.jl
+++ b/src/code.jl
@@ -722,7 +722,9 @@ function topological_sort(graph)
         end
         if iscall(node)
             args = map(dfs, arguments(node))
-            new_node = maketerm(typeof(node), operation(node), args, metadata(node))
+            # use `term` instead of `maketerm` because we only care about the operation being performed
+            # and not the representation. This avoids issues with `newsym` symbols not having sizes, etc.
+            new_node = term(operation(node), args...)
             sym = newsym(symtype(new_node))
             push!(sorted_nodes, sym ← new_node)
             visited[node] = sym

--- a/test/cse.jl
+++ b/test/cse.jl
@@ -16,28 +16,28 @@ end
     expr = sin(a + b) * (a + b)
     sorted_nodes = topological_sort(expr)
     @test length(sorted_nodes) == 3
-    @test isequal(sorted_nodes[1].rhs, a + b)
+    @test isequal(sorted_nodes[1].rhs, term(+, a, b))
     @test isequal(sin(sorted_nodes[1].lhs), sorted_nodes[2].rhs)
 
     expr = (a + b)^(a + b)
     sorted_nodes = topological_sort(expr)
     @test length(sorted_nodes) == 2
-    @test isequal(sorted_nodes[1].rhs, a + b)
+    @test isequal(sorted_nodes[1].rhs, term(+, a, b))
     ab_node = sorted_nodes[1].lhs
-    @test isequal(ab_node^ab_node, sorted_nodes[2].rhs)
+    @test isequal(term(^, ab_node, ab_node), sorted_nodes[2].rhs)
     let_expr = cse(expr)
     @test length(let_expr.pairs) == 1
-    @test isequal(let_expr.pairs[1].rhs, a + b)
+    @test isequal(let_expr.pairs[1].rhs, term(+, a, b))
     corresponding_sym = let_expr.pairs[1].lhs
-    @test isequal(let_expr.body, corresponding_sym^corresponding_sym)
+    @test isequal(let_expr.body, term(^, corresponding_sym, corresponding_sym))
 
     expr = a + b
     sorted_nodes = topological_sort(expr)
     @test length(sorted_nodes) == 1
-    @test isequal(sorted_nodes[1].rhs, a + b)
+    @test isequal(sorted_nodes[1].rhs, term(+, a, b))
     let_expr = cse(expr)
     @test isempty(let_expr.pairs)
-    @test isequal(let_expr.body, a + b)
+    @test isequal(let_expr.body, term(+, a, b))
     
     expr = a
     sorted_nodes = topological_sort(expr)


### PR DESCRIPTION
This is necessary for CSE on array symbolics represented as `ArrayOp`. It will be tested in Symbolics.jl, since there is no way to reproduce it otherwise.