### PR TITLE
Coerce FNTYPE_SEED to UInt to unbreak 32-bit Julia precompile

### DIFF
--- a/src/hashconsing.jl
+++ b/src/hashconsing.jl
@@ -307,7 +307,7 @@ implementation, which uses `objectid`, which changes across runs.
 """
 hash_addmulvariant(x::AddMulVariant.T, h::UInt) = hash(x === AddMulVariant.ADD ? 0x6d86258fc9cc0742 : 0x5e0a17a14cd8c815, h)
 
-const FNTYPE_SEED = 0x8b414291138f6c45
+const FNTYPE_SEED = 0x8b414291138f6c45 % UInt
 
 """
     $TYPEDSIGNATURES


### PR DESCRIPTION
## Summary

One-line fix for #894: `FNTYPE_SEED` (`src/hashconsing.jl:310`) was a bare `UInt64` literal. Its only use site (`hash(...)::UInt ⊻ FNTYPE_SEED` at line 349) widens the XOR result to `UInt64` on 32-bit Julia, which then fails to fit back into a `::UInt` (= `UInt32`) hash field — so `using SymbolicUtils` errors out with `InexactError: trunc(UInt32, 0x8b4142913acd1c23)` during `@compile_workload`.

```diff
-const FNTYPE_SEED = 0x8b414291138f6c45
+const FNTYPE_SEED = 0x8b414291138f6c45 % UInt
```

Matches the style already used for `SYM_SALT`/`DIV_SALT` (lines 225-226). No-op on 64-bit, truncates the constant to `UInt32` on 32-bit.

See #894 for the full diagnostic (XOR fingerprint, versions, downstream impact).

Closes #894.


## CI note (not in this PR)

This slipped through because `ci.yml` runs only on `ubuntu-latest × x64` (no `arch` key in the matrix). Adding `arch: [x64, x86]` (with a macOS-x86 exclude) would catch this class of 32-bit regressions. Not touching that here — happy to open a separate PR if the maintainers want it.
