### PR TITLE
feat: printing hook

### DIFF
--- a/src/despecialize.jl
+++ b/src/despecialize.jl
@@ -47,3 +47,6 @@ isbinop(::__InternalInvalidator1) = false
 operator_to_term(::__InternalInvalidator4, ::BasicSymbolic) = _unreachable()
 operator_to_term(::__InternalInvalidator5, ::BasicSymbolic) = _unreachable()
 operator_to_term(::__InternalInvalidator6, ::BasicSymbolic) = _unreachable()
+show_metadata(::IO, ::BasicSymbolic, ::Type{__InternalInvalidator1}, ::Any) = _unreachable()
+show_metadata(::IO, ::BasicSymbolic, ::Type{__InternalInvalidator2}, ::Any) = _unreachable()
+show_metadata(::IO, ::BasicSymbolic, ::Type{__InternalInvalidator3}, ::Any) = _unreachable()

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -1,4 +1,22 @@
-function Base.show(io::IO, x::BasicSymbolic{TreeReal})
+"""
+    show_metadata(io, x) -> Bool
+
+Hook for custom printing based on metadata. Return `true` if printing has been handled.
+Downstream packages can extend `show_metadata(io, x, ::Type{Ctx}, val)` for their
+metadata context and call `show_plain(io, x)` to bypass this hook.
+"""
+function show_metadata(io::IO, x::BasicSymbolic)
+    md = metadata(x)
+    md isa AbstractDict || return false
+    for (ctx, val) in md
+        show_metadata(io, x, ctx, val) && return true
+    end
+    return false
+end
+
+show_metadata(::IO, ::BasicSymbolic, ::DataType, @nospecialize(val)) = false
+
+function show_plain(io::IO, x::BasicSymbolic{TreeReal})
     @match x begin
         BSImpl.Sym(; name) => Base.show_unquoted(io, name)
         BSImpl.Const(; val) => begin
@@ -15,7 +33,7 @@ function Base.show(io::IO, x::BasicSymbolic{TreeReal})
     end
 end
 
-function Base.show(io::IO, x::BasicSymbolic)
+function show_plain(io::IO, x::BasicSymbolic)
     @match x begin
         BSImpl.Sym(; name) => Base.show_unquoted(io, name)
         BSImpl.Const(; val) => begin
@@ -37,6 +55,16 @@ function Base.show(io::IO, x::BasicSymbolic)
             end
         _ => show_term(io, x)
     end
+end
+
+function Base.show(io::IO, x::BasicSymbolic{TreeReal})
+    show_metadata(io, x) && return
+    show_plain(io, x)
+end
+
+function Base.show(io::IO, x::BasicSymbolic)
+    show_metadata(io, x) && return
+    show_plain(io, x)
 end
 
 show_term(io::IO, x::BasicSymbolic{TreeReal}) = show_call(io, operation(x), x)

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -7,7 +7,7 @@ metadata context and call `show_plain(io, x)` to bypass this hook.
 """
 function show_metadata(io::IO, x::BasicSymbolic)
     md = metadata(x)
-    md isa AbstractDict || return false
+    md isa Base.ImmutableDict{DataType, Any} || return false
     for (ctx, val) in md
         show_metadata(io, x, ctx, val) && return true
     end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -891,6 +891,15 @@ end
     @test repr(a + -1*b) == "a - b"
     @test repr(-1^a) == "-(1^a)"
     @test repr((-1)^a) == "(-1)^a"
+
+    struct PrintCtx end
+    function SymbolicUtils.show_metadata(io::IO, x::SymbolicUtils.BasicSymbolic, ::Type{PrintCtx}, val)
+        print(io, "CTX(", val, "):")
+        SymbolicUtils.show_plain(io, x)
+        return true
+    end
+    expr = SymbolicUtils.setmetadata(a + b, PrintCtx, "sum")
+    @test repr(expr) == "CTX(sum):a + b"
 end
 
 @testset "polynomial printing" begin


### PR DESCRIPTION
## Summary
Add a metadata-aware printing hook so downstream packages can customize `Base.show` output based on metadata attached to `BasicSymbolic` nodes.

This enables opt-in rendering for DSLs (e.g., sum prefixes or bracketed averages) without pirating.

## What changed
- Introduce `show_metadata(io, x)` and `show_metadata(io, x, ::Type{Ctx}, val)` hooks.
- Add `show_plain(io, x)` so hooks can reuse the default rendering without recursion.

## Example usage
```julia
struct SumIndices end

function SymbolicUtils.show_metadata(io::IO, x::SymbolicUtils.BasicSymbolic, ::Type{SumIndices}, val)
    print(io, "Σ(", val, ")")
    SymbolicUtils.show_plain(io, x)
    return true
end
```

## Example output
- `average(Σ(...))` can render as `Σ(i=1:N)⟨...⟩`
- `average(a)` can render as `⟨a⟩`

## Tests
- Added a test in `test/basics.jl` showing a custom metadata hook overriding output.

## Motivation
Downstream packages currently cannot alter printing based on metadata (only on the operator via `show_call`). This PR adds a general, non-pirating hook while keeping default behavior unchanged.
