### PR TITLE
[WIP] Negative exponent matching

### DIFF
--- a/src/matchers.jl
+++ b/src/matchers.jl
@@ -156,7 +156,7 @@ function defslot_term_matcher_constructor(term)
         # if data is not a list, return nothing
         !islist(data) && return nothing
         # if data (is not a tree and is just a symbol) or (is a tree not starting with the default operation)
-        if !iscall(car(data)) || (istree(car(data)) && nameof(operation(car(data))) != defslot.operation)
+        if !iscall(car(data)) || (iscall(car(data)) && nameof(operation(car(data))) != defslot.operation)
             other_part_matcher = matchers[defslot_index==2 ? 2 : 3] # find the matcher of the normal part
             
             # checks wether it matches the normal part

--- a/src/matchers.jl
+++ b/src/matchers.jl
@@ -156,7 +156,7 @@ function defslot_term_matcher_constructor(term)
         # if data is not a list, return nothing
         !islist(data) && return nothing
         # if data (is not a tree and is just a symbol) or (is a tree not starting with the default operation)
-        if !iscall(car(data)) || (istree(car(data)) && string(defslot.operation) != string(operation(car(data))))
+        if !iscall(car(data)) || (istree(car(data)) && nameof(operation(car(data))) != defslot.operation)
             other_part_matcher = matchers[defslot_index==2 ? 2 : 3] # find the matcher of the normal part
             
             # checks wether it matches the normal part

--- a/src/matchers.jl
+++ b/src/matchers.jl
@@ -5,25 +5,51 @@
 # 2. Dictionary
 # 3. Callback: takes arguments Dictionary × Number of elements matched
 #
+
 function matcher(val::Any)
-    iscall(val) && return term_matcher(val)
+    # if val is a call (like an operation) creates a term matcher or term matcher with defslot
+    if iscall(val)
+        # if has two arguments and one of them is a DefSlot, create a term matcher with defslot
+        if length(arguments(val)) == 2 && any(x -> isa(x, DefSlot), arguments(val))
+            return term_matcher_defslot(val)
+        # else return a normal term matcher
+        else
+            return term_matcher(val)
+        end
+    end
+
     function literal_matcher(next, data, bindings)
+        # car data is the first element of data
         islist(data) && isequal(car(data), val) ? next(bindings, 1) : nothing
     end
 end
 
 function matcher(slot::Slot)
     function slot_matcher(next, data, bindings)
-        !islist(data) && return
+        !islist(data) && return nothing
         val = get(bindings, slot.name, nothing)
+        # if slot name already is in bindings, check if it matches
         if val !== nothing
             if isequal(val, car(data))
                 return next(bindings, 1)
             end
-        else
-            if slot.predicate(car(data))
-                next(assoc(bindings, slot.name, car(data)), 1)
+        # elseif the first element of data matches the slot predicate, add it to bindings and call next
+        elseif slot.predicate(car(data))
+            next(assoc(bindings, slot.name, car(data)), 1)
+        end
+    end
+end
+
+function matcher(defslot::DefSlot)
+    function defslot_matcher(next, data, bindings)
+        !islist(data) && return
+        val = get(bindings, defslot.name, nothing)
+        if val !== nothing
+            if isequal(val, car(data))
+                return next(bindings, 1)
             end
+        elseif defslot.predicate(car(data))
+            next(assoc(bindings, defslot.name, car(data)), 1)
         end
     end
 end
@@ -86,10 +112,52 @@ end
 
 function term_matcher(term)
     matchers = (matcher(operation(term)), map(matcher, arguments(term))...,)
-    function term_matcher(success, data, bindings)
 
