### PR TITLE
[WIP] first prototype of default value rules implemented

### DIFF
--- a/src/matchers.jl
+++ b/src/matchers.jl
@@ -5,25 +5,51 @@
 # 2. Dictionary
 # 3. Callback: takes arguments Dictionary × Number of elements matched
 #
+
 function matcher(val::Any)
-    iscall(val) && return term_matcher(val)
+    # if val is a call (like an operation) creates a term matcher or term matcher with defslot
+    if iscall(val)
+        # if has two arguments and one of them is a DefSlot, create a term matcher with defslot
+        if length(arguments(val)) == 2 && any(x -> isa(x, DefSlot), arguments(val))
+            return term_matcher_defslot(val)
+        # else return a normal term matcher
+        else
+            return term_matcher(val)
+        end
+    end
+
     function literal_matcher(next, data, bindings)
+        # car data is the first element of data
         islist(data) && isequal(car(data), val) ? next(bindings, 1) : nothing
     end
 end
 
 function matcher(slot::Slot)
     function slot_matcher(next, data, bindings)
-        !islist(data) && return
+        !islist(data) && return nothing
         val = get(bindings, slot.name, nothing)
+        # if slot name already is in bindings, check if it matches
         if val !== nothing
             if isequal(val, car(data))
                 return next(bindings, 1)
             end
-        else
-            if slot.predicate(car(data))
-                next(assoc(bindings, slot.name, car(data)), 1)
+        # elseif the first element of data matches the slot predicate, add it to bindings and call next
+        elseif slot.predicate(car(data))
+            next(assoc(bindings, slot.name, car(data)), 1)
+        end
+    end
+end
+
+function matcher(defslot::DefSlot)
+    function defslot_matcher(next, data, bindings)
+        !islist(data) && return
+        val = get(bindings, defslot.name, nothing)
+        if val !== nothing
+            if isequal(val, car(data))
+                return next(bindings, 1)
             end
+        elseif defslot.predicate(car(data))
+            next(assoc(bindings, defslot.name, car(data)), 1)
         end
     end
 end
@@ -86,10 +112,52 @@ end
 
 function term_matcher(term)
     matchers = (matcher(operation(term)), map(matcher, arguments(term))...,)
-    function term_matcher(success, data, bindings)
 
-        !islist(data) && return nothing
-        !iscall(car(data)) && return nothing
+    function term_matcher(success, data, bindings)
+        !islist(data) && return nothing # if data is not a list, return nothing
+        !iscall(car(data)) && return nothing # if first element is not a call, return nothing
+
+        function loop(term, bindings′, matchers′) # Get it to compile faster
+            if !islist(matchers′)
+                if  !islist(term)
+                    return success(bindings′, 1)
+                end
+                return nothing
+            end
+            car(matchers′)(term, bindings′) do b, n
+                loop(drop_n(term, n), b, cdr(matchers′))
+            end
+            # explenation of above 3 lines:
+            # car(matchers′)(b,n -> loop(drop_n(term, n), b, cdr(matchers′)), term, bindings′)
+            #                ------- next(b,n) -----------------------------
+            # car = first element of list, cdr = rest of the list, drop_n = drop first n elements of list
+            # Calls the first matcher, with the "next" function being loop again but with n terms dropepd from term
+            # Term is a linked list (a list and a index). drop n advances the index. when the index sorpasses
+            # the length of the list, is considered empty
+        end
+
+        loop(car(data), bindings, matchers) # Try to eat exactly one term
+    end
+end
+
+
+# ~x + ~!y
+function term_matcher_defslot(term)
+    matchers = (matcher(operation(term)), map(matcher, arguments(term))...) # create matchers for the operation and arguments of the term
+
+    function term_matcher(success, data, bindings)
+        
+        !islist(data) && return nothing # if data is not a list, return nothing
+        if !iscall(car(data))
+            a = arguments(term)
+            slot = a[findfirst(x -> isa(x, Slot), a)] # find the first slot in the term
+            defslot = a[findfirst(x -> isa(x, DefSlot), a)] # find the first defslot in the term
+
+            bindings = assoc(bindings, slot.name, car(data))
+            bindings = assoc(bindings, defslot.name, defslot.default)
+
+            return success(bindings, 1) # if first element is not a call, return success with bindings and 1
+        end
 
         function loop(term, bindings′, matchers′) # Get it to compile faster
             if !islist(matchers′)

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -16,6 +16,71 @@ Base.isequal(s1::Slot, s2::Slot) = s1.name == s2.name
 
 Base.show(io::IO, s::Slot) = (print(io, "~"); print(io, s.name))
 
