### PR TITLE
[WIP] Commutative operations and negative exponent match in rules

### DIFF
--- a/docs/src/manual/rewrite.md
+++ b/docs/src/manual/rewrite.md
@@ -180,13 +180,13 @@ It works. This can be further simplified using Pythagorean identity and check it
 ```jldoctest rewriteex
 pyid = @rule sin(~x)^2 + cos(~x)^2 => 1
 
-pyid(cos(x)^2 + sin(x)^2) === nothing
+pyid(sin(x)^2 + 2sin(x)*cos(x) + cos(x)^2)===nothing
 
 # output
 true
 ```
 
-Why does it return `nothing`? If we look at the rule, we see that the order of `sin(x)` and `cos(x)` is different. Therefore, in order to work, the rule needs to be associative-commutative.
+Why does it return `nothing`? If we look at the expression, we see that we have an additional addend `+ 2sin(x)*cos(x)`. Therefore, in order to work, the rule needs to be associative-commutative.
 
 ```jldoctest rewriteex
 acpyid = @acrule sin(~x)^2 + cos(~x)^2 => 1

--- a/src/SymbolicUtils.jl
+++ b/src/SymbolicUtils.jl
@@ -54,7 +54,7 @@ export Rewriters
 # A library for composing together expr -> expr functions
 
 using Combinatorics: permutations, combinations
-export @rule, @acrule, RuleSet
+export @rule, @acrule, @smrule, RuleSet
 
 # Rule type and @rule macro
 include("rule.jl")

--- a/src/SymbolicUtils.jl
+++ b/src/SymbolicUtils.jl
@@ -54,7 +54,7 @@ export Rewriters
 # A library for composing together expr -> expr functions
 
 using Combinatorics: permutations, combinations
-export @rule, @acrule, @smrule, RuleSet
+export @rule, @acrule, RuleSet
 
 # Rule type and @rule macro
 include("rule.jl")

--- a/src/matchers.jl
+++ b/src/matchers.jl
@@ -150,6 +150,15 @@ function term_matcher_constructor(term, acSets)
                 result = loop(frankestein, bindings, matchers)
                 result !== nothing && return success(result, 1)
             end
+
+            # if data is of the alternative form 1/(...), it might match with exponent = -1
+            if (operation(data) === /) && isequal(arguments(data)[1], 1)
+                denominator = arguments(data)[2]
+                T = symtype(denominator)
+                frankestein = Term{T}(^, [denominator, -1])
+                result = loop(frankestein, bindings, matchers)
+                result !== nothing && return success(result, 1)
+            end
             
             # if data is a exp call, it might match with base e
             if operation(data)===exp

--- a/src/matchers.jl
+++ b/src/matchers.jl
@@ -152,6 +152,7 @@ function term_matcher_constructor(term, acSets)
         function commutative_term_matcher(success, data, bindings)
             !islist(data) && return nothing # if data is not a list, return nothing
             !iscall(car(data)) && return nothing # if first element is not a call, return nothing
+            operation(term) !== operation(car(data)) && return nothing # if the operation of data is not the correct one, don't even try
             
             T = symtype(car(data))
             f = operation(car(data))

--- a/src/matchers.jl
+++ b/src/matchers.jl
@@ -133,9 +133,6 @@ function term_matcher_constructor(term, acSets)
             data = car(data) # from (..., ) to ...
             !iscall(data) && return nothing # if first element is not a call, return nothing
             
-            result = loop(data, bindings, matchers)
-            result !== nothing && return success(result, 1)
-            
             # if data is of the alternative form (1/...)^(...), it might match with negative exponent
             if (operation(data) === ^) && iscall(arguments(data)[1]) && (operation(arguments(data)[1]) === /) && isequal(arguments(arguments(data)[1])[1], 1)
                 one_over_smth = arguments(data)[1]
@@ -144,6 +141,10 @@ function term_matcher_constructor(term, acSets)
                 result = loop(frankestein, bindings, matchers)
                 result !== nothing && return success(result, 1)
             end
+
+            result = loop(data, bindings, matchers)
+            result !== nothing && return success(result, 1)
+            
             # if data is of the alternative form 1/(...)^(...), it might match with negative exponent
             if (operation(data) === /) && isequal(arguments(data)[1], 1) && iscall(arguments(data)[2]) && (operation(arguments(data)[2]) === ^)
                 denominator = arguments(data)[2]

--- a/src/matchers.jl
+++ b/src/matchers.jl
@@ -153,6 +153,23 @@ function term_matcher_constructor(term, acSets)
                 result = loop(frankestein, bindings, matchers)
                 result !== nothing && return success(result, 1)
             end
+            
+            # if data is a exp call, it might match with base e
+            if operation(data)===exp
+                T = symtype(arguments(data)[1])
+                frankestein = Term{T}(^,[ℯ,arguments(data)[1]])
+                result = loop(frankestein, bindings, matchers)
+                result !== nothing && return success(result, 1)
+            end
+
+            # if data is a sqrt call, it might match with exponent 1//2
+            if operation(data)===sqrt
+                T = symtype(arguments(data)[1])
+                frankestein = Term{T}(^,[arguments(data)[1], 1//2])
+                result = loop(frankestein, bindings, matchers)
+                result !== nothing && return success(result, 1)
+            end
+
             return nothing
         end
         return pow_term_matcher

--- a/src/matchers.jl
+++ b/src/matchers.jl
@@ -13,10 +13,9 @@ function matcher(val::Any)
         # just two arguments bc defslot is only supported with operations with two args: *, ^, +
         if length(arguments(val)) == 2 && any(x -> isa(x, DefSlot), arguments(val))
             return defslot_term_matcher_constructor(val)
-        # else return a normal term matcher
-        else
-            return term_matcher_constructor(val)
         end
+        # else return a normal term matcher
+        return term_matcher_constructor(val)
     end
 
     function literal_matcher(next, data, bindings)
@@ -232,6 +231,7 @@ function defslot_term_matcher_constructor(term)
     normal_matcher = term_matcher_constructor(term)
 
     function defslot_term_matcher(success, data, bindings)
+        !islist(data) && return nothing # if data is not a list, return nothing
         result = normal_matcher(success, data, bindings)
         result !== nothing && return result
         # if no match, try to match with a defslot

--- a/src/matchers.jl
+++ b/src/matchers.jl
@@ -200,12 +200,14 @@ function defslot_term_matcher_constructor(term, acSets)
 
     function defslot_term_matcher(success, data, bindings)
         !islist(data) && return nothing # if data is not a list, return nothing
-        result = normal_matcher(success, data, bindings)
-        result !== nothing && return result
+        # call the normal mathcer, with succes function foo1 that simply returns the bindings
+        #                       <--foo1-->
+        result = normal_matcher((b,n) -> b, data, bindings)
+        result !== nothing && return success(result, 1)
         # if no match, try to match with a defslot.
-        # checks whether it matches the normal part if yes executes (foo)
-        # (foo): adds the pair (default value name, default value) to the found bindings
-        #                           <------------------(foo)---------------------------->
+        # checks whether it matches the normal part if yes executes foo2
+        # foo2: adds the pair (default value name, default value) to the found bindings
+        #                           <-------------------foo2---------------------------->
         result = other_part_matcher((b,n) -> assoc(b, defslot.name, defslot.defaultValue), data, bindings)
         result !== nothing && return success(result, 1)
         nothing

--- a/src/matchers.jl
+++ b/src/matchers.jl
@@ -184,7 +184,7 @@ function term_matcher_constructor(term, acSets)
                 
                 for inds in acSets(eachindex(data_args), length(data_args))
                     candidate = Term{T}(f, @views data_args[inds])
-                    
+
                     result = loop(candidate, bindings, matchers)                
                     result !== nothing && return success(result,1)
                 end

--- a/src/matchers.jl
+++ b/src/matchers.jl
@@ -13,9 +13,6 @@ function matcher(val::Any)
         # just two arguments bc defslot is only supported with operations with two args: *, ^, +
         if length(arguments(val)) == 2 && any(x -> isa(x, DefSlot), arguments(val))
             return defslot_term_matcher_constructor(val)
-        # else (a)^(b) can also match 1/( (a)^(b) ) , just with b of oppsite sign
-        elseif operation(val) == ^
-            return neg_pow_term_matcher_constructor(val)
         # else return a normal term matcher
         else
             return term_matcher_constructor(val)
@@ -56,6 +53,10 @@ function opposite_sign_matcher(slot::Slot)
             next(assoc(bindings, slot.name, -car(data)), 1) # this - is the only differenct wrt matcher(slot::Slot)
         end
     end
+end
+
+function opposite_sign_matcher(defslot::DefSlot)
+    opposite_sign_matcher(Slot(defslot.name, defslot.predicate))
 end
 
 # this is called only when defslot_term_matcher finds the operation and tries
@@ -147,48 +148,27 @@ function term_matcher_constructor(term)
             # the length of the list, is considered empty
         end
 
-        loop(car(data), bindings, matchers) # Try to eat exactly one term
-    end
-end
-
-# (a)^(b) can also match 1/( (a)^(b) ) , just with b of oppsite sign
-function neg_pow_term_matcher_constructor(term)
-    matchers = (matcher(operation(term)), map(matcher, arguments(term))...,)
-
-    function neg_pow_term_matcher(success, data, bindings)
-        !islist(data) && return nothing # if data is not a list, return nothing
-        !iscall(car(data)) && return nothing # if first element is not a call, return nothing
-
-        function loop(term, bindings′, matchers′)
-            if !islist(matchers′)
-                if  !islist(term)
-                    return success(bindings′, 1)
-                end
-                return nothing
-            end
-            car(matchers′)(term, bindings′) do b, n
-                loop(drop_n(term, n), b, cdr(matchers′))
-            end
-        end
-
         result = loop(car(data), bindings, matchers)
-        # if data is of the form 1/(...)^(...), it might match with negative exponent
-        if result === nothing && (operation(car(data))==/) && arguments(car(data))[1]==1 && iscall(arguments(car(data))[2]) && (operation(arguments(car(data))[2])==^)
-            denominator = arguments(car(data))[2]
-            # let's say data = a^b with a and b can be whatever
-            # if b is not a number then call the loop function with a^-b
-            if !isa(arguments(denominator)[2], Number)
-                frankestein = arguments(denominator)[1] ^ -(arguments(denominator)[2])
-                result = loop(frankestein, bindings, matchers)
-            else
-                # if b is a number, like 3, we cant call loop with a^-3 bc it
-                # will automatically transform into 1/a^3. Therfore we need to
-                # create a matcher that flips the sign of the exponent. I created
-                # this matecher just for `Slot`s and not for terms, because if b
-                # is a number and not a call, certainly doesn't match a term (I hope).
-                if isa(arguments(term)[2], Slot)
-                    matchers2 = (matcher(operation(term)), matcher(arguments(term)[1]), opposite_sign_matcher(arguments(term)[2])) # is this ok to be here or should it be outside neg_pow_term_matcher?
-                    result = loop(denominator, bindings, matchers2)
+        # if data is of the alternative form 1/(...)^(...), it might match with negative exponent
+        if operation(term)==^
+            alternative_form = (operation(car(data))==/) && arguments(car(data))[1]==1 && iscall(arguments(car(data))[2]) && (operation(arguments(car(data))[2])==^)
+            if result === nothing && alternative_form
+                denominator = arguments(car(data))[2]
+                # let's say data = a^b with a and b can be whatever
+                # if b is not a number then call the loop function with a^-b
+                if !isa(arguments(denominator)[2], Number)
+                    frankestein = arguments(denominator)[1] ^ -(arguments(denominator)[2])
+                    result = loop(frankestein, bindings, matchers)
+                else
+                    # if b is a number, like 3, we cant call loop with a^-3 bc it
+                    # will automatically transform into 1/a^3. Therfore we need to
+                    # create a matcher that flips the sign of the exponent. I created
+                    # this matecher just for `Slot`s and not for terms, because if b
+                    # is a number and not a call, certainly doesn't match a term (I hope).
+                    if isa(arguments(term)[2], Slot)
+                        matchers2 = (matcher(operation(term)), matcher(arguments(term)[1]), opposite_sign_matcher(arguments(term)[2])) # is this ok to be here or should it be outside neg_pow_term_matcher?
+                        result = loop(denominator, bindings, matchers2)
+                    end
                 end
             end
         end
@@ -205,7 +185,7 @@ end
 #     if yes (1): continues like term_matcher
 #     if no checks whether data matches the normal part
 #          if no returns nothing, rule is not applied
-#          if yes (2): adds the pair (default value name, default value) to the found bindings and 
+#          if yes (3): adds the pair (default value name, default value) to the found bindings and 
 #          calls the success function like term_matcher would do
 
 function defslot_term_matcher_constructor(term)
@@ -218,8 +198,53 @@ function defslot_term_matcher_constructor(term)
     function defslot_term_matcher(success, data, bindings)
         # if data is not a list, return nothing
         !islist(data) && return nothing
+        result = nothing
+        if iscall(car(data))
+            # (1)
+            function loop(term, bindings′, matchers′) # Get it to compile faster
+                if !islist(matchers′)
+                    if  !islist(term)
+                        return success(bindings′, 1)
+                    end
+                    return nothing
+                end
+                car(matchers′)(term, bindings′) do b, n
+                    loop(drop_n(term, n), b, cdr(matchers′))
+                end
+            end
+
+            result = loop(car(data), bindings, matchers) # Try to eat exactly one term
+            # if data is of the alternative form 1/(...)^(...), it might match with negative exponent
+            if operation(term)==^
+                alternative_form = (operation(car(data))==/) && arguments(car(data))[1]==1 && iscall(arguments(car(data))[2]) && (operation(arguments(car(data))[2])==^)
+                if result === nothing && alternative_form
+                    denominator = arguments(car(data))[2]
+                    # let's say data = a^b with a and b can be whatever
+                    # if b is not a number then call the loop function with a^-b
+                    if !isa(arguments(denominator)[2], Number)
+                        frankestein = arguments(denominator)[1] ^ -(arguments(denominator)[2])
+                        result = loop(frankestein, bindings, matchers)
+                    else
+                        # if b is a number, like 3, we cant call loop with a^-3 bc it
+                        # will automatically transform into 1/a^3. Therfore we need to
+                        # create a matcher that flips the sign of the exponent. I created
+                        # this matecher just for `DefSlot`s and not for terms, because if b
+                        # is a number and not a call, certainly doesn't match a term (I hope).
+                        if isa(arguments(term)[2], DefSlot)
+                            matchers2 = (matcher(operation(term)), matcher(arguments(term)[1]), opposite_sign_matcher(arguments(term)[2])) # is this ok to be here or should it be outside neg_pow_term_matcher?
+                            result = loop(denominator, bindings, matchers2)
+                        end
+                    end
+                end
+            end
+            # (2)
+            if result !== nothing
+                return result
+            end
+        end
+        
         # if data (is not a tree and is just a symbol) or (is a tree not starting with the default operation)
-        if !iscall(car(data)) || (iscall(car(data)) && nameof(operation(car(data))) != defslot.operation)
+        if ( !iscall(car(data)) || (iscall(car(data)) && nameof(operation(car(data))) != defslot.operation) )
             other_part_matcher = matchers[defslot_index==2 ? 2 : 3] # find the matcher of the normal part
             
             # checks whether it matches the normal part
@@ -229,22 +254,8 @@ function defslot_term_matcher_constructor(term)
             if bindings === nothing
                 return nothing
             end
-            return success(bindings, 1)
+            result = success(bindings, 1)
         end
-
-        # (1)
-        function loop(term, bindings′, matchers′) # Get it to compile faster
-            if !islist(matchers′)
-                if  !islist(term)
-                    return success(bindings′, 1)
-                end
-                return nothing
-            end
-            car(matchers′)(term, bindings′) do b, n
-                loop(drop_n(term, n), b, cdr(matchers′))
-            end
-        end
-
-        loop(car(data), bindings, matchers) # Try to eat exactly one term
+        result
     end
 end

--- a/src/matchers.jl
+++ b/src/matchers.jl
@@ -41,6 +41,16 @@ function matcher(slot::Slot)
     end
 end
 
+# this is called only when defslot_term_matcher finds the operation and tries
+# to match it, so no default value used. So the same function as slot_matcher
+# can be used
+function matcher(defslot::DefSlot)
+    matcher(Slot(defslot.name, defslot.predicate))
+end
+
+# function opposite_sign_matcher(val::Any)
+# end
+
 function opposite_sign_matcher(slot::Slot)
     function slot_matcher(next, data, bindings)
         !islist(data) && return nothing
@@ -57,13 +67,6 @@ end
 
 function opposite_sign_matcher(defslot::DefSlot)
     opposite_sign_matcher(Slot(defslot.name, defslot.predicate))
-end
-
-# this is called only when defslot_term_matcher finds the operation and tries
-# to match it, so no default value used. So the same function as slot_matcher
-# can be used
-function matcher(defslot::DefSlot)
-    matcher(Slot(defslot.name, defslot.predicate))
 end
 
 # returns n == offset, 0 if failed
@@ -124,138 +127,121 @@ end
 
 function term_matcher_constructor(term)
     matchers = (matcher(operation(term)), map(matcher, arguments(term))...,)
-
-    function term_matcher(success, data, bindings)
-        !islist(data) && return nothing # if data is not a list, return nothing
-        !iscall(car(data)) && return nothing # if first element is not a call, return nothing
-
-        function loop(term, bindings′, matchers′) # Get it to compile faster
-            if !islist(matchers′)
-                if  !islist(term)
-                    return success(bindings′, 1)
-                end
-                return nothing
+    
+    function loop(term, bindings′, matchers′) # Get it to compile faster
+        if !islist(matchers′)
+            if  !islist(term)
+                return bindings′
             end
-            car(matchers′)(term, bindings′) do b, n
-                loop(drop_n(term, n), b, cdr(matchers′))
-            end
-            # explanation of above 3 lines:
-            # car(matchers′)(b,n -> loop(drop_n(term, n), b, cdr(matchers′)), term, bindings′)
-            #                <------ next(b,n) ---------------------------->
-            # car = first element of list, cdr = rest of the list, drop_n = drop first n elements of list
-            # Calls the first matcher, with the "next" function being loop again but with n terms dropepd from term
-            # Term is a linked list (a list and a index). drop n advances the index. when the index sorpasses
-            # the length of the list, is considered empty
+            return nothing
         end
+        car(matchers′)(term, bindings′) do b, n
+            loop(drop_n(term, n), b, cdr(matchers′))
+        end
+        # explenation of above 3 lines:
+        # car(matchers′)(b,n -> loop(drop_n(term, n), b, cdr(matchers′)), term, bindings′)
+        #                <------ next(b,n) ---------------------------->
+        # car = first element of list, cdr = rest of the list, drop_n = drop first n elements of list
+        # Calls the first matcher, with the "next" function being loop again but with n terms dropepd from term
+        # Term is a linked list (a list and a index). drop n advances the index. when the index sorpasses
+        # the length of the list, is considered empty
+    end
 
-        result = loop(car(data), bindings, matchers)
-        # if data is of the alternative form 1/(...)^(...), it might match with negative exponent
-        if operation(term)==^
-            alternative_form = (operation(car(data))==/) && arguments(car(data))[1]==1 && iscall(arguments(car(data))[2]) && (operation(arguments(car(data))[2])==^)
-            if result === nothing && alternative_form
+    # if the operation is a pow, we have to match also 1/(...)^(...) with negative exponent
+    if operation(term)==^
+        # the below 4 lines could stay in the function term_matcher_pow, but 
+        # are here to speed up the rule matcher function
+        cond = isa(arguments(term)[2], Slot) || isa(arguments(term)[2], DefSlot)
+        if cond
+            matchers_modified = (matcher(operation(term)), matcher(arguments(term)[1]), opposite_sign_matcher(arguments(term)[2])) # is this ok to be here or should it be outside neg_pow_term_matcher?
+        end
+        
+        function term_matcher_pow(success, data, bindings)
+            !islist(data) && return nothing # if data is not a list, return nothing
+            !iscall(car(data)) && return nothing # if first element is not a call, return nothing
+            
+            result = loop(car(data), bindings, matchers)
+            result !== nothing && return success(result, 1)
+            
+            # if data is of the alternative form 1/(...)^(...), it might match with negative exponent
+            if (operation(car(data))==/) && arguments(car(data))[1]==1 && iscall(arguments(car(data))[2]) && (operation(arguments(car(data))[2])==^)
                 denominator = arguments(car(data))[2]
                 # let's say data = a^b with a and b can be whatever
                 # if b is not a number then call the loop function with a^-b
                 if !isa(arguments(denominator)[2], Number)
                     frankestein = arguments(denominator)[1] ^ -(arguments(denominator)[2])
                     result = loop(frankestein, bindings, matchers)
-                else
-                    # if b is a number, like 3, we cant call loop with a^-3 bc it
-                    # will automatically transform into 1/a^3. Therfore we need to
-                    # create a matcher that flips the sign of the exponent. I created
-                    # this matecher just for `Slot`s and not for terms, because if b
-                    # is a number and not a call, certainly doesn't match a term (I hope).
-                    if isa(arguments(term)[2], Slot)
-                        matchers2 = (matcher(operation(term)), matcher(arguments(term)[1]), opposite_sign_matcher(arguments(term)[2])) # is this ok to be here or should it be outside neg_pow_term_matcher?
-                        result = loop(denominator, bindings, matchers2)
-                    end
+                # if b is a number, like 3, we cant call loop with a^-3 bc it
+                # will automatically transform into 1/a^3. Therfore we need to
+                # create a matcher that flips the sign of the exponent. I created
+                # this matecher just for `Slot`s and `DefSlot`s, but not for 
+                # terms or literals,  because if b is a number and not a call,
+                # certainly doesn't match a term (I hope).
+                # Also not a literal because...?
+                elseif cond
+                    result = loop(denominator, bindings, matchers_modified)
                 end
             end
+            if result !== nothing
+                return success(result, 1)
+            end        
         end
-        result
+        return term_matcher_pow
+    # if the operation is commutative
+    elseif operation(term) in [+, *]
+        all_matchers = []
+        args = arguments(term)
+        for inds in permutations(eachindex(args), length(args))
+            reord = @views args[inds]
+            push!(all_matchers, (matcher(operation(term)), map(matcher, reord)...,))
+        end
+
+        function term_matcher_comm(success, data, bindings)
+            !islist(data) && return nothing # if data is not a list, return nothing
+            !iscall(car(data)) && return nothing # if first element is not a call, return nothing
+            
+            for m in all_matchers
+                result = loop(car(data), bindings, m)
+                result !== nothing && return success(result, 1)
+            end
+        end
+        return term_matcher_comm
+    else
+        function term_matcher(success, data, bindings)
+            !islist(data) && return nothing # if data is not a list, return nothing
+            !iscall(car(data)) && return nothing # if first element is not a call, return nothing
+            
+            result = loop(car(data), bindings, matchers)
+            if result !== nothing
+                return success(result, 1)
+            end
+        end
+        return term_matcher
     end
 end
 
 # creates a matcher for a term containing a defslot, such as:
 # (~x + ...complicated pattern...)     *          ~!y
 #    normal part (can bee a tree)   operation     defslot part
-
-# defslot_term_matcher works like this:
-# checks whether data starts with the default operation.
-#     if yes (1): continues like term_matcher
-#     if no checks whether data matches the normal part
-#          if no returns nothing, rule is not applied
-#          if yes (3): adds the pair (default value name, default value) to the found bindings and 
-#          calls the success function like term_matcher would do
-
 function defslot_term_matcher_constructor(term)
-    a = arguments(term) # length two bc defslot term matcher is allowed only with +,* and ^, that accept two arguments
-    matchers = (matcher(operation(term)), map(matcher, a)...) # create matchers for the operation and the two arguments of the term
-    
+    a = arguments(term) # lenght two bc defslot term matcher is allowed only with +,* and ^ that accept two arguments
     defslot_index = findfirst(x -> isa(x, DefSlot), a) # find the defslot in the term
     defslot = a[defslot_index]
+    other_part_matcher = matcher(defslot_index==1 ? a[2] : a[1]) # find the matcher of the normal part
     
-    function defslot_term_matcher(success, data, bindings)
-        # if data is not a list, return nothing
-        !islist(data) && return nothing
-        result = nothing
-        if iscall(car(data))
-            # (1)
-            function loop(term, bindings′, matchers′) # Get it to compile faster
-                if !islist(matchers′)
-                    if  !islist(term)
-                        return success(bindings′, 1)
-                    end
-                    return nothing
-                end
-                car(matchers′)(term, bindings′) do b, n
-                    loop(drop_n(term, n), b, cdr(matchers′))
-                end
-            end
+    normal_matcher = term_matcher_constructor(term)
 
-            result = loop(car(data), bindings, matchers) # Try to eat exactly one term
-            # if data is of the alternative form 1/(...)^(...), it might match with negative exponent
-            if operation(term)==^
-                alternative_form = (operation(car(data))==/) && arguments(car(data))[1]==1 && iscall(arguments(car(data))[2]) && (operation(arguments(car(data))[2])==^)
-                if result === nothing && alternative_form
-                    denominator = arguments(car(data))[2]
-                    # let's say data = a^b with a and b can be whatever
-                    # if b is not a number then call the loop function with a^-b
-                    if !isa(arguments(denominator)[2], Number)
-                        frankestein = arguments(denominator)[1] ^ -(arguments(denominator)[2])
-                        result = loop(frankestein, bindings, matchers)
-                    else
-                        # if b is a number, like 3, we cant call loop with a^-3 bc it
-                        # will automatically transform into 1/a^3. Therfore we need to
-                        # create a matcher that flips the sign of the exponent. I created
-                        # this matecher just for `DefSlot`s and not for terms, because if b
-                        # is a number and not a call, certainly doesn't match a term (I hope).
-                        if isa(arguments(term)[2], DefSlot)
-                            matchers2 = (matcher(operation(term)), matcher(arguments(term)[1]), opposite_sign_matcher(arguments(term)[2])) # is this ok to be here or should it be outside neg_pow_term_matcher?
-                            result = loop(denominator, bindings, matchers2)
-                        end
-                    end
-                end
-            end
-            # (2)
-            if result !== nothing
-                return result
-            end
-        end
-        
+    function defslot_term_matcher(success, data, bindings)
+        result = normal_matcher(success, data, bindings)
+        result !== nothing && return result
+        # if no match, try to match with a defslot
         # if data (is not a tree and is just a symbol) or (is a tree not starting with the default operation)
-        if ( !iscall(car(data)) || (iscall(car(data)) && nameof(operation(car(data))) != defslot.operation) )
-            other_part_matcher = matchers[defslot_index==2 ? 2 : 3] # find the matcher of the normal part
-            
-            # checks whether it matches the normal part
-            #                             <-----------------(2)------------------------------->
-            bindings = other_part_matcher((b,n) -> assoc(b, defslot.name, defslot.defaultValue), data, bindings)
-            
-            if bindings === nothing
-                return nothing
-            end
-            result = success(bindings, 1)
+        if ( !iscall(car(data)) || (iscall(car(data)) && nameof(operation(car(data))) != defslot.operation) )            
+            # checks wether it matches the normal part if yes executes (foo)
+            # (foo): adds the pair (default value name, default value) to the found bindings
+            #                           <------------------(foo)---------------------------->
+            result = other_part_matcher((b,n) -> assoc(b, defslot.name, defslot.defaultValue), data, bindings)
+            result !== nothing && return success(result, 1)
         end
-        result
     end
 end

--- a/src/matchers.jl
+++ b/src/matchers.jl
@@ -281,8 +281,8 @@ function defslot_term_matcher_constructor(term, acSets)
         # if no match, try to match with a defslot.
         # checks whether it matches the normal part if yes executes foo2
         # foo2: adds the pair (default value name, default value) to the found bindings
-        #       after checking predicate and presence in the bindings. If added succesfully
-        #       returns the bindings (foo3), otherwise return nothing
+        #       after checking predicate and presence in the bindings. If added 
+        #       successfully returns the bindings (foo3), otherwise return nothing
         #                           <-------------------foo2----------------------------------->
         #                                                  <-foo3->
         result = other_part_matcher((b,n)->defslot_matcher((b,n)->b, (defslot.defaultValue,), b), data, bindings)

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -130,6 +130,9 @@ function makepattern(expr, keys, parentCall=nothing)
                     # matches ~x::predicate
                     makeslot(expr.args[2], keys)
                 end
+            elseif expr.args[1] === :(//)
+                # bc when the expression is not quoted, 3//2 is a Rational{Int64}, not a call
+                return esc(expr.args[2] // expr.args[3])
             else
                 # make a pattern for every argument of the expr.
                 :(term($(map(x->makepattern(x, keys, operation(expr)), expr.args)...); type=Any))

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -82,7 +82,7 @@ function makeDefSlot(s::Expr, keys, op)
 
     push!(keys, name)
     tmp = defaultValOfCall(op)
-    :(DefSlot($(QuoteNode(name)), $(esc(s.args[2])), $(esc(op))), $(esc(tmp)))
+    :(DefSlot($(QuoteNode(name)), $(esc(s.args[2])), $(esc(op)), $(esc(tmp))))
 end
 
 

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -396,28 +396,10 @@ macro rule(expr)
     quote
         $(__source__)
         lhs_pattern = $(lhs_term)
-        Rule($(QuoteNode(expr)),
-             lhs_pattern,
-             matcher(lhs_pattern),
-             __MATCHES__ -> $(makeconsequent(rhs)),
-             rule_depth($lhs_term))
-    end
-end
-
-macro smrule(expr)
-    @assert expr.head == :call && expr.args[1] == :(=>)
-    lhs = expr.args[2]
-    rhs = rewrite_rhs(expr.args[3])
-    keys = Symbol[]
-    lhs_term = makepattern(lhs, keys)
-    unique!(keys)
-    quote
-        $(__source__)
-        lhs_pattern = $(lhs_term)
         Rule(
             $(QuoteNode(expr)),
             lhs_pattern,
-            matcher(lhs_pattern; acSets = permutations),
+            matcher(lhs_pattern, permutations),
             __MATCHES__ -> $(makeconsequent(rhs)),
             rule_depth($lhs_term)
         )
@@ -455,7 +437,7 @@ macro capture(ex, lhs)
         lhs_pattern = $(lhs_term)
         __MATCHES__ = Rule($(QuoteNode(lhs)),
              lhs_pattern,
-             matcher(lhs_pattern),
+             matcher(lhs_pattern, nothing),
              identity,
              rule_depth($lhs_term))($(esc(ex)))
         if __MATCHES__ !== nothing
@@ -523,7 +505,7 @@ macro acrule(expr)
         lhs_pattern = $(lhs_term)
         rule = Rule($(QuoteNode(expr)),
              lhs_pattern,
-             matcher(lhs_pattern; acSets = permutations),
+             matcher(lhs_pattern, permutations),
              __MATCHES__ -> $(makeconsequent(rhs)),
              rule_depth($lhs_term))
         ACRule(permutations, rule, $arity)
@@ -545,7 +527,7 @@ macro ordered_acrule(expr)
         lhs_pattern = $(lhs_term)
         rule = Rule($(QuoteNode(expr)),
              lhs_pattern,
-             matcher(lhs_pattern; acSets = combinations),
+             matcher(lhs_pattern, combinations),
              __MATCHES__ -> $(makeconsequent(rhs)),
              rule_depth($lhs_term))
         ACRule(combinations, rule, $arity)

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -240,10 +240,11 @@ it if it matches the LHS pattern to the RHS pattern, returns `nothing` otherwise
 The rule language is described below.
 
 LHS can be any possibly nested function call expression where any of the arguments can
-optionally be a Slot (`~x`) or a Segment (`~~x`) (described below).
+optionally be a Slot (`~x`), Default Value Slot (`~!x` also called DefSlot) or a Segment
+ (`~~x`) (described below).
 
-If an expression matches LHS entirely, then it is rewritten to the pattern in the RHS
-Segment (`~x`) and slot variables (`~~x`) on the RHS will substitute the result of the
+If an expression matches LHS entirely, then it is rewritten to the pattern in the RHS.
+Slot, DefSlot and Segment variables on the RHS will substitute the result of the
 matches found for these variables in the LHS.
 
 If the RHS is a single tilde `~`, then the rule returns a a dictionary of
@@ -305,6 +306,41 @@ julia> r(sin(2a)^2 + cos(2a)^2)
 julia> r(sin(2a)^2 + cos(a)^2)
 # nothing
 ```
