### PR TITLE
Simplify sqrt to ^(1//2) [Rebased #760]

### DIFF
--- a/src/simplify_rules.jl
+++ b/src/simplify_rules.jl
@@ -68,6 +68,7 @@ let
         @rule(imag(~x::_isreal) => zero(symtype(~x)))
         @rule(ifelse(~x::is_literal_number, ~y, ~z) => ~x ? ~y : ~z)
         @rule(ifelse(~x, ~y, ~y) => ~y)
+        @rule(sqrt(~x) => (~x)^(1//2))
     ]
 
     TRIG_EXP_RULES = [

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -55,6 +55,8 @@ end
     @test simplify(Term(zero, [a])) == 0
     @test simplify(Term(zero, [b + 1])) == 0
     @test simplify(Term(zero, [x + 2])) == 0
+
+    @test simplify(sqrt(b) - b^(1//2)) === 0
 end
 
 @testset "LiteralReal" begin


### PR DESCRIPTION
This is a rebased version of #760 by @Bumblebee00.

## Summary
- Adds a rule to convert all `sqrt` calls to `^(1//2)`
- Solves issue #759
- Makes expressions like `simplify(x^(1//2)-sqrt(x))` return `0`

## Original PR
This PR contains the same changes as #760, rebased onto the latest master branch.

Original PR: #760
Original author: @Bumblebee00

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>