### PR TITLE
Fix backward compatibility for deprecated polynorm parameter in simplify()

### DIFF
--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -23,8 +23,8 @@ function simplify(x;
     if polynorm !== nothing
         Base.depwarn("simplify(..; polynorm=$polynorm) is deprecated, use simplify(..; expand=$polynorm) instead",
                         :simplify)
+        expand = polynorm  # Use polynorm value as expand for backward compatibility
     end
-
 
     f = if rewriter === nothing
         if threaded


### PR DESCRIPTION
## Summary
Fixes a backward compatibility issue with the deprecated `polynorm` parameter in the `simplify()` function and ensures CI compatibility with `--depwarn=error`.

## Problem
The `polynorm` parameter in `simplify()` was deprecated in favor of `expand`, but there was a missing piece of logic that caused the deprecated parameter to be silently ignored instead of working correctly.

**Original behavior:**
```julia
# This showed a deprecation warning but didn't actually work:
simplify(expr, polynorm=true)  # polynorm value was ignored\!
```

**Expected behavior:**
```julia 
# This should work the same as:
simplify(expr, expand=true)
```

## Root Cause
The deprecation warning was present but the actual logic to use `polynorm` to set `expand` was missing:

```julia
if polynorm \!== nothing
    Base.depwarn("simplify(..; polynorm=$polynorm) is deprecated, use simplify(..; expand=$polynorm) instead", :simplify)
    # Missing: expand = polynorm  ← This line was missing\!
end
```

## Solution
Added the missing backward compatibility logic:

```julia
if polynorm \!== nothing
    Base.depwarn("simplify(..; polynorm=$polynorm) is deprecated, use simplify(..; expand=$polynorm) instead", :simplify)
    expand = polynorm  # Use polynorm value as expand for backward compatibility
end
```

## Testing
✅ **Backward compatibility preserved**: `polynorm` parameter now works correctly
✅ **Deprecation warning maintained**: Users still see the deprecation message  
✅ **CI compatibility**: No tests use `polynorm`, so `--depwarn=error` works fine
✅ **Functional equivalence**: `simplify(expr, polynorm=true)` ≡ `simplify(expr, expand=true)`

## Before/After

**Before (broken):**
```julia
julia> simplify(x^2 + 2x + 1, polynorm=true)
# Warning shown but polynorm value ignored - expand wasn't set\!
x^2 + 2x + 1  # Not expanded
```

**After (fixed):**
```julia
julia> simplify(x^2 + 2x + 1, polynorm=true)  
# Warning shown AND polynorm value used to set expand
1 + 2x + x^2  # Properly expanded
```

## Impact
- ✅ **No breaking changes** - purely fixes broken functionality
- ✅ **Better user experience** - deprecated parameter actually works as expected  
- ✅ **CI stability** - no impact on CI since tests don't use deprecated parameter
- ✅ **Cleaner migration path** - users can transition at their own pace

This is a pure bug fix that restores the intended behavior of the deprecated parameter while maintaining the deprecation path.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>