### PR TITLE
Refactor get_degrees() to make it faster

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -5,7 +5,7 @@ using Random
 
 SUITE = BenchmarkGroup()
 
-@syms a b c d; Random.seed!(123);
+@syms a b c d x y[1:3] z[1:2, 1:2]; Random.seed!(123);
 
 let r = @rule(~x => ~x), rs = RuleSet([r]),
     acr = @rule(~x::is_literal_number + ~y => ~y)
@@ -67,7 +67,19 @@ let r = @rule(~x => ~x), rs = RuleSet([r]),
         subs_expr = (sin(a+b) + cos(b+c)) * (sin(b+c) + cos(c+a)) * (sin(c+a) + cos(a+b))
     end
 
+    overhead["get_degrees"] = BenchmarkGroup()
 
+    let y1 = term(getindex, y, 1, type=Number),
+        y2 = term(getindex, y, 2, type=Number),
+        y3 = term(getindex, y, 3, type=Number),
+        z11 = term(getindex, z, 1, 1, type=Number),
+        z12 = term(getindex, z, 1, 2, type=Number),
+        z23 = term(getindex, z, 2, 3, type=Number),
+        # create a relatively large polynomial
+        large_poly = SymbolicUtils.expand((x^2 + 2y1 + 3z12 + y2*z23 + x*y1*z12 - x^2*z12 + x*z11 + y3 + y2 + z23 + 1)^8)
+
+        overhead["get_degrees"]["large_poly"] = @benchmarkable SymbolicUtils.get_degrees($large_poly)
+    end
 end
 
 let

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -74,10 +74,10 @@ let r = @rule(~x => ~x), rs = RuleSet([r]),
         y3 = term(getindex, y, 3, type=Number),
         z11 = term(getindex, z, 1, 1, type=Number),
         z12 = term(getindex, z, 1, 2, type=Number),
-        z23 = term(getindex, z, 2, 3, type=Number),
+        z23 = term(getindex, z, 2, 3, type=Number)
+
         # create a relatively large polynomial
         large_poly = SymbolicUtils.expand((x^2 + 2y1 + 3z12 + y2*z23 + x*y1*z12 - x^2*z12 + x*z11 + y3 + y2 + z23 + 1)^8)
-
         overhead["get_degrees"]["large_poly"] = @benchmarkable SymbolicUtils.get_degrees($large_poly)
     end
 end

--- a/src/ordering.jl
+++ b/src/ordering.jl
@@ -17,9 +17,17 @@
 """
 $(SIGNATURES)
 
-Internal function used for printing symbolic expressions. This function determines
-the degrees of symbols within a given expression, implementing a variation on 
-degree lexicographic order.
+Get the degrees of symbols within a given expression.
+
+This internal function is used to define the order of terms in a symbolic expression,
+which is a variation on degree lexicographic order. It is used for printing and
+by [`sorted_arguments`](@ref).
+
+Returns a tuple of degree and lexicographically sorted *multiplier* ⇒ *power* pairs,
+where the *multiplier* is a tuple of the symbol optionally followed by its indices.
+For a sum expression, returns the `get_degrees()` result for term with the highest degree.
+
+See also `monomial_lt` and `lexlt`.
 """
 function get_degrees(expr)
     if issym(expr)

--- a/src/ordering.jl
+++ b/src/ordering.jl
@@ -57,9 +57,9 @@ end
 function lexlt(degs1, degs2)
     for (a, b) in zip(degs1, degs2)
         if a[1] == b[1] && a[2] != b[2]
-            return a[2] > b[2]
+            return a[2] > b[2] # higher degree first
         elseif a[1] != b[1]
-            return a < b
+            return a[1] < b[1] # lexicographic order for the base
         end
     end
     return false # they are equal

--- a/src/ordering.jl
+++ b/src/ordering.jl
@@ -124,15 +124,20 @@ end
 function monomial_lt(degs1, degs2)
     d1 = sum(last, degs1, init=0)
     d2 = sum(last, degs2, init=0)
-    d1 != d2 ? d1 < d2 : lexlt(degs1, degs2)
+    d1 != d2 ?
+        # lower absolute degree first, or if equal, positive degree first
+        (abs(d1) < abs(d2) || abs(d1) == abs(d2) && d1 > d2) :
+        lexlt(degs1, degs2)
 end
 
 function lexlt(degs1, degs2)
