### PR TITLE
multiply by a rational instead of dividing by an integer

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -669,7 +669,7 @@ function Div{T}(n, d, simplified=false; metadata=nothing, kwargs...) where {T}
     end
 
     d isa Number && _isone(-d) && return -1 * n
-    n isa Rat && d isa Rat && return n // d # maybe called by oblivious code in simplify
+    !(n isa AbstractFloat) && d isa Rat && return n * (1 // d) # maybe called by oblivious code in simplify
 
     # GCD coefficient upon construction
     rat, nc = ratcoeff(n)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -368,6 +368,8 @@ end
     @test (2x/3y).num.coeff == 2
     @test (2x/3y).den.coeff == 3
     @test (2x/-3x) == -2//3
+    @test isequal((2x*y/-3x), -2y/3)
+    @test isequal((x*y/2x), y/2)
     @test (2.5x/3x).num == 2.5
     @test (2.5x/3x).den == 3
     @test (x/3x) == 1//3


### PR DESCRIPTION
Dividing symbolics by an integer returns a multiplication by a rational. This fix makes sure that it is handled the same when creating a Div.

This fixes issue #736.