### PR TITLE
feat: [AI] use new `OrderedDiGraph` for `IRStructure`

### DIFF
--- a/src/SymbolicUtils.jl
+++ b/src/SymbolicUtils.jl
@@ -167,6 +167,7 @@ export substitute
 include("substitute.jl")
 
 export IRStructure, populate_ir!, print_ir, get_reachability
+include("ordered_digraph.jl")
 include("irstructure.jl")
 
 include("code.jl")

--- a/src/irstructure.jl
+++ b/src/irstructure.jl
@@ -11,7 +11,9 @@ expressions.
 # Invariants
 
 The `dependency_graph` correctly encodes the argument structure of every expression in the
-IR. No ordering constraint is imposed on the indices of expressions and their arguments.
+IR. For expression at index `i`, `Graphs.outneighbors(dependency_graph, i)` yields
+dependency indices in the following order: the index of `operation(ir[i])` first (if it is
+a `BasicSymbolic`), then the indices of `arguments(ir[i])` in order.
 
 ## Extended help
 
@@ -24,10 +26,10 @@ $TYPEDFIELDS
 struct IRStructure{T}
     """
     Dependency graph (DAG), where `Graphs.outneighbors(g, v)` denotes the nodes that the
-    expression at index `v` depends on. In other words, `outneighbors` is the analogue of
-    `arguments`.
+    expression at index `v` depends on. Out-neighbors are in argument order: the operation
+    (if symbolic) comes first, followed by `arguments` in order.
     """
-    dependency_graph::Graphs.SimpleDiGraph{Int}
+    dependency_graph::OrderedDiGraph
     """
     Mapping from linear indices to the expression at that index.
     """
@@ -55,7 +57,7 @@ Create an empty `IRStructure` to store `BasicSymbolic{T}` expressions.
 """
 function IRStructure{T}() where {T}
     ir = IRStructure{T}(
-        Graphs.SimpleDiGraph{Int}(), BasicSymbolic{T}[],
+        OrderedDiGraph(), BasicSymbolic{T}[],
         IdDict{BasicSymbolic{T}, Int}(), BitVector(), Int[]
     )
     # It's pretty easy to hit this
@@ -346,35 +348,25 @@ struct PopulateClosure{T} <: Function
 end
 
 function (pc::PopulateClosure{T})() where {T}
-    (; ir, expr) = pc
-    # `outneighbors`
-    expr_uses = Int[]
-    if iscall(expr)
-        args = parent(arguments(expr))
-        # This avoids a lot of allocations
-        sizehint!(expr_uses, length(args))
-        @union_split_smallvec args for arg in args
-            # Add each argument to the IR. This is effectively a postorder traversal.
-            arg_idx = populate_ir!(ir, arg)
-            push!(expr_uses, arg_idx)
-        end
-        op = operation(expr)
-        if op isa BasicSymbolic{T}
-            op_idx = populate_ir!(ir, op)
-            push!(expr_uses, op_idx)
-        end
-    end
-    # Sorting ensures `add_edge!` is a `push!`
-    sort!(expr_uses)
-    Graphs.add_vertex!(ir.dependency_graph)
-    idx = Graphs.nv(ir.dependency_graph)
-    for dst in expr_uses
-        Graphs.add_edge!(ir.dependency_graph, idx, dst)
-    end
-    # Add `expr` to the IR
-    push!(ir.symbols, expr)
-    return idx
-end
+     (; ir, expr) = pc
+     Graphs.add_vertex!(ir.dependency_graph)
+     idx = Graphs.nv(ir.dependency_graph)
+     push!(ir.symbols, expr)           # must happen before add_edge! calls below
+                                       # so recursive populate_ir! sees correct nv
+     if iscall(expr)
+         op = operation(expr)
+         if op isa BasicSymbolic{T}
+             op_idx = populate_ir!(ir, op)
+             Graphs.add_edge!(ir.dependency_graph, idx, op_idx)
+         end
+         args = parent(arguments(expr))
+         @union_split_smallvec args for arg in args
+             arg_idx = populate_ir!(ir, arg)
+             Graphs.add_edge!(ir.dependency_graph, idx, arg_idx)
+         end
+     end
+     return idx
+ end
 
 """
     $TYPEDSIGNATURES