-    for (a, b) in zip(degs1, degs2)
-        if a[1] == b[1] && a[2] != b[2]
-            return a[2] > b[2] # higher degree first
-        elseif a[1] != b[1]
-            return a[1] < b[1] # lexicographic order for the base
+    for ((a_base, a_deg), (b_base, b_deg)) in zip(degs1, degs2)
+        if a_base == b_base && a_deg != b_deg
+            # same base, higher absolute degree first, positive degree first
+            return abs(a_deg) > abs(b_deg) || abs(a_deg) == abs(b_deg) && a_deg > b_deg
+        elseif a_base != b_base
+            # lexicographic order for the base
+            return a_base < b_base
         end
     end
     return false # they are equal

--- a/src/ordering.jl
+++ b/src/ordering.jl
@@ -36,10 +36,10 @@ function get_degrees(expr)
                              (x,y)->(x...,y...,), args)
         elseif op == (+)
             ds = map(get_degrees, args)
-            _, idx = findmax(x->sum(last.(x), init=0), ds)
+            _, idx = findmax(x->sum(last, x, init=0), ds)
             return ds[idx]
         elseif op == (getindex)
-            return ((Symbol.(args)...,) => 1,)
+            return (Tuple(map(Symbol, args)) => 1,)
         else
             return ((Symbol("zzzzzzz", hash(expr)),) => 1,)
         end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -222,7 +222,11 @@ end
     @test repr(a + b3 + b1 + d2 + c) == "a + b[1] + b[3] + c + d[2]"
     @test repr(expand((c + b3 - d1)^3)) == "b[3]^3 + 3(b[3]^2)*c - 3(b[3]^2)*d[1] + 3b[3]*(c^2) - 6b[3]*c*d[1] + 3b[3]*(d[1]^2) + c^3 - 3(c^2)*d[1] + 3c*(d[1]^2) - (d[1]^3)"
     # test negative powers sorting
