### PR TITLE
fix: handle explicit `::Any` annotation in `@cache` macro

### DIFF
--- a/src/cache.jl
+++ b/src/cache.jl
@@ -245,6 +245,13 @@ macro cache(args...)
         argname, Texpr = arg.args
         push!(argexprs, argname)
 
+        if Texpr == :Any
+            # if the type is `Any`, branch on it being a `BasicSymbolic`
+            push!(keyexprs, :($argname isa BasicSymbolic ? $SymbolicKey(objectid($argname)) : $argname))
+            push!(keytypes, Any)
+            continue
+        end
+
         # handle Union types that may contain a `BasicSymbolic`
         if Meta.isexpr(Texpr, :curly) && Texpr.args[1] == :Union
             Texprs = Texpr.args[2:end]

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -229,6 +229,14 @@ macro cache(args...)
     keytypes = []
     # The arguments of the workhorse function
     argexprs = []
+    # The name of the variable storing the result of looking up the cache
+    cache_value_name = :val
+    # The condition for a cache hit
+    cache_hit_condition = :(!($cache_value_name isa $CacheSentinel))
+    # Type of additional data stored with cached result. Used to compare
+    # equality of `BasicSymbolic` arguments, since `objectid` is a hash.
+    cache_additional_types = []
+    cache_additional_values = []
 
     for arg in fn.args
         # handle arguments with defaults
@@ -240,6 +248,9 @@ macro cache(args...)
             push!(keyexprs, :($arg isa BasicSymbolic ? $SymbolicKey(objectid($arg)) : $arg))
             push!(argexprs, arg)
             push!(keytypes, Any)
+            push!(cache_additional_types, Any)
+            push!(cache_additional_values, arg)
+            cache_hit_condition = :($cache_hit_condition && (!($arg isa BasicSymbolic) || $arg === $cache_value_name[$(length(cache_additional_values))]))
             continue
         end
         argname, Texpr = arg.args
@@ -249,6 +260,9 @@ macro cache(args...)
             # if the type is `Any`, branch on it being a `BasicSymbolic`
             push!(keyexprs, :($argname isa BasicSymbolic ? $SymbolicKey(objectid($argname)) : $argname))
             push!(keytypes, Any)
+            push!(cache_additional_types, Any)
+            push!(cache_additional_values, argname)
+            cache_hit_condition = :($cache_hit_condition && (!($argname isa BasicSymbolic) || $argname === $cache_value_name[$(length(cache_additional_values))]))
             continue
         end
 
@@ -257,8 +271,16 @@ macro cache(args...)
             Texprs = Texpr.args[2:end]
             Ts = map(Base.Fix1(Base.eval, __module__), Texprs)
             keyTs = map(x -> x <: BasicSymbolic ? SymbolicKey : x, Ts)
+            maybe_basicsymbolic = any(x -> x <: BasicSymbolic, Ts)
             push!(keytypes, Union{keyTs...})
-            push!(keyexprs, :($argname isa BasicSymbolic ? $SymbolicKey(objectid($argname)) : $argname))
+            if maybe_basicsymbolic
+                push!(keyexprs, :($argname isa BasicSymbolic ? $SymbolicKey(objectid($argname)) : $argname))
+                push!(cache_additional_types, Texpr)
+                push!(cache_additional_values, argname)
+                cache_hit_condition = :($cache_hit_condition && (!($argname isa BasicSymbolic) || $argname === $cache_value_name[$(length(cache_additional_values))]))
+            else
+                push!(keyexprs, argname)
+            end
             continue
         end
             
@@ -267,6 +289,9 @@ macro cache(args...)
         if T <: BasicSymbolic
             push!(keytypes, SymbolicKey) 
             push!(keyexprs, :($SymbolicKey(objectid($argname))))
+            push!(cache_additional_types, T)
+            push!(cache_additional_values, argname)
+            cache_hit_condition = :($cache_hit_condition && $argname === $cache_value_name[$(length(cache_additional_values))])
         else
             push!(keytypes, T)
             push!(keyexprs, argname)
@@ -287,8 +312,11 @@ macro cache(args...)
     # construct an expression for the type of the cache keys
     keyT = Expr(:curly, Tuple)
     append!(keyT.args, keytypes)
+    valT = Expr(:curly, Tuple)
+    append!(valT.args, cache_additional_types)
+    push!(valT.args, rettype)
     # the type of the cache
-    cacheT = :(Dict{$keyT, $rettype})
+    cacheT = :(Dict{$keyT, $valT})
     # type of the `TaskLocalValue`
     tlvT = :($(TaskLocalValue){Tuple{$cacheT, $CacheStats}})
     # the name of the cache struct