+
+**DefSlot**:
+
+A DefSlot variable is written as `~!x`. Works like a normal slot, but can also take additional values if not present in the expression.
+
+_Example in power:_
+```julia
+julia> r_pow = @rule (~x)^(~!m) => ~m
+(~x) ^ ~(!m) => ~m
+
+julia> r_pow(x^2)
+2
+
+julia> r_pow(x)
+1
+```
+
+_Example in sum:_
+```julia
+julia> r_sum = @rule ~x + ~!y => ~y
+~x + ~(!y) => ~y
+
+julia> r_sum(x+2)
+x
+
+julia> r_sum(x)
+0
+```
+
+Currently DefSlot is implemented in:
+Operation | Default value
+----------|--------------
+* | 1
++ | 0
+2nd argument of ^ | 1
 
 **Segment**:
 

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -404,6 +404,26 @@ macro rule(expr)
     end
 end
 
+macro smrule(expr)
+    @assert expr.head == :call && expr.args[1] == :(=>)
+    lhs = expr.args[2]
+    rhs = rewrite_rhs(expr.args[3])
+    keys = Symbol[]
+    lhs_term = makepattern(lhs, keys)
+    unique!(keys)
+    quote
+        $(__source__)
+        lhs_pattern = $(lhs_term)
+        Rule(
+            $(QuoteNode(expr)),
+            lhs_pattern,
+            matcher(lhs_pattern; acSets = permutations),
+            __MATCHES__ -> $(makeconsequent(rhs)),
+            rule_depth($lhs_term)
+        )
+    end
+end
+
 """
     @capture ex pattern
 

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -486,16 +486,46 @@ julia> r(y + x)
 See also: [`@rule`](@ref), [`@ordered_acrule`](@ref)
 """
 macro acrule(expr)