--- a/src/ordered_digraph.jl
+++ b/src/ordered_digraph.jl
@@ -1,0 +1,69 @@
+"""
+    $TYPEDEF
+
+A directed graph that wraps `Graphs.SimpleDiGraph` and remembers edge insertion order.
+`Graphs.outneighbors(g, v)` returns the out-neighbors of `v` in the order edges were
+added, rather than in sorted order.
+
+All other graph operations (`inneighbors`, `topological_sort_by_dfs`, etc.) are
+delegated to the underlying `SimpleDiGraph`.
+"""
+struct OrderedDiGraph <: Graphs.AbstractGraph{Int}
+    graph::Graphs.SimpleDiGraph{Int}
+    """
+    Out-neighbors of each vertex in edge-insertion order.
+    """
+    ordered_outneighbors::Vector{Vector{Int}}
+end
+
+OrderedDiGraph() = OrderedDiGraph(Graphs.SimpleDiGraph{Int}(), Vector{Int}[])
+
+Graphs.is_directed(::Type{OrderedDiGraph}) = true
+Graphs.nv(g::OrderedDiGraph) = Graphs.nv(g.graph)
+Graphs.ne(g::OrderedDiGraph) = Graphs.ne(g.graph)
+Graphs.vertices(g::OrderedDiGraph) = Graphs.vertices(g.graph)
+Graphs.edges(g::OrderedDiGraph) = Graphs.edges(g.graph)
+Graphs.has_vertex(g::OrderedDiGraph, v) = Graphs.has_vertex(g.graph, v)
+Graphs.has_edge(g::OrderedDiGraph, s, d) = Graphs.has_edge(g.graph, s, d)
+Graphs.inneighbors(g::OrderedDiGraph, v) = Graphs.inneighbors(g.graph, v)
+Graphs.outneighbors(g::OrderedDiGraph, v) = g.ordered_outneighbors[v]
+
+function Graphs.add_vertex!(g::OrderedDiGraph)
+    Graphs.add_vertex!(g.graph) || return false
+    push!(g.ordered_outneighbors, Int[])
+    return true
+end
+
+function Graphs.add_vertices!(g::OrderedDiGraph, n::Integer)
+    Graphs.add_vertices!(g.graph, n)
+    for _ in 1:n
+        push!(g.ordered_outneighbors, Int[])
+    end
+    return n
+end
+
+function Graphs.add_edge!(g::OrderedDiGraph, src::Integer, dst::Integer)
+    Graphs.add_edge!(g.graph, src, dst) || return false
+    push!(g.ordered_outneighbors[src], dst)
+    return true
+end
+
+function Graphs.rem_vertex!(g::OrderedDiGraph, v::Integer)
+    # Only removing the last vertex is supported. The sole caller (rollback!) always
+    # removes vertices in reverse order, so this fast path is always taken.
+    v == Graphs.nv(g) ||
+        throw(ArgumentError("OrderedDiGraph only supports removing the last vertex"))
+    Graphs.rem_vertex!(g.graph, v) || return false
+    pop!(g.ordered_outneighbors)
+    return true
+end
+
+function Graphs.rem_edge!(g::OrderedDiGraph, src::Integer, dst::Integer)
+    Graphs.rem_edge!(g.graph, src, dst) || return false
+    idx = findfirst(==(dst), g.ordered_outneighbors[src])
+    idx !== nothing && deleteat!(g.ordered_outneighbors[src], idx)
+    return true
+end
+
+Graphs.topological_sort_by_dfs(g::OrderedDiGraph) =
+    Graphs.topological_sort_by_dfs(g.graph)

