### PR TITLE
Revert "Simplify sqrt to ^(1//2) [Rebased #760]"

### DIFF
--- a/src/simplify_rules.jl
+++ b/src/simplify_rules.jl
@@ -68,7 +68,6 @@ let
         @rule(imag(~x::_isreal) => zero(symtype(~x)))
         @rule(ifelse(~x::is_literal_number, ~y, ~z) => ~x ? ~y : ~z)
         @rule(ifelse(~x, ~y, ~y) => ~y)
-        @rule(sqrt(~x) => (~x)^(1//2))
     ]
 
     TRIG_EXP_RULES = [

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -55,8 +55,6 @@ end
     @test simplify(Term(zero, [a])) == 0
     @test simplify(Term(zero, [b + 1])) == 0
     @test simplify(Term(zero, [x + 2])) == 0
-
-    @test simplify(sqrt(b) - b^(1//2)) === 0
 end
 
 @testset "LiteralReal" begin


### PR DESCRIPTION
Reverts JuliaSymbolics/SymbolicUtils.jl#763

This breaks the symbolic solvers. Reverting for now, will discuss and figure out how to proceed further tomorrow.