-    arity = length(expr.args[2].args[2:end])
+    @assert expr.head == :call && expr.args[1] == :(=>)
+    lhs = expr.args[2]
+    rhs = rewrite_rhs(expr.args[3])
+    keys = Symbol[]
+    lhs_term = makepattern(lhs, keys)
+    unique!(keys)
+
+    arity = length(lhs.args[2:end])
+
     quote
-        ACRule(permutations, $(esc(:(@rule($(expr))))), $arity)
+        $(__source__)
+        lhs_pattern = $(lhs_term)
+        rule = Rule($(QuoteNode(expr)),
+             lhs_pattern,
+             matcher(lhs_pattern; acSets = permutations),
+             __MATCHES__ -> $(makeconsequent(rhs)),
+             rule_depth($lhs_term))
+        ACRule(permutations, rule, $arity)
     end
 end
 
 macro ordered_acrule(expr)
-    arity = length(expr.args[2].args[2:end])
+    @assert expr.head == :call && expr.args[1] == :(=>)
+    lhs = expr.args[2]
+    rhs = rewrite_rhs(expr.args[3])
+    keys = Symbol[]
+    lhs_term = makepattern(lhs, keys)
+    unique!(keys)
+
+    arity = length(lhs.args[2:end])
+
     quote
-        ACRule(combinations, $(esc(:(@rule($(expr))))), $arity)
+        $(__source__)
+        lhs_pattern = $(lhs_term)
+        rule = Rule($(QuoteNode(expr)),
+             lhs_pattern,
+             matcher(lhs_pattern; acSets = combinations),
+             __MATCHES__ -> $(makeconsequent(rhs)),
+             rule_depth($lhs_term))
+        ACRule(combinations, rule, $arity)
     end
 end
 
