### PR TITLE
name CSE states in a reproducible way

### DIFF
--- a/src/code.jl
+++ b/src/code.jl
@@ -786,7 +786,8 @@ end
 
 CSEState() = CSEState(Union{Assignment, DestructuredArgs}[], IdDict(), Ref(1))
 
-Base.copy(x::CSEState) = CSEState(copy(x.sorted_exprs), copy(x.visited), Ref(x.varid[]))
+# the copy still references the same `varid` Ref to work in nested scopes
+Base.copy(x::CSEState) = CSEState(copy(x.sorted_exprs), copy(x.visited), x.varid)
 
 """
     $(TYPEDSIGNATURES)


### PR DESCRIPTION
The goals of this PR is make sure, that CSE variables are named in a reproducible way.
Otherwise, built functions are not considered egal which can lead to higher memory usage and hinders type stability in some contexts.
```julia
using Symbolics
@variables x, y, z
formulas = [x, x+y, x+y+z]
f1 = Symbolics.build_function(formulas, [x, y, z]; expression=false, cse=true)
f2 = Symbolics.build_function(formulas, [x, y, z]; expression=false, cse=true)
f1===f2
```