@@ -331,11 +359,11 @@ macro cache(args...)
             # look it up
             # we use a custom sentinel value since `nothing` is a valid return value
             # which we might want to cache
-            val = $(get)(cachedict, key, $(CacheSentinel)())
-            if !(val isa $CacheSentinel)
+            $cache_value_name = $(get)(cachedict, key, $(CacheSentinel)())
+            if $cache_hit_condition
                 # cache hit
                 cachestats.hits += 1
-                return val
+                return $cache_value_name[end]
             end
             # cache miss
             cachestats.misses += 1
@@ -346,7 +374,7 @@ macro cache(args...)
                 $(filter!)($cachename, cachedict)
             end
             # add to cache
-            cachedict[key] = val
+            cachedict[key] = ($(cache_additional_values...), val)
             return val
         end
 

--- a/test/cache_macro.jl
+++ b/test/cache_macro.jl
@@ -13,9 +13,9 @@ end
     @test isequal(val, 2x + 1)
     cachestruct = associated_cache(f1)
     cache, stats = cachestruct.tlv[]
-    @test cache isa Dict{Tuple{SymbolicKey}, BasicSymbolic}
+    @test cache isa Dict{Tuple{SymbolicKey}, Tuple{BasicSymbolic, BasicSymbolic}}
     @test length(cache) == 1
-    @test cache[(SymbolicKey(objectid(x)),)] === val
+    @test cache[(SymbolicKey(objectid(x)),)][end] === val
     @test stats.hits == 0
     @test stats.misses == 1
     f1(x)
@@ -75,9 +75,9 @@ end
     @test isequal(val, 2x + 1)
     cachestruct = associated_cache(f2)
     cache, stats = cachestruct.tlv[]
-    @test cache isa Dict{Tuple{Union{SymbolicKey, UInt}}, Union{BasicSymbolic, UInt}}
+    @test cache isa Dict{Tuple{Union{SymbolicKey, UInt}}, NTuple{2, Union{BasicSymbolic, UInt}}}
     @test length(cache) == 1
-    @test cache[(SymbolicKey(objectid(x)),)] === val
+    @test cache[(SymbolicKey(objectid(x)),)][end] === val
     @test stats.hits == 0
     @test stats.misses == 1
     f2(x)
@@ -88,7 +88,7 @@ end
     val = f2(y)
     @test val == 2y + 1
     @test length(cache) == 2
-    @test cache[(y,)] == val
+    @test cache[(y,)][end] == val
     @test stats.misses == 2
 
     clear_cache!(f2)
@@ -110,9 +110,9 @@ end
     @test isequal(val, 2x + 1)
     cachestruct = associated_cache(fn)
     cache, stats = cachestruct.tlv[]
-    @test cache isa Dict{Tuple{Any}, Union{BasicSymbolic, Int}}
+    @test cache isa Dict{Tuple{Any}, Tuple{Any, Union{BasicSymbolic, Int}}}
     @test length(cache) == 1
-    @test cache[(SymbolicKey(objectid(x)),)] === val
+    @test cache[(SymbolicKey(objectid(x)),)][end] === val
     @test stats.hits == 0
     @test stats.misses == 1
     fn(x)

--- a/test/cache_macro.jl
+++ b/test/cache_macro.jl
@@ -100,27 +100,31 @@ end
     return 2x + 1
 end
 
-@testset "::Any" begin
+@cache function f3_2(x::Any)::Union{BasicSymbolic, Int}
+    return 2x + 1
+end
+
+@testset "$name" for (name, fn) in [("implicit ::Any", f3), ("explicit ::Any", f3_2)]
     @syms x
-    val = f3(x)
+    val = fn(x)
     @test isequal(val, 2x + 1)
-    cachestruct = associated_cache(f3)
+    cachestruct = associated_cache(fn)
     cache, stats = cachestruct.tlv[]
     @test cache isa Dict{Tuple{Any}, Union{BasicSymbolic, Int}}
     @test length(cache) == 1
     @test cache[(SymbolicKey(objectid(x)),)] === val
     @test stats.hits == 0
     @test stats.misses == 1
-    f3(x)
+    fn(x)
     @test stats.hits == 1
     @test stats.misses == 1
 
-    val = f3(3)
+    val = fn(3)
     @test val == 7
     @test length(cache) == 2
     @test stats.misses == 2
 
-    clear_cache!(f3)
+    clear_cache!(fn)
     @test length(cache) == 0
     @test stats.hits == stats.misses == stats.clears == 0
 end


### PR DESCRIPTION
Close https://github.com/JuliaSymbolics/Symbolics.jl/issues/1470
Close https://github.com/SciML/ModelingToolkit.jl/issues/3447