@@ -503,15 +533,11 @@ Base.show(io::IO, acr::ACRule) = print(io, "ACRule(", acr.rule, ")")
 
 function (acr::ACRule)(term)
     r = Rule(acr)
-    if !iscall(term)
+    if !iscall(term) || operation(term) != operation(r.lhs)
+        # different operations -> try deflsot
         r(term)
     else
-        f =  operation(term)
-        # Assume that the matcher was formed by closing over a term
-        if f != operation(r.lhs) # Maybe offer a fallback if m.term errors. 
-            return nothing
-        end
-
+        f = operation(term)
         T = symtype(term)
         args = arguments(term)
 

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -48,17 +48,21 @@ end
 end
 
 @testset "Commutative + and *" begin
-    r1 = @rule sin(~x) + cos(~x) => ~x
-    @test r1(sin(a)+cos(a)) === a
-    @test r1(sin(x)+cos(x)) === x
-    r2 = @rule (~x+~y)*(~z+~w)^(~m) => (~x, ~y, ~z, ~w, ~m)
-    r3 = @rule (~z+~w)^(~m)*(~x+~y) => (~x, ~y, ~z, ~w, ~m)
+    r1 = @acrule exp(sin(~x) + cos(~x)) => ~x
+    @test r1(exp(sin(a)+cos(a))) === a
+    @test r1(exp(sin(x)+cos(x))) === x
+    r2 = @acrule (~x+~y)*(~z+~w)^(~m) => (~x, ~y, ~z, ~w, ~m)
+    r3 = @acrule (~z+~w)^(~m)*(~x+~y) => (~x, ~y, ~z, ~w, ~m)
     @test r2((a+b)*(x+c)^b) === (a, b, x, c, b)
     @test r3((a+b)*(x+c)^b) === (a, b, x, c, b)