--- a/test/irstructure.jl
+++ b/test/irstructure.jl
@@ -201,7 +201,8 @@ function make_reversed_ir(T, root_expr::BasicSymbolic)
     populate_ir!(ir_normal, root_expr)
     n = length(ir_normal)
 
-    dep_graph = Graphs.SimpleDiGraph{Int}(n)
+    dep_graph = SU.OrderedDiGraph()
+    Graphs.add_vertices!(dep_graph, n)
     reversed_symbols = reverse(ir_normal.symbols)  # root at index 1, leaves at end
     reversed_def = IdDict{BasicSymbolic{T}, Int}()
     for (i, sym) in enumerate(reversed_symbols)

--- a/test/ordered_digraph.jl
+++ b/test/ordered_digraph.jl
@@ -1,0 +1,150 @@
+using SymbolicUtils: OrderedDiGraph
+import Graphs
+
+@testset "OrderedDiGraph" begin
+    @testset "construction" begin
+        g = OrderedDiGraph()
+        @test Graphs.nv(g) == 0
+        @test Graphs.ne(g) == 0
+        @test Graphs.is_directed(g)
+        @test isempty(Graphs.vertices(g))
+        @test isempty(Graphs.edges(g))
+    end
+
+    @testset "add_vertex!" begin
+        g = OrderedDiGraph()
+        @test Graphs.add_vertex!(g)
+        @test Graphs.nv(g) == 1
+        @test Graphs.has_vertex(g, 1)
+        @test !Graphs.has_vertex(g, 2)
+        @test isempty(Graphs.outneighbors(g, 1))
+
+        Graphs.add_vertex!(g)
+        @test Graphs.nv(g) == 2
+        @test length(g.ordered_outneighbors) == 2
+    end
+
+    @testset "add_vertices!" begin
+        g = OrderedDiGraph()
+        @test Graphs.add_vertices!(g, 4) == 4
+        @test Graphs.nv(g) == 4
+        @test length(g.ordered_outneighbors) == 4
+        for v in 1:4
+            @test isempty(Graphs.outneighbors(g, v))
+        end
+    end
+
+    @testset "add_edge! and outneighbors order" begin
+        g = OrderedDiGraph()
+        Graphs.add_vertices!(g, 4)
+
+        # Add edges out-of-sorted order: 3, 1, 2
+        @test Graphs.add_edge!(g, 4, 3)
+        @test Graphs.add_edge!(g, 4, 1)
+        @test Graphs.add_edge!(g, 4, 2)
+
+        @test Graphs.ne(g) == 3
+        @test Graphs.has_edge(g, 4, 3)
+        @test Graphs.has_edge(g, 4, 1)
+        @test Graphs.has_edge(g, 4, 2)
+
+        # outneighbors must preserve insertion order, NOT sort
+        @test Graphs.outneighbors(g, 4) == [3, 1, 2]
+
+        # Underlying SimpleDiGraph stores sorted (just verify via inneighbors)
+        @test issetequal(Graphs.inneighbors(g, 3), [4])
+        @test issetequal(Graphs.inneighbors(g, 1), [4])
+        @test issetequal(Graphs.inneighbors(g, 2), [4])
+    end
+
+    @testset "add_edge! duplicate" begin
+        g = OrderedDiGraph()
+        Graphs.add_vertices!(g, 2)
+        @test Graphs.add_edge!(g, 1, 2)
+        # Duplicate add returns false and does not append to ordered list
+        @test !Graphs.add_edge!(g, 1, 2)
+        @test Graphs.ne(g) == 1
+        @test Graphs.outneighbors(g, 1) == [2]
+    end
+
+    @testset "inneighbors" begin
+        g = OrderedDiGraph()
+        Graphs.add_vertices!(g, 3)
+        Graphs.add_edge!(g, 2, 1)
+        Graphs.add_edge!(g, 3, 1)
+        @test issetequal(Graphs.inneighbors(g, 1), [2, 3])
+        @test isempty(Graphs.inneighbors(g, 2))
+        @test isempty(Graphs.inneighbors(g, 3))
+    end
+
+    @testset "rem_edge!" begin
+        g = OrderedDiGraph()
+        Graphs.add_vertices!(g, 4)
+        Graphs.add_edge!(g, 1, 4)
+        Graphs.add_edge!(g, 1, 2)
+        Graphs.add_edge!(g, 1, 3)
+
+        # Remove the middle edge; order of remaining edges is preserved
+        @test Graphs.rem_edge!(g, 1, 2)
+        @test Graphs.ne(g) == 2
+        @test !Graphs.has_edge(g, 1, 2)
+        @test Graphs.outneighbors(g, 1) == [4, 3]
+
+        # Removing a non-existent edge returns false
+        @test !Graphs.rem_edge!(g, 1, 2)
+        @test Graphs.ne(g) == 2
+    end
+
+    @testset "rem_vertex! (last vertex only)" begin
+        g = OrderedDiGraph()
+        Graphs.add_vertices!(g, 3)
+        Graphs.add_edge!(g, 3, 1)
+        Graphs.add_edge!(g, 3, 2)
+
+        @test Graphs.rem_vertex!(g, 3)
+        @test Graphs.nv(g) == 2
+        @test Graphs.ne(g) == 0
+        @test length(g.ordered_outneighbors) == 2
+        @test !Graphs.has_vertex(g, 3)
+
+        # Attempting to remove a non-last vertex throws
+        @test_throws ArgumentError Graphs.rem_vertex!(g, 1)
+    end
+
+    @testset "topological_sort_by_dfs" begin
+        # Build a simple DAG: 1→2, 1→3, 2→4, 3→4 — topo order must have 4 before 2,3 before 1
+        g = OrderedDiGraph()
+        Graphs.add_vertices!(g, 4)
+        Graphs.add_edge!(g, 1, 2)
+        Graphs.add_edge!(g, 1, 3)
+        Graphs.add_edge!(g, 2, 4)
+        Graphs.add_edge!(g, 3, 4)
+
+        # topological_sort_by_dfs: for edge u→v, u appears before v
+        order = Graphs.topological_sort_by_dfs(g)
+        @test length(order) == 4
+        pos = Dict(v => i for (i, v) in enumerate(order))
+        @test pos[1] < pos[2]
+        @test pos[1] < pos[3]
+        @test pos[2] < pos[4]
+        @test pos[3] < pos[4]
+    end
+
+    @testset "outneighbors order is independent of vertex indices" begin
+        # Edges added with decreasing dst: order [5,3,1] must be preserved
+        g = OrderedDiGraph()
+        Graphs.add_vertices!(g, 6)
+        Graphs.add_edge!(g, 6, 5)
+        Graphs.add_edge!(g, 6, 3)
+        Graphs.add_edge!(g, 6, 1)
+        @test Graphs.outneighbors(g, 6) == [5, 3, 1]
+
+        # Edges added with increasing dst: order [1,3,5] must be preserved
+        g2 = OrderedDiGraph()
+        Graphs.add_vertices!(g2, 6)
+        Graphs.add_edge!(g2, 6, 1)
+        Graphs.add_edge!(g2, 6, 3)
+        Graphs.add_edge!(g2, 6, 5)
+        @test Graphs.outneighbors(g2, 6) == [1, 3, 5]
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,7 @@ using Pkg, Test, SafeTestsets
         @safetestset "Recursive utilities" begin include("recursive_utils.jl") end
         @safetestset "Misc" begin include("misc.jl") end
         @safetestset "Method library" begin include("methods.jl") end
+        @safetestset "OrderedDiGraph" begin include("ordered_digraph.jl") end
         @safetestset "IRStructure" begin include("irstructure.jl") end
     end
 end


### PR DESCRIPTION
This allows `outneighbors` to correspond with `arguments`. Codegen can subsequently be refactored to only depend on the graph and `operation(ir.symbols[i])`.