+# for when the slot is a symbol, like `~x`
+makeslot(s::Symbol, keys) = (push!(keys, s); Slot(s))
+
+# for when the slot is an expression, like `~x::predicate`
+function makeslot(s::Expr, keys)
+    if !(s.head == :(::))
+        error("Syntax for specifying a slot is ~x::\$predicate, where predicate is a boolean function")
+    end
+
+    name = s.args[1]
+
+    push!(keys, name)
+    :(Slot($(QuoteNode(name)), $(esc(s.args[2]))))
+end
+
+# matches one term with built in default value.
+# syntax: ~!x
+# Example usage:
+# (~!x + ~y) can match (a + b) but also just "a" and x takes default value of zero.
+# (~!x)*(~y) can match a*b but also just "a", and x takes default value of one.
+# (~x + ~y)^(~!z) can match (a + b)^c but also just "a + b", and z takes default value of one.
+# only these three operations are supported for default values.
+# Note that the default value is not used in the consequent, it is only used to match the pattern.
+
+struct DefSlot{P, D}
+    name::Symbol
+    predicate::P
+    default::D
+end
+
+DefSlot(s) = DefSlot(s, alwaystrue, nothing)
+Base.isequal(s1::DefSlot, s2::DefSlot) = s1.name == s2.name
+Base.show(io::IO, s::DefSlot) = (print(io, "~!"); print(io, s.name))
+
+makeDefSlot(s::Symbol, keys, default) = (push!(keys, s); DefSlot(s, alwaystrue, default))
+
+function makeDefSlot(s::Expr, keys, default)
+    if !(s.head == :(::))
+        error("Syntax for specifying a default slot is ~!x::\$predicate, where predicate is a boolean function")
+    end
+
+    name = s.args[1]
+
+    push!(keys, name)
+    :(DefSlot($(QuoteNode(name)), $(esc(s.args[2])), $(esc(default))))
+end
+
+# parent | default
+# + | 0
+# * | 1
+# ^ | 1
+function defaultValOfCall(call)
+    if call == :+
+        return 0
+    elseif call == :*
+        return 1
+    elseif call == :^
+        return 1
+    end
+
+    return nothing # no default value for this call
+end
+
+
+
 # matches zero or more terms
 # syntax: ~~x
 struct Segment{F}
@@ -37,37 +102,29 @@ function makesegment(s::Expr, keys)
     end
 
     name = s.args[1]
-
+    
     push!(keys, name)
     :(Segment($(QuoteNode(name)), $(esc(s.args[2]))))
 end
 
-makeslot(s::Symbol, keys) = (push!(keys, s); Slot(s))
-
-function makeslot(s::Expr, keys)
-    if !(s.head == :(::))
-        error("Syntax for specifying a slot is ~x::\$predicate, where predicate is a boolean function")
-    end
-
-    name = s.args[1]
-
-    push!(keys, name)
-    :(Slot($(QuoteNode(name)), $(esc(s.args[2]))))
-end
-
-function makepattern(expr, keys)
+# parent call is needed to know which default value to give if any default slots are present
+function makepattern(expr, keys, parentCall=nothing)
     if expr isa Expr
         if expr.head === :call
             if expr.args[1] === :(~)
                 if expr.args[2] isa Expr && expr.args[2].args[1] == :(~)
                     # matches ~~x::predicate
                     makesegment(expr.args[2].args[2], keys)
+                elseif expr.args[2] isa Expr && expr.args[2].args[1] == :(!)
+                    # matches ~!x::predicate
+                    makeDefSlot(expr.args[2].args[2], keys, defaultValOfCall(parentCall))
                 else
                     # matches ~x::predicate
                     makeslot(expr.args[2], keys)
                 end
             else
-                :(term($(map(x->makepattern(x, keys), expr.args)...); type=Any))
+                # make a pattern for every argument of the expr.
+                :(term($(map(x->makepattern(x, keys, operation(expr)), expr.args)...); type=Any))
             end
         elseif expr.head === :ref
             :(term(getindex, $(map(x->makepattern(x, keys), expr.args)...); type=Any))

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -47,6 +47,20 @@ end
     @eqtest @rule(+(~~x,~y,~~x) => (~~x, ~y, ~~x))(term(+,6,type=Any)) == ([], 6, [])
 end
 
+@testset "Slot matcher with default value" begin
+    r_sum = @rule (~x + ~!y)^2 => ~y
+    @test r_sum((a + b)^2) === b
+    @test r_sum(b^2) === 0
+
+    r_mult = @rule (~x * ~!y + ~z) => ~y
+    @test r_mult(c + a*b) === b
+    @test r_mult(c + b) === 1
+
+    r_pow = @rule (~x + ~y)^(~!m) => ~m
+    @test r_pow((a + b)^2) === 2
+    @test r_pow(a + b) === 1
+end
+
 using SymbolicUtils: @capture
 
 @testset "Capture form" begin


### PR DESCRIPTION
Reading Mathematica pattern matching documantation ([here](https://reference.wolfram.com/language/tutorial/Patterns.html)) I saw they have a **pattern matching with slots that can take a default value**. In Mathematica a generic pattern named "a" is written a_  (in julia symbolics ~a ). But then if I write a_.  it matches a pattern with built in default value, so basically (a_. + b_*x_)  can match 2x where "a" takes the default value of 0 (and b=2 of course). or another example (a_ + b_*x_)^m_.  can match (1 + 2x) where m takes the default value of 1 (and a=1 b=2 of course), whereas the pattern  (a_ + b_*x_)^m_  would not match (1 + 2x) because the exponent m needs to be there and cannot take a default value.

This feature is needed for my gsoc project of implementing a rule based integrator in julia symbolics.

Now I implemented this default value for sum and multiplication.
I choose the syntax of this new slot to be `~!x`, so for example:
```
r_mult = @rule (~x * ~!y + ~z) => ~y
r_mult(c + a*b) # returns b
r_mult(c + b) # returns 1
```
whereas
```
r_mult_old = @rule (~x * ~y + ~z) => ~y
r_mult_old(c + a*b) # returns b
r_mult_old(c + b) # returns nothing because it did not match
```