-        !islist(data) && return nothing
-        !iscall(car(data)) && return nothing
+    function term_matcher(success, data, bindings)
+        !islist(data) && return nothing # if data is not a list, return nothing
+        !iscall(car(data)) && return nothing # if first element is not a call, return nothing
+
+        function loop(term, bindings′, matchers′) # Get it to compile faster
+            if !islist(matchers′)
+                if  !islist(term)
+                    return success(bindings′, 1)
+                end
+                return nothing
+            end
+            car(matchers′)(term, bindings′) do b, n
+                loop(drop_n(term, n), b, cdr(matchers′))
+            end
+            # explenation of above 3 lines:
+            # car(matchers′)(b,n -> loop(drop_n(term, n), b, cdr(matchers′)), term, bindings′)
+            #                ------- next(b,n) -----------------------------
+            # car = first element of list, cdr = rest of the list, drop_n = drop first n elements of list
+            # Calls the first matcher, with the "next" function being loop again but with n terms dropepd from term
+            # Term is a linked list (a list and a index). drop n advances the index. when the index sorpasses
+            # the length of the list, is considered empty
+        end
+
+        loop(car(data), bindings, matchers) # Try to eat exactly one term
+    end
+end
+
+
+# ~x + ~!y
+function term_matcher_defslot(term)
+    matchers = (matcher(operation(term)), map(matcher, arguments(term))...) # create matchers for the operation and arguments of the term
+
+    function term_matcher(success, data, bindings)
+        
+        !islist(data) && return nothing # if data is not a list, return nothing
+        if !iscall(car(data))
+            a = arguments(term)
+            slot = a[findfirst(x -> isa(x, Slot), a)] # find the first slot in the term
+            defslot = a[findfirst(x -> isa(x, DefSlot), a)] # find the first defslot in the term
+
+            bindings = assoc(bindings, slot.name, car(data))
+            bindings = assoc(bindings, defslot.name, defslot.default)
+
+            return success(bindings, 1) # if first element is not a call, return success with bindings and 1
+        end
 
         function loop(term, bindings′, matchers′) # Get it to compile faster
             if !islist(matchers′)

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -64,7 +64,7 @@ function defaultValOfCall(call)
         return 1
     end
     # else no default value for this call
-    return nothing
+    error("You can use default slots only with +, * and ^, but you tried with: $call")
 end
 
 DefSlot(s) = DefSlot(s, alwaystrue, nothing, 0)

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -16,6 +16,71 @@ Base.isequal(s1::Slot, s2::Slot) = s1.name == s2.name
 
 Base.show(io::IO, s::Slot) = (print(io, "~"); print(io, s.name))
 
+# for when the slot is a symbol, like `~x`
+makeslot(s::Symbol, keys) = (push!(keys, s); Slot(s))
+
+# for when the slot is an expression, like `~x::predicate`
+function makeslot(s::Expr, keys)
+    if !(s.head == :(::))
+        error("Syntax for specifying a slot is ~x::\$predicate, where predicate is a boolean function")
+    end
+
+    name = s.args[1]
+
+    push!(keys, name)
+    :(Slot($(QuoteNode(name)), $(esc(s.args[2]))))
+end
+
+# matches one term with built in default value.
+# syntax: ~!x
+# Example usage:
+# (~!x + ~y) can match (a + b) but also just "a" and x takes default value of zero.
+# (~!x)*(~y) can match a*b but also just "a", and x takes default value of one.
+# (~x + ~y)^(~!z) can match (a + b)^c but also just "a + b", and z takes default value of one.
+# only these three operations are supported for default values.
+# Note that the default value is not used in the consequent, it is only used to match the pattern.
+
+struct DefSlot{P, D}
+    name::Symbol
+    predicate::P
+    default::D
+end
+
+DefSlot(s) = DefSlot(s, alwaystrue, nothing)
+Base.isequal(s1::DefSlot, s2::DefSlot) = s1.name == s2.name
+Base.show(io::IO, s::DefSlot) = (print(io, "~!"); print(io, s.name))
+
+makeDefSlot(s::Symbol, keys, default) = (push!(keys, s); DefSlot(s, alwaystrue, default))
+
+function makeDefSlot(s::Expr, keys, default)
+    if !(s.head == :(::))
+        error("Syntax for specifying a default slot is ~!x::\$predicate, where predicate is a boolean function")
+    end
+
+    name = s.args[1]
+
+    push!(keys, name)
+    :(DefSlot($(QuoteNode(name)), $(esc(s.args[2])), $(esc(default))))
+end
+
+# parent | default
+# + | 0
+# * | 1
+# ^ | 1
+function defaultValOfCall(call)
+    if call == :+
+        return 0
+    elseif call == :*
+        return 1
+    elseif call == :^
+        return 1
+    end
+
+    return nothing # no default value for this call
+end
+
+
+
 # matches zero or more terms
 # syntax: ~~x
 struct Segment{F}