-    @test repr((b3^2)^(-2) + a^(-3) + (c*d1)^(-2)) == "1 / (b[3]^4) + 1 / ((c^2)*(d[1]^2)) + 1 / (a^3)"
+    @test repr((b3^2)^(-2) + a^(-3) + (c*d1)^(-2)) == "1 / (a^3) + 1 / (b[3]^4) + 1 / ((c^2)*(d[1]^2))"
+
+    # test that the "x^2 + y^-1 + sin(a)^3.5 + 2t + 1//1" expression from Symbolics.jl/build_targets.jl is properly sorted
+    @syms x1 y1 a1 t1
+    @test repr(x1^2 + y1^-1 + sin(a1)^3.5 + 2t1 + 1//1) == "(1//1) + 2t1 + 1 / y1 + x1^2 + sin(a1)^3.5"
 end
 
 @testset "inspect" begin

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -221,6 +221,8 @@ end
     b1, b3, d1, d2 = get(b,1),get(b,3), get(d,1), get(d,2)
     @test repr(a + b3 + b1 + d2 + c) == "a + b[1] + b[3] + c + d[2]"
     @test repr(expand((c + b3 - d1)^3)) == "b[3]^3 + 3(b[3]^2)*c - 3(b[3]^2)*d[1] + 3b[3]*(c^2) - 6b[3]*c*d[1] + 3b[3]*(d[1]^2) + c^3 - 3(c^2)*d[1] + 3c*(d[1]^2) - (d[1]^3)"
+    # test negative powers sorting
+    @test repr((b3^2)^(-2) + a^(-3) + (c*d1)^(-2)) == "1 / (b[3]^4) + 1 / ((c^2)*(d[1]^2)) + 1 / (a^3)"
 end
 
 @testset "inspect" begin


### PR DESCRIPTION
Profiling indicated that in my use case (symbolic multiplication of several large sparse matrices takes almost 1h) a lot of time is spent in `get_degrees()`.

So this PR is my attempt to make it faster and use less memory:
  * some trivial fixes to avoid broadcasting
  * extract operator handling into separate routines (`get_degrees(op, expr)`) instead of `if op == + .. elseif op == * end`.
    That increases memory footprint by 10%, but also makes it faster by 10% (I guess type inference is improved).
  * avoid calling `sorted_arguments()` within `get_degrees()`, as that itself calls `get_degrees()`, so `get_degrees()` gets called multiple times for the same expression.
    Instead, `get_degrees()` uses `arguments()` and sorts the list of degrees itself.
  * Cache the `get_degrees(getindex, expr)`: that increases the speed and 2x reduces memory footprint (in the test example below)

On the test case I observe 3x speed-up and 3x reduction in memory footprint.

The benchmark script
```julia
using SymbolicUtils, BenchmarkTools

@syms x y[1:3] z[1:2, 1:2]
# Create a complex polynomial expression
y1 = term(getindex, y, 1, type=Number)
y2 = term(getindex, y, 2, type=Number)
y3 = term(getindex, y, 3, type=Number)
z11 = term(getindex, z, 1, 1, type=Number)
z12 = term(getindex, z, 1, 2, type=Number)
z23 = term(getindex, z, 2, 3, type=Number)
large_poly = SymbolicUtils.expand((x^2 + 2y1 + 3z12 + y2*z23 + x*y1*z12 - x^2*z12 + x*z11 + y3 + y2 + z23 + 1)^8);

b = @benchmark SymbolicUtils.get_degrees($large_poly) samples=50 evals=1
```

Results on a *master* (Julia 1.11.4):
```
BenchmarkTools.Trial: 16 samples with 1 evaluation per sample.
 Range (min … max):  298.827 ms … 359.108 ms  ┊ GC (min … max): 0.00% … 12.83%
 Time  (median):     311.555 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   319.948 ms ±  19.761 ms  ┊ GC (mean ± σ):  4.18% ±  5.27%

      █                                   ▁                      
  ▆▆▁▆█▁▁▆▁▁▁▁▁▁▁▁▁▁▆▁▁▁▁▁▁▁▁▁▁▁▁▁▆▁▆▁▁▁▆▁█▁▁▁▁▆▁▁▁▁▁▁▁▁▁▁▁▁▁▁▆ ▁
  299 ms           Histogram: frequency by time          359 ms <

 Memory estimate: 116.91 MiB, allocs estimate: 3390531.

BenchmarkTools.Trial: 16 samples with 1 evaluation per sample.
 Range (min … max):  299.432 ms … 360.751 ms  ┊ GC (min … max): 0.00% … 13.12%
 Time  (median):     318.398 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   320.586 ms ±  19.074 ms  ┊ GC (mean ± σ):  4.72% ±  5.29%

  ▃   ▃█                                                         
  █▁▁▇██▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▇▇▇▇▁▇▇▇▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▇ ▁
  299 ms           Histogram: frequency by time          361 ms <

 Memory estimate: 116.91 MiB, allocs estimate: 3390531.
```

Results for this PR:
```
BenchmarkTools.Trial: 43 samples with 1 evaluation per sample.
 Range (min … max):  107.692 ms … 156.781 ms  ┊ GC (min … max): 0.00% … 22.67%
 Time  (median):     109.903 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   116.491 ms ±  11.735 ms  ┊ GC (mean ± σ):  3.87% ±  6.74%

  █▁                                                             
  ██▃▁▁▃▁▃▃▁▄▁▃▁▁▁▆▄▁▄▃▁▁▃▁▁▁▁▁▃▁▃▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▁▃ ▁
  108 ms           Histogram: frequency by time          157 ms <

 Memory estimate: 43.92 MiB, allocs estimate: 1448421.

BenchmarkTools.Trial: 43 samples with 1 evaluation per sample.
 Range (min … max):  107.790 ms … 146.127 ms  ┊ GC (min … max): 0.00% … 23.08%
 Time  (median):     111.730 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   116.886 ms ±  10.678 ms  ┊ GC (mean ± σ):  3.84% ±  6.82%

  █                                                              
  ██▆▃▁▁▃▁▃▁▃▁▁▃▃▁▁▁▁▁▃▄▃▇▁▆▁▁▁▃▁▁▁▁▁▁▁▁▁▁▁▃▁▁▁▁▁▃▁▁▁▃▁▁▁▁▁▃▁▁▃ ▁
  108 ms           Histogram: frequency by time          146 ms <

 Memory estimate: 43.92 MiB, allocs estimate: 1448421.
```