-    rPredicate1 = @rule ~x::(x->isa(x,Number)) + ~y => (~x, ~y)
-    rPredicate2 = @rule ~y + ~x::(x->isa(x,Number)) => (~x, ~y)
+    rPredicate1 = @acrule ~x::(x->isa(x,Number)) + ~y => (~x, ~y)
+    rPredicate2 = @acrule ~y + ~x::(x->isa(x,Number)) => (~x, ~y)
     @test rPredicate1(2+x) === (2, x)
     @test rPredicate2(2+x) === (2, x)
+    r5 = @acrule (~y*(~z+~w))+~x => (~x, ~y, ~z, ~w)
+    r6 = @acrule ~x+((~z+~w)*~y) => (~x, ~y, ~z, ~w)
+    @test r5(c*(a+b)+d) === (d, c, a, b)
+    @test r6(c*(a+b)+d) === (d, c, a, b)
 end
 
 @testset "Slot matcher with default value" begin

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -121,6 +121,7 @@ end
     @test r1(1/a^b) === (a, -b) # uses frankestein
     @test r1(1/a^(b+2c)) === (a, -b-2c) # uses frankestein
     @test r1(1/a^2) === (a, -2) # uses opposite_sign_matcher
+    @test r1(1/a) === (a, -1)
 
     r2 = @rule (~x)^(~y + ~z) => (~x, ~y, ~z) # rule with term as exponent
     @test r2(1/a^(b+2c)) === (a, -b, -2c) # uses frankestein

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -2,7 +2,7 @@ using SymbolicUtils
 
 include("utils.jl")
 
