### PR TITLE
added functionality to return matches dictionary

### DIFF
--- a/src/rule.jl
+++ b/src/rule.jl
@@ -163,6 +163,8 @@ function makeconsequent(expr)
         else
             return Expr(expr.head, map(makeconsequent, expr.args)...)
         end
+    elseif expr===:(~)
+        return :(__MATCHES__)
     else
         # treat as a literal
         return esc(expr)

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -82,6 +82,22 @@ end
     @test r_mix((a + b)) === 2 #1+1
 end
 
+@testset "Return the matches dictionary" begin
+    r = @rule (~x + (~y)^2) => ~
+    res = r(a + b^2)
+    @test isa(res, Base.ImmutableDict)
+    @test res[:x] === a
+    @test res[:y] === b
+
+    r2 = @rule (~x + (~y)^(~m)) => (~) where ~m===2
+    @test isa(r2(a + b^2), Base.ImmutableDict)
+    @test r2(a + b^3)===nothing
+
+    r3 = @rule (~x + (~y)^(~m)) => ~m===2 ? (~) : ~x
+    @test isa(r3(a + b^2), Base.ImmutableDict)
+    @test r3(a + b^3)===a
+end
+
 using SymbolicUtils: @capture
 
 @testset "Capture form" begin


### PR DESCRIPTION
when working with and debugging rules, its very handy to return all their matches. But to do so one has to manually write in the rhs somehting like: `(~x, ~y, ...)` etc for all the slots:
```
julia> r = @rule ((~a) + (~!b)*(~x))^(~!m)*((~c) + (~!d)*(~x)^2)^(~!n) => (~a, ~b, ~x, ~c, ~d, ~n)
(~a + ~(!b) * ~x) ^ ~(!m) * (~c + ~(!d) * (~x) ^ 2) ^ ~(!n) => (~a, ~b, ~x, ~c, ~d, ~n)

julia> r((1+2x)^2*(3+4x^2))
(1, 2, x, 3, 4, 1)
```
With this pr you can just write one `~` charachter:
```
julia> r = @rule ((~a) + (~!b)*(~x))^(~!m)*((~c) + (~!d)*(~x)^2)^(~!n) => ~
(~a + ~(!b) * ~x) ^ ~(!m) * (~c + ~(!d) * (~x) ^ 2) ^ ~(!n) => (~)

julia> res = r((1+2y)^2*(3+4y^2))
Base.ImmutableDict{Symbol, Any} with 9 entries:
  :MATCH => ((1 + 2y)^2)*(3 + 4(y^2))
  :n     => 1
  :d     => 4
  :c     => 3
  :m     => 2
  :x     => y
  :b     => 2
  :a     => 1
  :____  => nothing

```
and the complete dictionary is returned, that is also accessible by indexing it like this:
```
julia> res[:x]
y

```
and I think it's really useful and time saving

I also added tests, but I think I need to add also documentation right? but I don't know how to do it, could please someone help 🙏?