@@ -37,37 +102,29 @@ function makesegment(s::Expr, keys)
     end
 
     name = s.args[1]
-
+    
     push!(keys, name)
     :(Segment($(QuoteNode(name)), $(esc(s.args[2]))))
 end
 
-makeslot(s::Symbol, keys) = (push!(keys, s); Slot(s))
-
-function makeslot(s::Expr, keys)
-    if !(s.head == :(::))
-        error("Syntax for specifying a slot is ~x::\$predicate, where predicate is a boolean function")
-    end
-
-    name = s.args[1]
-
-    push!(keys, name)
-    :(Slot($(QuoteNode(name)), $(esc(s.args[2]))))
-end
-
-function makepattern(expr, keys)
+# parent call is needed to know which default value to give if any default slots are present
+function makepattern(expr, keys, parentCall=nothing)
     if expr isa Expr
         if expr.head === :call
             if expr.args[1] === :(~)
                 if expr.args[2] isa Expr && expr.args[2].args[1] == :(~)
                     # matches ~~x::predicate
                     makesegment(expr.args[2].args[2], keys)
+                elseif expr.args[2] isa Expr && expr.args[2].args[1] == :(!)
+                    # matches ~!x::predicate
+                    makeDefSlot(expr.args[2].args[2], keys, defaultValOfCall(parentCall))
                 else
                     # matches ~x::predicate
                     makeslot(expr.args[2], keys)
                 end
             else
-                :(term($(map(x->makepattern(x, keys), expr.args)...); type=Any))
+                # make a pattern for every argument of the expr.
+                :(term($(map(x->makepattern(x, keys, operation(expr)), expr.args)...); type=Any))
             end
         elseif expr.head === :ref
             :(term(getindex, $(map(x->makepattern(x, keys), expr.args)...); type=Any))

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -91,6 +91,12 @@ end
     r2 = @rule (~x)^(~y + ~z) => (~x, ~y, ~z) # rule with term as exponent
     @test r2(1/a^(b+2c)) === (a, -b, -2c) # uses frankestein
     @test r2(1/a^3) === nothing # should use a term_matcher that flips the sign, but is not implemented
+
+    r1defslot = @rule (~x)^(~!y) => (~x, ~y) # rule with slot as exponent
+    @test r1defslot(1/a^b) === (a, -b) # uses frankestein
+    @test r1defslot(1/a^(b+2c)) === (a, -b-2c) # uses frankestein
+    @test r1defslot(1/a^2) === (a, -2) # uses opposite_sign_matcher
+    @test r1defslot(a) === (a, 1)
 end
 
 using SymbolicUtils: @capture

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -77,9 +77,20 @@ end
     @test r_pow2(a+b) === 1
 
     r_mix = @rule (~x + (~y)*(~!c))^(~!m) => ~m + ~c
-    @test r_mix((a + b*c)^2) === 2 + c
-    @test r_mix((a + b*c)) === 1 + c
-    @test r_mix((a + b)) === 2 #1+1
+    @test r_mix((a + b*c)^2) === (2, c)
+    @test r_mix((a + b*c)) === (1, c)
+    @test r_mix((a + b)) === (1, 1)
+end
+
+@testset "1/power matches power with exponent of opposite sign" begin
+    r1 = @rule (~x)^(~y) => (~x, ~y) # rule with slot as exponent
+    @test r1(1/a^b) === (a, -b) # uses frankestein
+    @test r1(1/a^(b+2c)) === (a, -b-2c) # uses frankestein
+    @test r1(1/a^2) === (a, -2) # uses opposite_sign_matcher
+
+    r2 = @rule (~x)^(~y + ~z) => (~x, ~y, ~z) # rule with term as exponent
+    @test r2(1/a^(b+2c)) === (a, -b, -2c) # uses frankestein
+    @test r2(1/a^3) === nothing # should use a term_matcher that flips the sign, but is not implemented
 end
 
 using SymbolicUtils: @capture

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -47,6 +47,20 @@ end
     @eqtest @rule(+(~~x,~y,~~x) => (~~x, ~y, ~~x))(term(+,6,type=Any)) == ([], 6, [])
 end
 