-@syms a b c
+@syms a b c x
 
 @testset "Equality" begin
     @eqtest a == a
@@ -45,6 +45,20 @@ end
     @eqtest @rule(+(~~x,~y, ~~x) => (~~x, ~y))(term(+,9,8,9,type=Any)) == ([9,],8)
     @eqtest @rule(+(~~x,~y, ~~x) => (~~x, ~y, ~~x))(term(+,9,8,9,9,8,type=Any)) == ([9,8], 9, [9,8])
     @eqtest @rule(+(~~x,~y,~~x) => (~~x, ~y, ~~x))(term(+,6,type=Any)) == ([], 6, [])
+end
+
+@testset "Commutative + and *" begin
+    r1 = @rule sin(~x) + cos(~x) => ~x
+    @test r1(sin(a)+cos(a)) === a
+    @test r1(sin(x)+cos(x)) === x
+    r2 = @rule (~x+~y)*(~z+~w)^(~m) => (~x, ~y, ~z, ~w, ~m)
+    r3 = @rule (~z+~w)^(~m)*(~x+~y) => (~x, ~y, ~z, ~w, ~m)
+    @test r2((a+b)*(x+c)^b) === (a, b, x, c, b)
+    @test r3((a+b)*(x+c)^b) === (a, b, x, c, b)
+    rPredicate1 = @rule ~x::(x->isa(x,Number)) + ~y => (~x, ~y)
+    rPredicate2 = @rule ~y + ~x::(x->isa(x,Number)) => (~x, ~y)
+    @test rPredicate1(2+x) === (2, x)
+    @test rPredicate2(2+x) === (2, x)
 end
 
 @testset "Slot matcher with default value" begin

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -2,7 +2,7 @@ using SymbolicUtils
 
 include("utils.jl")
 
