### PR TITLE
Fix warning block indentation in variants documentation

### DIFF
--- a/docs/src/manual/variants.md
+++ b/docs/src/manual/variants.md
@@ -27,11 +27,11 @@ of different `vartype`s.
 
 !!! warning "A short note on (im-)mutability"
   
-  While `ismutabletype(BasicSymbolic)` returns `true`, symbolic types are IMMUTABLE.
-  Any mutation is undefined behavior and can lead to very confusing and hard-to-debug issues.
-  This includes internal mutation, such as mutating `AddMul.dict`. The arrays returned from
-  `TermInterface.arguments` and `TermInterface.sorted_arguments` are read-only arrays for this
-  reason.
+    While `ismutabletype(BasicSymbolic)` returns `true`, symbolic types are IMMUTABLE.
+    Any mutation is undefined behavior and can lead to very confusing and hard-to-debug issues.
+    This includes internal mutation, such as mutating `AddMul.dict`. The arrays returned from
+    `TermInterface.arguments` and `TermInterface.sorted_arguments` are read-only arrays for this
+    reason.
 
 ## Expression symtypes
 


### PR DESCRIPTION
Fixes the warning block indentation on the variants page. The content was not rendering inside the warning block due to 2-space indentation instead of the required 4-space indentation for Documenter.jl admonitions.

<img width="1527" height="680" alt="image" src="https://github.com/user-attachments/assets/1c1270f8-b867-48e8-b254-6b7a6f6b5684" />
