### PR TITLE
[WIP] NEIM problem proposed solution

### DIFF
--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -144,6 +144,20 @@ end
 
     r = @rule (~x + ~y)^(~m) => (~x, ~y, ~m) # rule to match (1/...)^(...)
     @test r((1/(a+b))^3) === (a,b,-3)
+
+
+    # neim problem
+    r_one = @rule a*b^(~n) => ~
+    @test r_one(a/b)[:n] === -1
+    @test r_one(a/b^3)[:n] === -3
+    @test r_one(a/sqrt(b))[:n] === -1//2
+
+    r_two = @rule b^(~n)*c^(~m) => ~
+    @test r_two(b^2/c)[:m] === -1 
+    @test r_two(b^2/c)[:n] === 2 
+    @test r_two(1/(b*sqrt(c)))[:n] === -1 
+    @test r_two(1/(b*sqrt(c)))[:m] === -1//2 
+
 end
 
 @testset "Return the matches dictionary" begin


### PR DESCRIPTION
this pr aims to solve [this](https://github.com/JuliaSymbolics/SymbolicUtils.jl/issues/777) issue. Is still experimental and I havent tested it a lot.

Basically works like this:
When the code is in the matcher for a * operation, and at leas one of the factors of the * (in the lhs) has a power, check if the operation of data is a division, if yes continue the matching with data being transformed to a multiplication between the numerator of the division, and the denominator raised to a negative power.

So for example the rule `r_one = @rule a*b^(~n) => ~`, if called with `r_one(a/b)` before this pr would skip the matching process, now instead continues the matching process with data transformed to `a*(b^-1)`