-@syms a b c x
+@syms a b c d x
 
 @testset "Equality" begin
     @eqtest a == a

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -76,7 +76,7 @@ end
     @test r_pow2((a+b)^c) === c
     @test r_pow2(a+b) === 1
 
-    r_mix = @rule (~x + (~y)*(~!c))^(~!m) => ~m + ~c
+    r_mix = @rule (~x + (~y)*(~!c))^(~!m) => (~m, ~c)
     @test r_mix((a + b*c)^2) === (2, c)
     @test r_mix((a + b*c)) === (1, c)
     @test r_mix((a + b)) === (1, 1)
@@ -92,7 +92,7 @@ end
     @test r2(1/a^(b+2c)) === (a, -b, -2c) # uses frankestein
     @test r2(1/a^3) === nothing # should use a term_matcher that flips the sign, but is not implemented
 
-    r1defslot = @rule (~x)^(~!y) => (~x, ~y) # rule with slot as exponent
+    r1defslot = @rule (~x)^(~!y) => (~x, ~y) # rule with defslot as exponent
     @test r1defslot(1/a^b) === (a, -b) # uses frankestein
     @test r1defslot(1/a^(b+2c)) === (a, -b-2c) # uses frankestein
     @test r1defslot(1/a^2) === (a, -2) # uses opposite_sign_matcher

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -48,19 +48,20 @@ end
 end
 
 @testset "Commutative + and *" begin
-    r1 = @acrule exp(sin(~x) + cos(~x)) => ~x
+    r1 = @rule exp(sin(~x) + cos(~x)) => ~x
+    # using a or x changes the order of the arguments in the call
     @test r1(exp(sin(a)+cos(a))) === a
     @test r1(exp(sin(x)+cos(x))) === x
-    r2 = @acrule (~x+~y)*(~z+~w)^(~m) => (~x, ~y, ~z, ~w, ~m)
-    r3 = @acrule (~z+~w)^(~m)*(~x+~y) => (~x, ~y, ~z, ~w, ~m)
+    r2 = @rule (~x+~y)*(~z+~w)^(~m) => (~x, ~y, ~z, ~w, ~m)
+    r3 = @rule (~z+~w)^(~m)*(~x+~y) => (~x, ~y, ~z, ~w, ~m)
     @test r2((a+b)*(x+c)^b) === (a, b, x, c, b)
     @test r3((a+b)*(x+c)^b) === (a, b, x, c, b)
-    rPredicate1 = @acrule ~x::(x->isa(x,Number)) + ~y => (~x, ~y)
-    rPredicate2 = @acrule ~y + ~x::(x->isa(x,Number)) => (~x, ~y)
+    rPredicate1 = @rule ~x::(x->isa(x,Number)) + ~y => (~x, ~y)
+    rPredicate2 = @rule ~y + ~x::(x->isa(x,Number)) => (~x, ~y)
     @test rPredicate1(2+x) === (2, x)
     @test rPredicate2(2+x) === (2, x)
-    r5 = @acrule (~y*(~z+~w))+~x => (~x, ~y, ~z, ~w)
-    r6 = @acrule ~x+((~z+~w)*~y) => (~x, ~y, ~z, ~w)
+    r5 = @rule (~y*(~z+~w))+~x => (~x, ~y, ~z, ~w)
+    r6 = @rule ~x+((~z+~w)*~y) => (~x, ~y, ~z, ~w)
     @test r5(c*(a+b)+d) === (d, c, a, b)
     @test r6(c*(a+b)+d) === (d, c, a, b)
 end

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -108,6 +108,12 @@ end
     @test r_mixmix(exp(x)*sin(1+x+x^2)*2) === (2, 1, x)
     @test r_mixmix(exp(x)*sin(x+x^2)*2) === (2, 0, x)
     @test r_mixmix(exp(x)*sin(x+x^2)) === (1, 0, x)
+
+    r_predicate = @rule ~x + (~!m::(var->isa(var, Int))) => (~x, ~m)
+    @test r_predicate(x+2) === (x, 2)
+    @test r_predicate(x+2.0) !== (x, 2.0)
+    # Note: r_predicate(x+2.0) doesnt return nothing, but (x+2.0, 0)
+    # becasue of the defslot
 end
 
 @testset "power matcher with negative exponent" begin

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -98,6 +98,15 @@ end
     @test r_mix((a + b*c)^2) === (2, c)
     @test r_mix((a + b*c)) === (1, c)
     @test r_mix((a + b)) === (1, 1)
+
+    r_more_than_two_arguments = @rule (~!a)*exp(~x)*sin(~x) => (~a, ~x)
+    @test r_more_than_two_arguments(sin(x)*exp(x)) === (1, x)
+    @test r_more_than_two_arguments(sin(x)*exp(x)*a) === (a, x)
+
+    r_mixmix = @rule (~!a)*exp(~x)*sin(~!b + (~x)^2 + ~x) => (~a, ~b, ~x)
+    @test r_mixmix(exp(x)*sin(1+x+x^2)*2) === (2, 1, x)
+    @test r_mixmix(exp(x)*sin(x+x^2)*2) === (2, 0, x)
+    @test r_mixmix(exp(x)*sin(x+x^2)) === (1, 0, x)
 end
 
 @testset "1/power matches power with exponent of opposite sign" begin

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -109,7 +109,7 @@ end
     @test r_mixmix(exp(x)*sin(x+x^2)) === (1, 0, x)
 end
 
-@testset "1/power matches power with exponent of opposite sign" begin
+@testset "power matcher with negative exponent" begin
     r1 = @rule (~x)^(~y) => (~x, ~y) # rule with slot as exponent
     @test r1(1/a^b) === (a, -b) # uses frankestein
     @test r1(1/a^(b+2c)) === (a, -b-2c) # uses frankestein
@@ -124,6 +124,9 @@ end
     @test r1defslot(1/a^(b+2c)) === (a, -b-2c) # uses frankestein
     @test r1defslot(1/a^2) === (a, -2) # uses opposite_sign_matcher
     @test r1defslot(a) === (a, 1)
