### PR TITLE
Feat: Add API for Defining Symbolic Codegen Optimization Rules

### DIFF
--- a/src/code.jl
+++ b/src/code.jl
@@ -1145,14 +1145,6 @@ end
 
 abstract type AbstractMatched end
 
-function bank(dic, key, value)
-    if haskey(dic, key)
-        dic[key] = vcat(dic[key], value)
-    else
-        dic[key] = value
-    end
-end
-
 function apply_substitution_map(expr::Code.Let, substitution_map::Dict)
     substitute_in_ir(expr, substitution_map)
 end


### PR DESCRIPTION
Adds an API that can define and apply optimizing rules on existing IR. Also allows for downstream packages to use as a hook to add additional rules as needed. 