+@testset "Slot matcher with default value" begin
+    r_sum = @rule (~x + ~!y)^2 => ~y
+    @test r_sum((a + b)^2) === b
+    @test r_sum(b^2) === 0
+
+    r_mult = @rule (~x * ~!y + ~z) => ~y
+    @test r_mult(c + a*b) === b
+    @test r_mult(c + b) === 1
+
+    r_pow = @rule (~x + ~y)^(~!m) => ~m
+    @test r_pow((a + b)^2) === 2
+    @test r_pow(a + b) === 1
+end
+
 using SymbolicUtils: @capture
 
 @testset "Capture form" begin

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -52,13 +52,34 @@ end
     @test r_sum((a + b)^2) === b
     @test r_sum(b^2) === 0
 
-    r_mult = @rule (~x * ~!y + ~z) => ~y
-    @test r_mult(c + a*b) === b
-    @test r_mult(c + b) === 1
+    r_mult = @rule ~x * ~!y  => ~y
+    @test r_mult(a * b) === b
+    @test r_mult(a) === 1
 
-    r_pow = @rule (~x + ~y)^(~!m) => ~m
-    @test r_pow((a + b)^2) === 2
-    @test r_pow(a + b) === 1
+    r_mult2 = @rule (~x * ~!y + ~z) => ~y
+    @test r_mult2(c + a*b) === b
+    @test r_mult2(c + b) === 1
+
+    # here the "normal part" in the defslot_term_matcher is not a symbol but a tree
+    r_mult3 = @rule (~!x)*(~y + ~z) => ~x
+    @test r_mult3(a*(c+2)) === a
+    @test r_mult3(2*(c+2)) === 2
+    @test r_mult3(c+2) === 1
+    
+    r_pow = @rule (~x)^(~!m) => ~m
+    @test r_pow(a^(b+1)) === b+1
+    @test r_pow(a) === 1
+    @test r_pow(a+1) === 1
+
+    # here the "normal part" in the defslot_term_matcher is not a symbol but a tree
+    r_pow2 = @rule (~x + ~y)^(~!m) => ~m
+    @test r_pow2((a+b)^c) === c
+    @test r_pow2(a+b) === 1
+
+    r_mix = @rule (~x + (~y)*(~!c))^(~!m) => ~m + ~c
+    @test r_mix((a + b*c)^d) === c + d
+    @test r_mix((a + b*c)) === 1 + c
+    @test r_mix((a + b)) === 2 #1+1
 end
 
 using SymbolicUtils: @capture

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -77,7 +77,7 @@ end
     @test r_pow2(a+b) === 1
 
     r_mix = @rule (~x + (~y)*(~!c))^(~!m) => ~m + ~c
-    @test r_mix((a + b*c)^d) === c + d
+    @test r_mix((a + b*c)^2) === 2 + c
     @test r_mix((a + b*c)) === 1 + c
     @test r_mix((a + b)) === 2 #1+1
 end


### PR DESCRIPTION
This pr builds on top of the defslot feature i added in another pr. The aim is for rule `@rule (~x)^(~m) => ..something..` to match 1 / (x^2) with m=-2.

I did that by modifying the `term_matcher` and `defslot_term_matcher` functions, they are functions called when the rule gets applied, and they have to check wheter a certain term (the pattern to match in the ruel, like in this example `(~x)^(~m)`) matches with certain data (1/(x^2) in this example). I did basically the same modification to the two of them. They work by using a loop function called recursively, that uses some matcher functions (1) that assign the values to their label. The modification di did in `term_matcher` is:
- call the loop function recursively like normal.
- If still you dont have a match, and if the operation of the term is a power, and if data is in the form 1 over a power, like 1/a^b, then:
- - if the exponent of the power b is not a number (but a symbol or expression), call the loop function with a^-b
- - if b is a number, this cannot be done bc x^-3 gets [automatically transformed](https://github.com/JuliaSymbolics/SymbolicUtils.jl/blob/a95aea2310ea12f1ee2d9b2850d062ec82a437c4/src/types.jl#L1535-L1550) into 1 / (x^3). So I cant call loop with a^-b, i have to call it with a^b, so I had to create a new matcher function (1) that assigns the opposite value of data to the label.

in `defslot_term_matcher` i did a similar thing, and if after all this still doesnt find a match, also tries to match with the default value of defslot

I find it a bit messy