+
+    r = @rule (~x + ~y)^(~m) => (~x, ~y, ~m) # rule to match (1/...)^(...)
+    @test r((1/(a+b))^3) === (a,b,-3)
 end
 
 @testset "Return the matches dictionary" begin

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -91,6 +91,12 @@ end
     r2 = @rule (~x)^(~y + ~z) => (~x, ~y, ~z) # rule with term as exponent
     @test r2(1/a^(b+2c)) === (a, -b, -2c) # uses frankestein
     @test r2(1/a^3) === nothing # should use a term_matcher that flips the sign, but is not implemented
+
+    r1defslot = @rule (~x)^(~!y) => (~x, ~y) # rule with slot as exponent
+    @test r1defslot(1/a^b) === (a, -b) # uses frankestein
+    @test r1defslot(1/a^(b+2c)) === (a, -b-2c) # uses frankestein
+    @test r1defslot(1/a^2) === (a, -2) # uses opposite_sign_matcher
+    @test r1defslot(a) === (a, 1)
 end
 
 @testset "Return the matches dictionary" begin

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -113,7 +113,7 @@ end
     @test r_predicate(x+2) === (x, 2)
     @test r_predicate(x+2.0) !== (x, 2.0)
     # Note: r_predicate(x+2.0) doesnt return nothing, but (x+2.0, 0)
-    # becasue of the defslot
+    # because of the defslot
 end
 
 @testset "power matcher with negative exponent" begin
@@ -157,6 +157,16 @@ end
     r1 = @rule (~x)^(~y) => (~x, ~y)
     @test r1(exp(a)) === (ℯ, a) # uses exp_matcher
     @test r1(sqrt(a)) === (a, 1//2) # uses sqrt_matcher
+end
+
+@testset "Alternate form of special functions" begin
+    rsqrt = @rule sqrt(~x) => ~x
+    @test rsqrt(sqrt(x))===x
+    @test rsqrt((x)^(1//2))===x
+
+    rexp = @rule exp(~x) => ~x
+    @test rexp(exp(x)) === x
+    @test rexp(ℯ^x) === x
 end
 
 using SymbolicUtils: @capture

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -153,6 +153,12 @@ end
     @test r3(a + b^3)===a
 end
 
+@testset "special power matches" begin
+    r1 = @rule (~x)^(~y) => (~x, ~y)
+    @test r1(exp(a)) === (ℯ, a) # uses exp_matcher
+    @test r1(sqrt(a)) === (a, 1//2) # uses sqrt_matcher
+end
+
 using SymbolicUtils: @capture
 
 @testset "Capture form" begin

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -109,11 +109,20 @@ end
     @test r_mixmix(exp(x)*sin(x+x^2)*2) === (2, 0, x)
     @test r_mixmix(exp(x)*sin(x+x^2)) === (1, 0, x)
 
-    r_predicate = @rule ~x + (~!m::(var->isa(var, Int))) => (~x, ~m)
-    @test r_predicate(x+2) === (x, 2)
-    @test r_predicate(x+2.0) !== (x, 2.0)
-    # Note: r_predicate(x+2.0) doesnt return nothing, but (x+2.0, 0)
-    # because of the defslot
+    # predicate checked in normal matching process
+    r_predicate1 = @rule x + (~!m::(var->isa(var, Int))) => ~m
+    @test r_predicate1(x+2) === 2
+    @test r_predicate1(x+2.0) === nothing
+
+    # predicate checked in defslot mathcing process
+    r_predicate2 = @rule x + ~!m::(var->!(var===0)) => ~m
+    @test r_predicate2(x+1)===1 # matches normally
+    @test r_predicate2(x)===nothing # doesnt matches bc the default value is 0 and doesnt respect the predicate
+
+    # multiple defslots with the same name
+    r3 = @rule sin(~!f*~x)+cos(~!f*~x) => ~
+    @test r3(sin(2x)+cos(2x))[:f]===2
+    @test r3(sin(2x)+cos(x))===nothing
 end
 
 @testset "power matcher with negative exponent" begin

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -114,7 +114,7 @@ end
     @test r_predicate1(x+2) === 2
     @test r_predicate1(x+2.0) === nothing
 
-    # predicate checked in defslot mathcing process
+    # predicate checked in defslot matching process
     r_predicate2 = @rule x + ~!m::(var->!(var===0)) => ~m
     @test r_predicate2(x+1)===1 # matches normally
     @test r_predicate2(x)===nothing # doesnt matches bc the default value is 0 and doesnt respect the predicate

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -77,9 +77,20 @@ end
     @test r_pow2(a+b) === 1
 
     r_mix = @rule (~x + (~y)*(~!c))^(~!m) => ~m + ~c
-    @test r_mix((a + b*c)^2) === 2 + c
-    @test r_mix((a + b*c)) === 1 + c
-    @test r_mix((a + b)) === 2 #1+1
+    @test r_mix((a + b*c)^2) === (2, c)
+    @test r_mix((a + b*c)) === (1, c)
+    @test r_mix((a + b)) === (1, 1)
+end
+
+@testset "1/power matches power with exponent of opposite sign" begin
+    r1 = @rule (~x)^(~y) => (~x, ~y) # rule with slot as exponent
+    @test r1(1/a^b) === (a, -b) # uses frankestein
+    @test r1(1/a^(b+2c)) === (a, -b-2c) # uses frankestein
+    @test r1(1/a^2) === (a, -2) # uses opposite_sign_matcher
+
+    r2 = @rule (~x)^(~y + ~z) => (~x, ~y, ~z) # rule with term as exponent
+    @test r2(1/a^(b+2c)) === (a, -b, -2c) # uses frankestein
+    @test r2(1/a^3) === nothing # should use a term_matcher that flips the sign, but is not implemented
 end
 
 @testset "Return the matches dictionary" begin


### PR DESCRIPTION
this pr builds on top of [defslot](https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/749) and extends [negative exponent matching](https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/750). Before this pr julia symbolic rewriting rules had this unfortunate behaviour:
```
julia> @syms a x
(a, x)

julia> rule = @rule sin(~x) + cos(~x) => "yes"
sin(~x) + cos(~x) => 1

julia> arguments(sin(x) + cos(x))
2-element SymbolicUtils.SmallVec{Any, Vector{Any}}:
 cos(x)
 sin(x)

julia> rule(sin(x)+cos(x)) # doesnt match bc arguments are ordered cos first and then sin


julia> arguments(sin(a) + cos(a))
2-element SymbolicUtils.SmallVec{Any, Vector{Any}}:
 sin(a)
 cos(a)

julia> rule(sin(a)+cos(a)) # match bc arguments are ordered sin first and then cos
"yes"
```
there was the [acrule](https://symbolicutils.juliasymbolics.org/rewrite/#associative-commutative_rules) macro that helped, but was working only on the first operation of the expression, not every level. with this pr instead every * and + operation creates a matcher that checks all possible orderings of its arguments. 

This can also be a bad thing becuse the cases to check could be too many...

Also I refacored the code from my last two pr to make everything clearer and cleaner