### PR TITLE
feat: [AI] use new graph for `IRStructure`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
           - 'min'
           - '1.11' # to test inference
           - '1'
+        group:
+          - 'Core'
+          - 'QA'
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/src/SymbolicUtils.jl
+++ b/src/SymbolicUtils.jl
@@ -166,6 +166,8 @@ include("simplify.jl")
 export substitute
 include("substitute.jl")
 
+include("ordereddigraph.jl")
+
 export IRStructure, populate_ir!, print_ir, get_reachability
 include("irstructure.jl")
 

--- a/src/SymbolicUtils.jl
+++ b/src/SymbolicUtils.jl
@@ -167,6 +167,7 @@ export substitute
 include("substitute.jl")
 
 include("ordereddigraph.jl")
+include("graph_traversal.jl")
 
 export IRStructure, populate_ir!, print_ir, get_reachability
 include("irstructure.jl")

--- a/src/faster_code.jl
+++ b/src/faster_code.jl
@@ -46,7 +46,7 @@ mutable struct CodegenState{T}
     In such a case, if we assume that the index of `x + y` in `ir` is `4`, then
     `cache[4] == Symbol("%3")`.
     """
-    const cache::Dictionary{Int, Symbol}
+    const cache::Dictionary{Int32, Symbol}
     """
     Rewrite rules, similar to `NameState`.
     """
@@ -68,7 +68,7 @@ written to `block` and `ir` is the underlying `IRStructure`. Rewrite rules can o
 be supplied as the last argument.
 """
 function CodegenState(expr::Expr, block::Expr, ir::IRStructure{T}, rewrites = Dict()) where {T}
-    CodegenState{T}(expr, block, ir, Dictionary{Int, Symbol}(), rewrites, 0)
+    CodegenState{T}(expr, block, ir, Dictionary{Int32, Symbol}(), rewrites, 0)
 end
 
 """
@@ -82,7 +82,7 @@ Note that this is intended to be used to generate individual atomic expressions 
 In case a symbolic requires a larger compound expression, prefer to declare intermediates
 via [`SymbolicUtils.Code.declare!`](@ref) and use them here.
 """
-function codegen!(cs::CodegenState, idx::Int, @nospecialize(sym))
+function codegen!(cs::CodegenState, idx::Integer, @nospecialize(sym))
     lhs = get_cse_name(length(cs.cache))
     push!(cs.block.args, Expr(:(=), lhs, sym))
     insert!(cs.cache, idx, lhs)
@@ -137,7 +137,7 @@ function get_allocator!(cs::CodegenState, @nospecialize(default))
     return result
 end
 
-const CodegenBookmarkT = Int
+const CodegenBookmarkT = Int32
 
 """
     $TYPEDSIGNATURES
@@ -146,7 +146,7 @@ Return a bookmark for `cs`, typically used to introduce new scopes and end them 
 [`rollback!`](@ref).
 """
 function bookmark(cs::CodegenState)
-    return isempty(cs.cache) ? 0 : lastindex(cs.cache)
+    return isempty(cs.cache) ? zero(Int32) : lastindex(cs.cache)
 end
 
 """
@@ -218,7 +218,7 @@ end
 Generate an expression for calling the allocator `allocator` to store the result of `expr`.
 """
 function codegen_allocator_call!(
-        cs::CodegenState{T}, @nospecialize(allocator), expr::BasicSymbolic{T}, expr_idx::Int
+        cs::CodegenState{T}, @nospecialize(allocator), expr::BasicSymbolic{T}, expr_idx::Integer
     ) where {T}
     allocator_sym::Symbol = if allocator isa BasicSymbolic{T}
         cs(allocator)
@@ -266,7 +266,7 @@ function fast_toexpr(sym::CodegenPrimitive, ir::IRStructure{T}, rewrites::Dict{A
 end
 
 """
-    function codegen_function!(fn::F, cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Int) where {F, T}
+    function codegen_function!(fn::F, cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {F, T}
 
 Generate code for `expr` whose operation is `fn` and index in `cs.ir` is `expr_idx`.
 Implementers of this function should _only_ dispatch on `F`, and the rest of the types should
@@ -298,7 +298,7 @@ The code generation in this function does not need to handle checking if `expr` 
 """
 function codegen_function! end
 
-function codegen_function!(::Type{ArrayOp{T}}, cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Int) where {T}
+function codegen_function!(::Type{ArrayOp{T}}, cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
     _allocator = get_allocator!(cs, zeros)
     output_buffer = codegen_allocator_call!(cs, _allocator, expr, expr_idx)
     ranges, innerexpr, output_idx = @match expr begin
@@ -349,7 +349,7 @@ function codegen_function!(::Type{ArrayOp{T}}, cs::CodegenState{T}, expr::BasicS
     return output_buffer
 end
 
-function codegen_function!(f::SymbolicUtils.Fill, cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Int) where {T}
+function codegen_function!(f::SymbolicUtils.Fill, cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
     _allocator = get_allocator!(cs, nothing)
     result = Expr(:call)
     if _allocator === nothing
@@ -377,7 +377,7 @@ function write_constant_array!(cs::CodegenState{T}, vw::Symbol, val::AbstractArr
     end
 end
 
-function codegen_function!(::Type{ArrayMaker{T}}, cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Int) where {T}
+function codegen_function!(::Type{ArrayMaker{T}}, cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
     _allocator = get_allocator!(cs, zeros)
     output_buffer = codegen_allocator_call!(cs, _allocator, expr, expr_idx)
     regions, values = @match expr begin
@@ -427,7 +427,7 @@ end
 
 function codegen_function!(
         ::typeof(SymbolicUtils.array_literal), cs::CodegenState{T}, expr::BasicSymbolic{T},
-        expr_idx::Int
+        expr_idx::Integer
     ) where {T}
     _allocator = get_allocator!(cs, nothing)
     if _allocator === nothing
@@ -444,7 +444,7 @@ function codegen_function!(
     return output_buffer
 end
 
-function codegen_function!(@nospecialize(op::Union{typeof(*), typeof(+)}), cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Int) where {T}
+function codegen_function!(@nospecialize(op::Union{typeof(*), typeof(+)}), cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
     if get(cs.rewrites, :sort_addmul, true)::Bool
         args = parent(sorted_arguments(expr))
     else
@@ -470,7 +470,7 @@ function codegen_function!(@nospecialize(op::Union{typeof(*), typeof(+)}), cs::C
     return codegen!(cs, expr_idx, result)
 end
 
-function codegen_function!(op::typeof(^), cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Int) where {T}
+function codegen_function!(op::typeof(^), cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
     base, exp = arguments(expr)
     base_sym = cs(base)
     @match exp begin
@@ -500,12 +500,12 @@ function codegen_function!(op::typeof(^), cs::CodegenState{T}, expr::BasicSymbol
     end
 end
 
-function codegen_function!(::typeof(ifelse), cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Int) where {T}
+function codegen_function!(::typeof(ifelse), cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
     cond, iftrue, iffalse = arguments(expr)
     return codegen!(cs, expr_idx, Expr(:if, cs(cond), cs(iftrue), cs(iffalse)))
 end
 
-function codegen_function_no_nanmath!(@nospecialize(op), cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Int) where {T}
+function codegen_function_no_nanmath!(@nospecialize(op), cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
     result = Expr(:call)
     if op isa BasicSymbolic{T}
         opsym = cs(op)
@@ -520,7 +520,7 @@ function codegen_function_no_nanmath!(@nospecialize(op), cs::CodegenState{T}, ex
     return codegen!(cs, expr_idx, result)
 end
 
-function codegen_function!(@nospecialize(op), cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Int) where {T}
+function codegen_function!(@nospecialize(op), cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
     # Avoid using `op in NaNMathFuns` since that is dynamic dispatch.
     # Also avoid using `nameof(op)` for the same reason.
     if !get(cs.rewrites, :nanmath, false)::Bool
@@ -558,7 +558,7 @@ function codegen_function!(@nospecialize(op), cs::CodegenState{T}, expr::BasicSy
     return codegen_function_no_nanmath!(op, cs, expr, expr_idx)
 end
 
-function codegen_function!(::typeof(getindex), cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Int) where {T}
+function codegen_function!(::typeof(getindex), cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
     args = parent(arguments(expr))
     if isequal(args[1], SymbolicUtils.idxs_for_arrayop(T))
         offset = unwrap_const(args[2])::Int
@@ -571,7 +571,7 @@ function codegen_function!(::typeof(getindex), cs::CodegenState{T}, expr::BasicS
     return codegen!(cs, expr_idx, result)
 end
 
-function codegen_function!(@nospecialize(op::SymbolicUtils.Mapper), cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Int) where {T}
+function codegen_function!(@nospecialize(op::SymbolicUtils.Mapper), cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
     result = Expr(:call, map)
     fn = op.f
     if fn isa BasicSymbolic{T}
@@ -588,7 +588,7 @@ function codegen_function!(@nospecialize(op::SymbolicUtils.Mapper), cs::CodegenS
     return codegen!(cs, expr_idx, result)
 end
 
-function codegen_function!(@nospecialize(op::SymbolicUtils.Mapreducer), cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Int) where {T}
+function codegen_function!(@nospecialize(op::SymbolicUtils.Mapreducer), cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
     result = Expr(:call, mapreduce)
     kws = Expr(:parameters)
     if op.dims isa Int
@@ -642,7 +642,7 @@ function reset_allocator!(cs::CodegenState, @nospecialize(old_alloc))
     return nothing
 end
 
-function codegen_ir!(cs::CodegenState{T}, idx::Int) where {T}
+function codegen_ir!(cs::CodegenState{T}, idx::Integer) where {T}
     cached = get(cs.cache, idx, nothing)
     if cached isa Symbol
         return cached

--- a/src/faster_code.jl
+++ b/src/faster_code.jl
@@ -137,16 +137,16 @@ function get_allocator!(cs::CodegenState, @nospecialize(default))
     return result
 end
 
-const CodegenBookmarkT = Tuple{Int, SymbolicUtils.IRBookmarkT}
+const CodegenBookmarkT = Int
 
 """
     $TYPEDSIGNATURES
 
 Return a bookmark for `cs`, typically used to introduce new scopes and end them via
-[`SymbolicUtils.rollback!`](@ref).
+[`rollback!`](@ref).
 """
-function SymbolicUtils.bookmark(cs::CodegenState)
-    return (isempty(cs.cache) ? 0 : lastindex(cs.cache), SymbolicUtils.bookmark(cs.ir))
+function bookmark(cs::CodegenState)
+    return isempty(cs.cache) ? 0 : lastindex(cs.cache)
 end
 
 """
@@ -155,8 +155,8 @@ end
 Rollback `cs` to the state identified by `bm`. This has similar semantics to `rollback!` for
 [`SymbolicUtils.IRStructure`](@ref). It is typically used for scoping in `cs`.
 """
-function SymbolicUtils.rollback!(cs::CodegenState, bm::CodegenBookmarkT)
-    last_cache_key, ir_bm = bm
+function rollback!(cs::CodegenState, bm::CodegenBookmarkT)
+    last_cache_key = bm
     if iszero(last_cache_key)
         empty!(cs.cache)
     else
@@ -166,7 +166,6 @@ function SymbolicUtils.rollback!(cs::CodegenState, bm::CodegenBookmarkT)
             k = lastindex(cs.cache)
         end
     end
-    SymbolicUtils.rollback!(cs.ir, ir_bm)
     return cs
 end
 
@@ -188,7 +187,7 @@ in the enclosing scope (the scope of `cs`). Calling `enter_scope` without a corr
 """
 function enter_scope(cs::CodegenState{T}) where {T}
     new_scope = Expr(:block)
-    bm = SymbolicUtils.bookmark(cs)
+    bm = bookmark(cs)
     scoped_cs = CodegenState{T}(new_scope, new_scope, cs.ir, cs.cache, cs.rewrites, cs.misc_idx)
     
     return scoped_cs, bm
@@ -209,7 +208,7 @@ scope. That is the responsibility of the caller. Calling `exit_scope!` twice on 
 """
 function exit_scope!(cs::CodegenState, bm::CodegenBookmarkT)
     result = cs.block
-    SymbolicUtils.rollback!(cs, bm)
+    rollback!(cs, bm)
     return result
 end
 

--- a/src/graph_traversal.jl
+++ b/src/graph_traversal.jl
@@ -1,0 +1,41 @@
+struct RecursiveDFS{G, N, E, X}
+    graph::G
+    visited::BitVector
+    neighbors_fn::N
+    on_enter::E
+    on_exit::X
+end
+
+function RecursiveDFS(
+        g::G; neighbors_fn::N = Graphs.outneighbors,
+        on_enter::E = Returns(nothing), on_exit::X = Returns(nothing)
+    ) where {G <: Graphs.AbstractGraph, N, E, X}
+    return RecursiveDFS{G, N, E, X}(g, falses(Graphs.nv(g)), neighbors_fn, on_enter, on_exit)
+end
+
+function (rdfs::RecursiveDFS)(cur::Integer)
+    (; graph, visited, neighbors_fn, on_enter, on_exit) = rdfs
+    visited[cur] && return
+    visited[cur] = true
+    on_enter(cur)
+    for nbor in neighbors_fn(graph, cur)
+        rdfs(nbor)
+    end
+    on_exit(cur)
+    return nothing
+end
+
+struct PushToBuffer{T} <: Function
+    buffer::Vector{T}
+end
+
+(ptb::PushToBuffer)(val) = push!(ptb.buffer, val)
+
+struct FilteredNeighbors{F, N} <: Function
+    filter::F
+    nbors::N
+end
+
+function (fn::FilteredNeighbors)(graph::Graphs.AbstractGraph, i::Integer)
+    return Iterators.filter(fn.filter, fn.nbors(graph, i))
+end

--- a/src/irstructure.jl
+++ b/src/irstructure.jl
@@ -296,39 +296,6 @@ you need to inspect an `IRStructure` with more statements than that limit.
 print_ir(io::IO, ir::IRStructure) = _show_ir(io, ir; limit = nothing)
 print_ir(ir::IRStructure) = print_ir(stdout, ir)
 
-const IRBookmarkT = Int
-
-"""
-    $TYPEDSIGNATURES
-
-Obtain a token representing the current state of `ir`. After populating `ir` with additional
-expressions, it can be rolled back to the point of the bookmark using
-[`SymbolicUtils.rollback!`](@ref). Note that deleting nodes present in `ir` when it was
-bookmarked is undefined behavior, and will invalidate the bookmark. Attempting to rollback
-to invalidated bookmarks is undefined behavior. In case multiple bookmarks are made,
-rolling back to an earlier bookmark invalidates subsequent bookmarks.
-"""
-function bookmark(ir::IRStructure)::IRBookmarkT
-    return length(ir)
-end
-
-"""
-    $TYPEDSIGNATURES
-
-Revert `ir` to the state it had when the bookmark `bm` was made. See
-[`SymbolicUtils.bookmark`](@ref) for further details.
-"""
-function rollback!(ir::IRStructure, bm::IRBookmarkT)
-    to_rm = length(ir):-1:(bm + 1)
-    # `rem_vertices!` is pretty slow
-    for vert in to_rm
-        Graphs.rem_vertex!(ir.dependency_graph, vert)
-        delete!(ir.definition, ir.symbols[vert])
-    end
-    resize!(ir.symbols, bm)
-    return ir
-end
-
 """
     $TYPEDEF
 

--- a/src/irstructure.jl
+++ b/src/irstructure.jl
@@ -27,7 +27,7 @@ struct IRStructure{T}
     expression at index `v` depends on. In other words, `outneighbors` is the analogue of
     `arguments`.
     """
-    dependency_graph::Graphs.SimpleDiGraph{Int}
+    dependency_graph::OrderedDiGraph{Int}
     """
     Mapping from linear indices to the expression at that index.
     """
@@ -55,7 +55,7 @@ Create an empty `IRStructure` to store `BasicSymbolic{T}` expressions.
 """
 function IRStructure{T}() where {T}
     ir = IRStructure{T}(
-        Graphs.SimpleDiGraph{Int}(), BasicSymbolic{T}[],
+        OrderedDiGraph{Int}(), BasicSymbolic{T}[],
         IdDict{BasicSymbolic{T}, Int}(), BitVector(), Int[]
     )
     # It's pretty easy to hit this

--- a/src/irstructure.jl
+++ b/src/irstructure.jl
@@ -37,6 +37,11 @@ struct IRStructure{T}
     """
     definition::IdDict{BasicSymbolic{T}, Int32}
     """
+    Map from expressions to all nodes they are `isequal` to. This is not `definition` since
+    that uses `===` equality.
+    """
+    weak_definitions::Dict{BasicSymbolic{T}, Vector{Int32}}
+    """
     A cached `BitVector` to be used for several operations supported by this struct. It
     is required for many common operations, and `fill!(false, cached_mask)` is much faster
     than allocating a new one of the appropriate size.
@@ -56,7 +61,8 @@ Create an empty `IRStructure` to store `BasicSymbolic{T}` expressions.
 function IRStructure{T}() where {T}
     ir = IRStructure{T}(
         OrderedDiGraph{Int32}(), BasicSymbolic{T}[],
-        IdDict{BasicSymbolic{T}, Int32}(), BitVector(), Int32[]
+        IdDict{BasicSymbolic{T}, Int32}(), Dict{BasicSymbolic{T}, Vector{Int32}}(),
+        BitVector(), Int32[]
     )
     # It's pretty easy to hit this
     sizehint!(ir, 100)
@@ -135,6 +141,7 @@ Preallocate space for `n` nodes in `ir`.
 function Base.sizehint!(ir::IRStructure, n::Integer)
     sizehint!(ir.symbols, n)
     sizehint!(ir.definition, n)
+    sizehint!(ir.weak_definitions, n)
     sizehint!(ir.cached_mask, n)
     sizehint!(ir.cached_idxs, n)
     return ir
@@ -330,6 +337,10 @@ function (pc::PopulateClosure{T})() where {T}
     end
     # Add `expr` to the IR
     push!(ir.symbols, expr)
+
+    buffer = get!(() -> Int32[], ir.weak_definitions, expr)
+    push!(buffer, idx)
+
     return idx
 end
 
@@ -390,6 +401,8 @@ function subset_ir(ir::IRStructure{T}, exprs::AbstractVector{BasicSymbolic{T}}) 
         sym = ir.symbols[iold]
         push!(new_ir.symbols, sym)
         new_ir.definition[sym] = inew
+        buffer = get!(() -> Int32[], new_ir.weak_definitions, sym)
+        push!(buffer, inew)
 
         # Translate old neighbors to new ones. Since we're iterating
         # `reachables` in topologically sorted order, we can guarantee that these

--- a/src/irstructure.jl
+++ b/src/irstructure.jl
@@ -418,27 +418,119 @@ function subset_ir(ir::IRStructure{T}, exprs::AbstractVector{BasicSymbolic{T}}) 
     return new_ir
 end
 
-"""
-    $TYPEDSIGNATURES
+struct IRStructureSearchBuffer{T, S <: AbstractSet{BasicSymbolic{T}}} <: AbstractSet{BasicSymbolic{T}}
+    ir::IRStructure{T}
+    buffer::S
+    searched::BitSet
+end
 
-Optimized version of [`SymbolicUtils.search_variables!`](@ref) that leverages the provided
-[`SymbolicUtils.IRStructure`](@ref). May also add `expr` to `ir` in the process.
-"""
+function IRStructureSearchBuffer(ir::IRStructure{T}, buffer::S) where {T, S <: AbstractSet{BasicSymbolic{T}}}
+    return IRStructureSearchBuffer{T, S}(ir, buffer, BitSet())
+end
+
+Base.length(s::IRStructureSearchBuffer) = length(s.buffer)
+Base.iterate(s::IRStructureSearchBuffer, state...) = iterate(s.buffer, state...)
+Base.in(x::BasicSymbolic{T}, s::IRStructureSearchBuffer{T}) where {T} = in(x, s.buffer)
+
+function Base.empty(s::IRStructureSearchBuffer{T, S}) where {T, S}
+    return IRStructureSearchBuffer{T, S}(s.ir, empty(s.buffer), empty(s.searched))
+end
+
+function Base.push!(s::IRStructureSearchBuffer{T}, x::BasicSymbolic{T}) where {T}
+    push!(s.buffer, x)
+    return s
+end
+
+Base.keytype(::Type{I}) where {T, I <: IRStructureSearchBuffer{T}} = BasicSymbolic{T}
+
+function Base.delete!(s::IRStructureSearchBuffer{T}, x::BasicSymbolic{T}) where {T}
+    was_in_buffer = x in s.buffer
+    delete!(s.buffer, x)
+    was_in_buffer || return s
+    # Deleting invalidates the cache. Find all nodes `isequal` to this one.
+    defs = get(s.ir.weak_definitions, x, nothing)
+    defs isa Vector{Int32} || return s
+    # Go through `defs`, walk the dependency tree backwards and delete any entries in
+    # `s.searched` that we find.
+    rdfs = RecursiveDFS(
+        s.ir.dependency_graph;
+        neighbors_fn = FilteredNeighbors(in(s.searched), Graphs.inneighbors),
+        on_exit = Base.Fix1(delete!, s.searched)
+    )
+    for def in defs
+        def in s.searched || continue
+        rdfs(def)
+    end
+    return s
+end
+
+function Base.setdiff!(s::IRStructureSearchBuffer{T}, ss...) where {T}
+    idxs = get_cached_idxs!(s.ir)
+    empty!(idxs)
+    for other in ss
+        for x in other
+            was_in_buffer = x in s.buffer
+            delete!(s.buffer, x)
+            was_in_buffer || continue
+            defs = get(s.ir.weak_definitions, x, nothing)
+            if defs isa Vector{Int32}
+                append!(idxs, defs)
+            end
+        end
+    end
+    isempty(idxs) && return s
+    rdfs = RecursiveDFS(
+        s.ir.dependency_graph;
+        neighbors_fn = FilteredNeighbors(in(s.searched), Graphs.inneighbors),
+        on_exit = Base.Fix1(delete!, s.searched)
+    )
+    for idx in idxs
+        def in s.searched || continue
+        rdfs(idx)
+    end
+    return s
+end
+
+function Base.filter!(pred::F, s::IRStructureSearchBuffer{T}) where {F, T}
+    idxs = get_cached_idxs!(s.ir)
+    empty!(idxs)
+
+    for x in s
+        pred(x) && continue
+        delete!(s.buffer, x)
+        defs = get(s.ir.weak_definitions, x, nothing)
+        if defs isa Vector{Int32}
+            append!(idxs, defs)
+        end
+    end
+    isempty(idxs) && return s
+    rdfs = RecursiveDFS(
+        s.ir.dependency_graph;
+        neighbors_fn = FilteredNeighbors(in(s.searched), Graphs.inneighbors),
+        on_exit = Base.Fix1(delete!, s.searched)
+    )
+    for idx in idxs
+        def in s.searched || continue
+        rdfs(idx)
+    end
+    return s
+end
+
 function search_variables!(
-        buffer, ir::IRStructure{T}, expr::BasicSymbolic{T}; is_atomic::F = default_is_atomic,
-        recurse::G = iscall
-    ) where {T, F, G}
+        buffer::IRStructureSearchBuffer{T, S}, expr::BasicSymbolic{T};
+        is_atomic::F = default_is_atomic, recurse::G = iscall
+    ) where {T, S, F, G}
     if is_atomic(expr)
         push!(buffer, expr)
         return
     end
     recurse(expr) || return
+    # We call `populate_ir!` late because it's possible that `recurse` filters
+    # out a big expression before we have to put it into the IR.
+    ir = buffer.ir
     idx = populate_ir!(ir, expr)
-    # We don't have a fast path here, since `is_atomic` also prevents recursing into
-    # subtrees. Thus, we always have to use the general BFS approach.
+    idx in buffer.searched && return
 
-    # This is basically equivalent to a BFS, since `recurse` may filter out sections of the
-    # DAG which means we can't just iterate over the reachable vertices.
     mask = get_cached_mask!(ir, length(ir))
     for arg_i in Graphs.outneighbors(ir.dependency_graph, idx)
         mask[arg_i] = true
@@ -449,6 +541,8 @@ function search_variables!(
     get_reachability!(reachability, ir, idx)
     for cur_i in Iterators.reverse(reachability)
         mask[cur_i] || continue
+        cur_i in buffer.searched && continue
+        push!(buffer.searched, cur_i)
         cur = ir[cur_i]
         if is_atomic(cur)
             push!(buffer, cur)
@@ -459,6 +553,23 @@ function search_variables!(
             mask[arg_i] = true
         end
     end
+
+    push!(buffer.searched, idx)
+
+    return nothing
+end
+
+"""
+    $TYPEDSIGNATURES
+
+Optimized version of [`SymbolicUtils.search_variables!`](@ref) that leverages the provided
+[`SymbolicUtils.IRStructure`](@ref). May also add `expr` to `ir` in the process.
+"""
+function search_variables!(
+        buffer::AbstractSet{BasicSymbolic{T}}, ir::IRStructure{T}, expr::BasicSymbolic{T};
+        is_atomic::F = default_is_atomic, recurse::G = iscall
+    ) where {T, F, G}
+    search_variables!(IRStructureSearchBuffer(ir, buffer), expr; is_atomic, recurse)
     return nothing
 end
 

--- a/src/irstructure.jl
+++ b/src/irstructure.jl
@@ -27,7 +27,7 @@ struct IRStructure{T}
     expression at index `v` depends on. In other words, `outneighbors` is the analogue of
     `arguments`.
     """
-    dependency_graph::OrderedDiGraph{Int}
+    dependency_graph::OrderedDiGraph{Int32}
     """
     Mapping from linear indices to the expression at that index.
     """
@@ -35,7 +35,7 @@ struct IRStructure{T}
     """
     Inverse mapping of `symbols`.
     """
-    definition::IdDict{BasicSymbolic{T}, Int}
+    definition::IdDict{BasicSymbolic{T}, Int32}
     """
     A cached `BitVector` to be used for several operations supported by this struct. It
     is required for many common operations, and `fill!(false, cached_mask)` is much faster
@@ -43,9 +43,9 @@ struct IRStructure{T}
     """
     cached_mask::BitVector
     """
-    Similar to `cached_mask` but a `Vector{Int}`.
+    Similar to `cached_mask` but a `Vector{Int32}`.
     """
-    cached_idxs::Vector{Int}
+    cached_idxs::Vector{Int32}
 end
 
 """
@@ -55,8 +55,8 @@ Create an empty `IRStructure` to store `BasicSymbolic{T}` expressions.
 """
 function IRStructure{T}() where {T}
     ir = IRStructure{T}(
-        OrderedDiGraph{Int}(), BasicSymbolic{T}[],
-        IdDict{BasicSymbolic{T}, Int}(), BitVector(), Int[]
+        OrderedDiGraph{Int32}(), BasicSymbolic{T}[],
+        IdDict{BasicSymbolic{T}, Int32}(), BitVector(), Int32[]
     )
     # It's pretty easy to hit this
     sizehint!(ir, 100)
@@ -90,13 +90,13 @@ end
 """
     $TYPEDSIGNATURES
 
-Get the cached `Vector{Int}` inside IR.
+Get the cached `Vector{Int32}` inside IR.
 """
 function get_cached_idxs!(ir::IRStructure)
     return ir.cached_idxs
 end
 
-function _get_reachability_dfs!(reachability::Vector{Int}, visited::BitVector, ir::IRStructure, cur::Int)
+function _get_reachability_dfs!(reachability::Vector{Int32}, visited::BitVector, ir::IRStructure, cur::Int32)
     visited[cur] = true
     for nbor in Graphs.outneighbors(ir.dependency_graph, cur)
         visited[nbor] && continue
@@ -110,14 +110,14 @@ end
     $TYPEDSIGNATURES
 
 Compute the transitive closure of `dependency_graph` from node `idx` via DFS postorder,
-returning a topologically sorted `Vector{Int}` of all node indices that `idx` (directly or
+returning a topologically sorted `Vector{Int32}` of all node indices that `idx` (directly or
 indirectly) depends on. Dependencies (children) appear before the expressions that depend on
 them (parents). Writes the result to and returns `reachability`.
 
 This function allocates its own scratch space and does not use `ir.cached_mask` or
 `ir.cached_idxs`, so it is safe to call even when those are held by an outer caller.
 """
-function get_reachability!(reachability::Vector{Int}, ir::IRStructure, idx::Int)
+function get_reachability!(reachability::Vector{Int32}, ir::IRStructure, idx::Int32)
     g = ir.dependency_graph
     n = length(ir)
     visited = falses(n)
@@ -135,7 +135,7 @@ end
 
 Out-of-place version of [`get_reachability!`](@ref).
 """
-get_reachability(ir::IRStructure, idx::Int) = get_reachability!(Int[], ir, idx)
+get_reachability(ir::IRStructure, idx::Int32) = get_reachability!(Int32[], ir, idx)
 
 """
     $TYPEDSIGNATURES
@@ -176,7 +176,7 @@ Iterate over valid node indices in `ir`.
 """
 Base.eachindex(ir::IRStructure) = eachindex(ir.symbols)
 
-function _print_ssa_var(io::IO, i::Int)
+function _print_ssa_var(io::IO, i::Int32)
     printstyled(io, "%", i; color = :yellow)
 end
 
@@ -189,7 +189,7 @@ and a summary line is printed instead. Pass `limit = nothing` to print all state
 
 See also [`SymbolicUtils.print_ir`](@ref) which defaults to printing all statements.
 """
-function _show_ir(io::IO, ir::IRStructure; limit::Union{Int, Nothing} = 50)
+function _show_ir(io::IO, ir::IRStructure; limit::Union{Integer, Nothing} = 50)
     n = length(ir)
     println(io, "IRStructure with $n node$(n == 1 ? "" : "s"):")
     n == 0 && return
@@ -216,7 +216,7 @@ function _show_ir(io::IO, ir::IRStructure; limit::Union{Int, Nothing} = 50)
     # Expansion pass: iterate parents before children so that `to_expand` is
     # propagated correctly from roots downward.
     to_expand = falses(n)
-    indeg = zeros(Int, n)
+    indeg = zeros(Int32, n)
     for i in 1:n
         Graphs.indegree(g, i) == 0 && (to_expand[i] = true)
     end
@@ -232,7 +232,7 @@ function _show_ir(io::IO, ir::IRStructure; limit::Union{Int, Nothing} = 50)
     # Assign consecutive SSA indices to non-inlineable visible nodes
     # (indeg == 0 are roots; indeg > 1 are shared).
     # Iterate children before parents so dependencies receive lower SSA numbers.
-    new_idx = zeros(Int, n)
+    new_idx = zeros(Int32, n)
     counter = 0
     for i in Iterators.reverse(topo)
         (to_expand[i] && indeg[i] != 1) || continue
@@ -315,7 +315,7 @@ end
 function (pc::PopulateClosure{T})() where {T}
     (; ir, expr) = pc
     # `outneighbors`
-    expr_uses = Int[]
+    expr_uses = Int32[]
     if iscall(expr)
         args = parent(arguments(expr))
         # This avoids a lot of allocations
@@ -512,8 +512,8 @@ struct IRSubstituter{Fold, T, D <: AbstractDict{BasicSymbolic{T}, BasicSymbolic{
     ir::IRStructure{T}
     rules::D
     filterer::F
-    cache::Dict{Int, Int}
-    reachability::Vector{Int}
+    cache::Dict{Int32, Int32}
+    reachability::Vector{Int32}
 end
 
 """
@@ -524,7 +524,7 @@ Create an `IRSubstituter` using the given `ir` and `rules`.
 function IRSubstituter{Fold}(
         ir::IRStructure{T}, rules::D; filterer::F = default_substitute_filter
     ) where {Fold, T, D <: AbstractDict, F}
-    IRSubstituter{Fold, T, D, F}(ir, rules, filterer, Dict{Int, Int}(), Int[])
+    IRSubstituter{Fold, T, D, F}(ir, rules, filterer, Dict{Int32, Int32}(), Int32[])
 end
 
 get_substitution_dict(sub::IRSubstituter) = sub.rules
@@ -537,11 +537,11 @@ clear_cache!(sub::IRSubstituter) = empty!(sub.cache)
 Perform the substitution on element `idx` in the IR, returning the index of the new
 element.
 """
-function substitute_ir!(sub::IRSubstituter{Fold, T}, idx::Int) where {Fold, T}
+function substitute_ir!(sub::IRSubstituter{Fold, T}, idx::Int32) where {Fold, T}
     (; rules, filterer, ir) = sub
 
     # Check the cache, filter, and rules for `idx`
-    cached = get(sub.cache, idx, 0)
+    cached = get(sub.cache, idx, zero(Int32))
     iszero(cached) || return cached
     idxsym = ir[idx]
     other = get(rules, idxsym, nothing)
@@ -569,7 +569,7 @@ function substitute_ir!(sub::IRSubstituter{Fold, T}, idx::Int) where {Fold, T}
     get_reachability!(reachability, ir, idx)
     for i in reachability
         # Check the cache, filter, and rules for `i`
-        cached = get(sub.cache, i, 0)
+        cached = get(sub.cache, i, zero(Int32))
         if !iszero(cached) && cached != i
             modified[i] = true
             continue

--- a/src/irstructure.jl
+++ b/src/irstructure.jl
@@ -96,16 +96,6 @@ function get_cached_idxs!(ir::IRStructure)
     return ir.cached_idxs
 end
 
-function _get_reachability_dfs!(reachability::Vector{Int32}, visited::BitVector, ir::IRStructure, cur::Int32)
-    visited[cur] = true
-    for nbor in Graphs.outneighbors(ir.dependency_graph, cur)
-        visited[nbor] && continue
-        _get_reachability_dfs!(reachability, visited, ir, nbor)
-    end
-    push!(reachability, cur)
-    return nothing
-end
-
 """
     $TYPEDSIGNATURES
 
@@ -119,13 +109,13 @@ This function allocates its own scratch space and does not use `ir.cached_mask` 
 """
 function get_reachability!(reachability::Vector{Int32}, ir::IRStructure, idx::Int32)
     g = ir.dependency_graph
+    rdfs = RecursiveDFS(g; on_exit = PushToBuffer(reachability))
     n = length(ir)
-    visited = falses(n)
     sizehint!(reachability, n)
-    visited[idx] = true
+    rdfs.visited[idx] = true
     for nbor in Graphs.outneighbors(g, idx)
-        visited[nbor] && continue
-        _get_reachability_dfs!(reachability, visited, ir, nbor)
+        rdfs.visited[nbor] && continue
+        rdfs(nbor)
     end
     return reachability
 end

--- a/src/ordereddigraph.jl
+++ b/src/ordereddigraph.jl
@@ -1,0 +1,400 @@
+"""
+    OrderedDiGraph{T<:Integer}
+
+A directed graph where the forward adjacency list preserves edge insertion
+order. Mirrors `Graphs.SimpleDiGraph` with two differences:
+- `outneighbors(g, v)` returns neighbors in the order edges were inserted.
+- `inneighbors(g, v)` returns an `AdjView` (unordered); membership tests are O(1).
+
+### Adjacency representation
+
+Each entry of `fadjlist` is a `Union{NTuple{2,T}, Vector{T}}`:
+- `NTuple{2,T}` for vertices with 0, 1, or 2 out-edges. `zero(T)` is a
+  sentinel: `(0,0)` means 0 edges, `(dst,0)` means 1 edge, `(a,b)` (both
+  non-zero) means 2 edges. Non-zero entries always occupy the front slots.
+- `Vector{T}` once a vertex acquires a third out-edge. The vector is never
+  shrunk back to a tuple after removal.
+
+Each entry of `badjlist` is a `Union{NTuple{2,T}, Set{T}}`:
+- `NTuple{2,T}` for vertices with 0, 1, or 2 in-edges (same sentinel convention).
+- `Set{T}` once a vertex acquires a third in-edge. Never shrunk back to a tuple.
+
+For example, after inserting edges `2 => 3`, `1 => 3`, `1 => 2` in that order:
+- `outneighbors(g, 1)` returns `[3, 2]`
+- `inneighbors(g, 3)` returns a `Set` containing `{2, 1}` (order unspecified)
+"""
+mutable struct OrderedDiGraph{T <: Integer} <: Graphs.AbstractGraph{T}
+    ne::Int
+    fadjlist::Vector{Union{NTuple{2, T}, Vector{T}}}
+    badjlist::Vector{Union{NTuple{2, T}, Set{T}}}
+
+    function OrderedDiGraph{T}(
+            ne::Int,
+            fadjlist::Vector{Union{NTuple{2, T}, Vector{T}}},
+            badjlist::Vector{Union{NTuple{2, T}, Set{T}}},
+        ) where {T <: Integer}
+        return new{T}(ne, fadjlist, badjlist)
+    end
+end
+
+function OrderedDiGraph(
+        ne::Int,
+        fadjlist::Vector{Union{NTuple{2, T}, Vector{T}}},
+        badjlist::Vector{Union{NTuple{2, T}, Set{T}}},
+    ) where {T}
+    return OrderedDiGraph{T}(ne, fadjlist, badjlist)
+end
+
+#
+# Internal helpers for adjacency list entries.
+# fadjlist entries are Union{NTuple{2,T}, Vector{T}}.
+# badjlist entries are Union{NTuple{2,T}, Set{T}}.
+#
+
+# Effective length (number of real, non-sentinel neighbors).
+@inline _flen(t::NTuple{2, T}) where {T} = iszero(t[1]) ? 0 : iszero(t[2]) ? 1 : 2
+@inline _flen(v::Vector) = length(v)
+@inline _flen(s::Set) = length(s)
+
+# Indexed access into effective elements (assumes 1 <= i <= _flen(entry)).
+# Only valid for NTuple and Vector (not Set, which is unordered).
+@inline _fget(t::NTuple{2}, i::Int) = t[i]
+@inline _fget(v::Vector, i::Int) = v[i]
+
+# Membership test. Assumes x is a valid (non-zero) vertex index.
+@inline _fin(t::NTuple{2, T}, x) where {T} = t[1] == x || t[2] == x
+@inline _fin(v::Vector, x) = x in v
+@inline _fin(s::Set, x) = x in s
+
+#
+# AdjView{T}: lightweight non-allocating view over an adjacency list entry.
+# The entry field stores one of three concrete backing types:
+#   NTuple{2,T} — 0–2 neighbors (small case, no heap allocation)
+#   Vector{T}   — 3+ out-neighbors (fadjlist after transition)
+#   Set{T}      — 3+ in-neighbors  (badjlist after transition)
+#
+# Storing the union inside the struct (rather than as a type parameter) means
+# outneighbors and inneighbors both return the single concrete type AdjView{T},
+# avoiding a Union return type at call sites.  Efficiency is recovered by
+# manually union-splitting on entry type inside each method: isa checks let the
+# compiler specialize each branch.  All three backing types use Int as their
+# iteration state, so the inferred state type is concrete across all branches.
+#
+
+struct AdjView{T <: Integer}
+    entry::Union{NTuple{2, T}, Vector{T}, Set{T}}
+end
+
+Base.eltype(::Type{AdjView{T}}) where {T} = T
+
+# length and membership dispatch through _flen / _fin (defined for all three).
+Base.length(v::AdjView) = _flen(v.entry)
+Base.in(x, v::AdjView) = _fin(v.entry, x)
+
+# getindex: valid only for ordered backing (NTuple / Vector).
+Base.getindex(v::AdjView, i::Int) = _fget(v.entry, i)
+
+# --- iterate: manual union-split on entry type ---
+# NTuple and Vector use sequential Int indices as state; Set uses its internal
+# hash-table slot index, also an Int.  All branches share Int state so the
+# inferred return type is Union{Nothing, Tuple{T, Int}} — no dynamic dispatch.
+
+function Base.iterate(v::AdjView{T}) where {T}
+    entry = v.entry
+    if entry isa NTuple{2, T}
+        _flen(entry) == 0 && return nothing
+        return _fget(entry, 1)::T, 2
+    elseif entry isa Vector{T}
+        isempty(entry) && return nothing
+        return @inbounds(entry[1])::T, 2
+    else
+        return iterate(entry::Set{T})
+    end
+end
+
+function Base.iterate(v::AdjView{T}, state::Int) where {T}
+    entry = v.entry
+    if entry isa NTuple{2, T}
+        state > _flen(entry) && return nothing
+        return _fget(entry, state)::T, state + 1
+    elseif entry isa Vector{T}
+        state > length(entry) && return nothing
+        return @inbounds(entry[state])::T, state + 1
+    else
+        return iterate(entry::Set{T}, state)
+    end
+end
+
+
+#
+# Constructors
+#
+
+"""
+    OrderedDiGraph{T}(n=0)
+
+Construct an `OrderedDiGraph{T}` with `n` vertices and 0 edges.
+"""
+function OrderedDiGraph{T}(n::Integer = 0) where {T <: Integer}
+    z = zero(T)
+    fadjlist = Union{NTuple{2, T}, Vector{T}}[(z, z) for _ in Base.OneTo(n)]
+    badjlist = Union{NTuple{2, T}, Set{T}}[(z, z) for _ in Base.OneTo(n)]
+    return OrderedDiGraph{T}(0, fadjlist, badjlist)
+end
+
+OrderedDiGraph(n::T) where {T <: Integer} = OrderedDiGraph{T}(n)
+OrderedDiGraph() = OrderedDiGraph{Int}()
+
+"""
+    OrderedDiGraph(::Type{T})
+
+Construct an empty `OrderedDiGraph{T}` with 0 vertices and 0 edges.
+"""
+OrderedDiGraph(::Type{T}) where {T <: Integer} = OrderedDiGraph{T}()
+
+"""
+    OrderedDiGraph{T}(g::OrderedDiGraph)
+
+Construct a copy of `g`, converting vertex indices to type `T`.
+"""
+function OrderedDiGraph{T}(g::OrderedDiGraph) where {T <: Integer}
+    fadj = Union{NTuple{2, T}, Vector{T}}[
+        entry isa Vector ? Vector{T}(entry) : (T(entry[1]), T(entry[2]))
+            for entry in g.fadjlist
+    ]
+    badj = Union{NTuple{2, T}, Set{T}}[
+        entry isa Set ? Set{T}(entry) : (T(entry[1]), T(entry[2]))
+            for entry in g.badjlist
+    ]
+    return OrderedDiGraph{T}(g.ne, fadj, badj)
+end
+
+OrderedDiGraph(g::OrderedDiGraph) = Base.copy(g)
+
+"""
+    OrderedDiGraph{T}(g::AbstractGraph)
+    OrderedDiGraph(g::AbstractGraph)
+
+Construct an `OrderedDiGraph` from any `AbstractGraph` by enumerating its edges.
+If `g` is undirected, both directed edges `(u, v)` and `(v, u)` are added.
+"""
+function OrderedDiGraph{T}(g::Graphs.AbstractGraph) where {T <: Integer}
+    h = OrderedDiGraph{T}(Graphs.nv(g))
+    for e in Graphs.edges(g)
+        Graphs.add_edge!(h, T(Graphs.src(e)), T(Graphs.dst(e)))
+        if !Graphs.is_directed(g)
+            Graphs.add_edge!(h, T(Graphs.dst(e)), T(Graphs.src(e)))
+        end
+    end
+    return h
+end
+
+OrderedDiGraph(g::Graphs.AbstractGraph{T}) where {T} = OrderedDiGraph{T}(g)
+
+#
+# Graphs.jl interface
+#
+
+Graphs.edgetype(::OrderedDiGraph{T}) where {T} = Graphs.Edge{T}
+
+Graphs.nv(g::OrderedDiGraph{T}) where {T} = T(length(g.fadjlist))
+
+Graphs.ne(g::OrderedDiGraph) = g.ne
+
+Graphs.vertices(g::OrderedDiGraph) = Base.OneTo(Graphs.nv(g))
+
+Graphs.is_directed(::Type{<:OrderedDiGraph}) = true
+
+Graphs.has_vertex(g::OrderedDiGraph, v::Integer) = v in Graphs.vertices(g)
+
+function Graphs.has_edge(g::OrderedDiGraph, s, d)
+    verts = Graphs.vertices(g)
+    (s in verts && d in verts) || return false
+    return _fin(@inbounds(g.badjlist[d]), s)
+end
+
+Graphs.outneighbors(g::OrderedDiGraph{T}, v::Integer) where {T} = AdjView{T}(@inbounds g.fadjlist[v])
+Graphs.inneighbors(g::OrderedDiGraph{T}, v::Integer) where {T} = AdjView{T}(@inbounds g.badjlist[v])
+
+Base.zero(::Type{OrderedDiGraph{T}}) where {T} = OrderedDiGraph{T}()
+Base.zero(g::G) where {G <: OrderedDiGraph} = zero(G)
+
+#
+# Edge iteration
+#
+
+struct OrderedDiGraphEdgeIter{T <: Integer} <: Graphs.AbstractEdgeIter
+    g::OrderedDiGraph{T}
+end
+
+Graphs.edges(g::OrderedDiGraph) = OrderedDiGraphEdgeIter(g)
+
+Base.eltype(::Type{OrderedDiGraphEdgeIter{T}}) where {T} = Graphs.Edge{T}
+Base.length(it::OrderedDiGraphEdgeIter) = Graphs.ne(it.g)
+
+@inline function Base.iterate(
+        it::OrderedDiGraphEdgeIter{T}, state = (one(T), 1)
+    ) where {T}
+    g = it.g
+    n = Graphs.nv(g)
+    u, i = state
+    n == 0 && return nothing
+    return @inbounds while true
+        entry = g.fadjlist[u]
+        if i > _flen(entry)
+            u == n && return nothing
+            u += one(T)
+            i = 1
+            continue
+        end
+        return Graphs.Edge(u, _fget(entry, i)), (u, i + 1)
+    end
+end
+
+Base.in(e, it::OrderedDiGraphEdgeIter) = Graphs.has_edge(it.g, e)
+
+function Base.show(io::IO, it::OrderedDiGraphEdgeIter)
+    return print(io, "OrderedDiGraphEdgeIter $(Graphs.ne(it.g))")
+end
+
+#
+# Display and equality
+#
+
+function Base.show(io::IO, ::MIME"text/plain", g::OrderedDiGraph{T}) where {T}
+    return print(io, "{$(Graphs.nv(g)), $(Graphs.ne(g))} directed ordered $T graph")
+end
+
+Base.show(io::IO, g::OrderedDiGraph) = show(io, MIME"text/plain"(), g)
+
+function Base.:(==)(g::OrderedDiGraph, h::OrderedDiGraph)
+    Graphs.nv(g) == Graphs.nv(h) || return false
+    Graphs.ne(g) == Graphs.ne(h) || return false
+    return g.fadjlist == h.fadjlist && g.badjlist == h.badjlist
+end
+
+function Base.copy(g::OrderedDiGraph{T}) where {T}
+    # NTuples are immutable — share them; only Vector/Set entries need copying.
+    fadj = Union{NTuple{2, T}, Vector{T}}[
+        entry isa Vector{T} ? copy(entry) : entry for entry in g.fadjlist
+    ]
+    badj = Union{NTuple{2, T}, Set{T}}[
+        entry isa Set{T} ? copy(entry) : entry for entry in g.badjlist
+    ]
+    return OrderedDiGraph{T}(g.ne, fadj, badj)
+end
+
+#
+# Mutation
+#
+
+function Graphs.add_vertex!(g::OrderedDiGraph{T}) where {T}
+    (Graphs.nv(g) + one(T) <= Graphs.nv(g)) && return false  # overflow guard
+    push!(g.fadjlist, (zero(T), zero(T)))
+    push!(g.badjlist, (zero(T), zero(T)))
+    return true
+end
+
+function Graphs.add_edge!(g::OrderedDiGraph{T}, e::Graphs.Edge{T}) where {T}
+    s, d = Graphs.src(e), Graphs.dst(e)
+    verts = Graphs.vertices(g)
+    (s in verts && d in verts) || return false
+
+    @inbounds entry = g.fadjlist[s]
+    @inbounds bentry = g.badjlist[d]
+    # Parallel edge guard. This checks `bentry` since it is a `Set`.
+    _fin(bentry, s) && return false  # parallel edge guard
+
+    if entry isa Vector{T}
+        push!(entry, d)
+    else
+        a, b = entry
+        if iszero(a)
+            @inbounds g.fadjlist[s] = (d, zero(T))
+        elseif iszero(b)
+            @inbounds g.fadjlist[s] = (a, d)
+        else
+            @inbounds g.fadjlist[s] = T[a, b, d]
+        end
+    end
+
+    g.ne += 1
+    if bentry isa Set{T}
+        push!(bentry, s)
+    else
+        a, b = bentry
+        if iszero(a)
+            @inbounds g.badjlist[d] = (s, zero(T))
+        elseif iszero(b)
+            @inbounds g.badjlist[d] = (a, s)
+        else
+            @inbounds g.badjlist[d] = Set{T}((a, b, s))
+        end
+    end
+    return true
+end
+
+function Graphs.add_edge!(g::OrderedDiGraph{T}, s::Integer, d::Integer) where {T}
+    return Graphs.add_edge!(g, Graphs.Edge{T}(T(s), T(d)))
+end
+
+function Graphs.add_edge!(g::OrderedDiGraph{T}, e::Graphs.AbstractEdge) where {T}
+    return Graphs.add_edge!(g, T(Graphs.src(e)), T(Graphs.dst(e)))
+end
+
+function Graphs.rem_edge!(g::OrderedDiGraph{T}, e::Graphs.Edge{T}) where {T}
+    s, d = Graphs.src(e), Graphs.dst(e)
+    verts = Graphs.vertices(g)
+    (s in verts && d in verts) || return false
+
+    @inbounds entry = g.fadjlist[s]
+    if entry isa Vector{T}
+        idx = findfirst(==(d), entry)
+        idx === nothing && return false
+        deleteat!(entry, idx)
+    else
+        a, b = entry
+        if iszero(a)
+            return false
+        elseif iszero(b)
+            a == d || return false
+            @inbounds g.fadjlist[s] = (zero(T), zero(T))
+        else
+            if a == d
+                @inbounds g.fadjlist[s] = (b, zero(T))
+            elseif b == d
+                @inbounds g.fadjlist[s] = (a, zero(T))
+            else
+                return false
+            end
+        end
+    end
+
+    g.ne -= 1
+    @inbounds bentry = g.badjlist[d]
+    if bentry isa Set{T}
+        delete!(bentry, s)
+    else
+        a, b = bentry
+        if iszero(b)
+            @inbounds g.badjlist[d] = (zero(T), zero(T))
+        else
+            @inbounds g.badjlist[d] = a == s ? (b, zero(T)) : (a, zero(T))
+        end
+    end
+    return true
+end
+
+function Graphs.rem_edge!(g::OrderedDiGraph{T}, s::Integer, d::Integer) where {T}
+    return Graphs.rem_edge!(g, Graphs.Edge{T}(T(s), T(d)))
+end
+
+function Graphs.rem_edge!(g::OrderedDiGraph{T}, e::Graphs.AbstractEdge) where {T}
+    return Graphs.rem_edge!(g, T(Graphs.src(e)), T(Graphs.dst(e)))
+end
+
+Graphs.rem_vertex!(g::OrderedDiGraph, v::Integer) =
+    error("OrderedDiGraph does not support vertex removal")
+
+Graphs.rem_vertices!(g::OrderedDiGraph, vs::AbstractVector{<:Integer}; kwargs...) =
+    error("OrderedDiGraph does not support vertex removal")

--- a/test/irstructure.jl
+++ b/test/irstructure.jl
@@ -201,9 +201,9 @@ function make_reversed_ir(T, root_expr::BasicSymbolic)
     populate_ir!(ir_normal, root_expr)
     n = length(ir_normal)
 
-    dep_graph = SymbolicUtils.OrderedDiGraph{Int}(n)
+    dep_graph = SymbolicUtils.OrderedDiGraph{Int32}(n)
     reversed_symbols = reverse(ir_normal.symbols)  # root at index 1, leaves at end
-    reversed_def = IdDict{BasicSymbolic{T}, Int}()
+    reversed_def = IdDict{BasicSymbolic{T}, Int32}()
     for (i, sym) in enumerate(reversed_symbols)
         reversed_def[sym] = i
     end
@@ -220,7 +220,7 @@ function make_reversed_ir(T, root_expr::BasicSymbolic)
             end
         end
     end
-    IRStructure{T}(dep_graph, reversed_symbols, reversed_def, BitVector(), Int[])
+    IRStructure{T}(dep_graph, reversed_symbols, reversed_def, BitVector(), Int32[])
 end
 
 @testset "Out-of-order IRStructure" begin

--- a/test/irstructure.jl
+++ b/test/irstructure.jl
@@ -220,7 +220,7 @@ function make_reversed_ir(T, root_expr::BasicSymbolic)
             end
         end
     end
-    IRStructure{T}(dep_graph, reversed_symbols, reversed_def, BitVector(), Int32[])
+    IRStructure{T}(dep_graph, reversed_symbols, reversed_def, Dict{BasicSymbolic{T}, Int32}(), BitVector(), Int32[])
 end
 
 @testset "Out-of-order IRStructure" begin

--- a/test/irstructure.jl
+++ b/test/irstructure.jl
@@ -201,7 +201,7 @@ function make_reversed_ir(T, root_expr::BasicSymbolic)
     populate_ir!(ir_normal, root_expr)
     n = length(ir_normal)
 
-    dep_graph = Graphs.SimpleDiGraph{Int}(n)
+    dep_graph = SymbolicUtils.OrderedDiGraph{Int}(n)
     reversed_symbols = reverse(ir_normal.symbols)  # root at index 1, leaves at end
     reversed_def = IdDict{BasicSymbolic{T}, Int}()
     for (i, sym) in enumerate(reversed_symbols)

--- a/test/ordereddigraph.jl
+++ b/test/ordereddigraph.jl
@@ -1,0 +1,727 @@
+using SymbolicUtils: OrderedDiGraph, AdjView, OrderedDiGraphEdgeIter
+using Graphs
+using Test
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+# Build a graph from a list of (src, dst) pairs and return it.
+function make_graph(n::Int, edges::Pair{Int,Int}...)
+    g = OrderedDiGraph{Int}(n)
+    for (s, d) in edges
+        add_edge!(g, s, d)
+    end
+    return g
+end
+
+# Helper functions for @inferred tests — must be at module scope so that the
+# compiler can fully specialize them.
+function _sum_outneighbors(g::OrderedDiGraph{Int}, v::Int)
+    s = 0
+    for x in outneighbors(g, v)
+        s += x
+    end
+    return s
+end
+
+function _sum_inneighbors(g::OrderedDiGraph{Int}, v::Int)
+    s = 0
+    for x in inneighbors(g, v)
+        s += x
+    end
+    return s
+end
+
+function _has_any_outneighbor(g::OrderedDiGraph{Int}, v::Int, target::Int)
+    for x in outneighbors(g, v)
+        x == target && return true
+    end
+    return false
+end
+
+# ── Construction ───────────────────────────────────────────────────────────────
+
+@testset "Construction" begin
+    @testset "empty constructors" begin
+        g = OrderedDiGraph{Int}()
+        @test nv(g) == 0
+        @test ne(g) == 0
+
+        g2 = OrderedDiGraph()
+        @test eltype(g2) == Int
+        @test nv(g2) == 0
+
+        g3 = OrderedDiGraph(Int32)
+        @test eltype(g3) == Int32
+        @test nv(g3) == 0
+    end
+
+    @testset "n-vertex constructor" begin
+        g = OrderedDiGraph{Int}(5)
+        @test nv(g) == 5
+        @test ne(g) == 0
+        @test vertices(g) == 1:5
+
+        # Infer T from argument
+        g2 = OrderedDiGraph(Int16(4))
+        @test eltype(g2) == Int16
+        @test nv(g2) == 4
+    end
+
+    @testset "copy constructor" begin
+        g = make_graph(3, 1=>2, 1=>3, 2=>3)
+        h = OrderedDiGraph(g)
+        @test g == h
+        # Mutating the copy does not affect the original
+        add_edge!(h, 3, 1)
+        @test !has_edge(g, 3, 1)
+        @test ne(h) == ne(g) + 1
+    end
+
+    @testset "type-converting copy constructor" begin
+        g = make_graph(3, 1=>2, 2=>3)
+        h = OrderedDiGraph{Int32}(g)
+        @test eltype(h) == Int32
+        @test nv(h) == 3 && ne(h) == 2
+        @test has_edge(h, 1, 2) && has_edge(h, 2, 3)
+        # Insertion order preserved after type conversion
+        @test collect(outneighbors(h, 1)) == Int32[2]
+        @test collect(outneighbors(h, 2)) == Int32[3]
+    end
+
+    @testset "construct from SimpleDiGraph" begin
+        sdg = SimpleDiGraph(3)
+        add_edge!(sdg, 1, 2)
+        add_edge!(sdg, 2, 3)
+        g = OrderedDiGraph(sdg)
+        @test nv(g) == 3 && ne(g) == 2
+        @test has_edge(g, 1, 2) && has_edge(g, 2, 3)
+        @test !has_edge(g, 1, 3)
+    end
+
+    @testset "zero" begin
+        g = zero(OrderedDiGraph{Int})
+        @test nv(g) == 0 && ne(g) == 0
+
+        g2 = make_graph(3, 1=>2)
+        @test zero(g2) == zero(OrderedDiGraph{Int})
+    end
+end
+
+# ── Graphs.jl interface ────────────────────────────────────────────────────────
+
+@testset "Graphs.jl interface" begin
+    g = make_graph(4, 1=>2, 1=>3, 2=>4, 3=>4)
+
+    @testset "basic queries" begin
+        @test nv(g) == 4
+        @test ne(g) == 4
+        @test vertices(g) == 1:4
+        @test is_directed(g)
+        @test is_directed(OrderedDiGraph{Int})
+        @test edgetype(g) == Graphs.Edge{Int}
+    end
+
+    @testset "has_vertex" begin
+        @test has_vertex(g, 1)
+        @test has_vertex(g, 4)
+        @test !has_vertex(g, 0)
+        @test !has_vertex(g, 5)
+    end
+
+    @testset "has_edge" begin
+        @test has_edge(g, 1, 2)
+        @test has_edge(g, 1, 3)
+        @test has_edge(g, 2, 4)
+        @test has_edge(g, 3, 4)
+        @test !has_edge(g, 2, 1)   # directed: reverse absent
+        @test !has_edge(g, 1, 4)   # no direct edge
+        @test !has_edge(g, 4, 4)   # no self-loop
+        # Out-of-bounds vertices
+        @test !has_edge(g, 0, 1)
+        @test !has_edge(g, 1, 5)
+    end
+
+    @testset "outneighbors / inneighbors types" begin
+        # both always return AdjView{T}
+        @test outneighbors(g, 1) isa AdjView{Int}
+        @test inneighbors(g, 4)  isa AdjView{Int}
+    end
+
+    @testset "indegree / outdegree" begin
+        @test outdegree(g, 1) == 2
+        @test outdegree(g, 4) == 0
+        @test indegree(g, 4) == 2
+        @test indegree(g, 1) == 0
+    end
+end
+
+# ── Insertion-order invariant ──────────────────────────────────────────────────
+
+@testset "Insertion-order invariant" begin
+    @testset "spec example" begin
+        # From the docstring: insert 2=>3, 1=>3, 1=>2 in that order
+        g = OrderedDiGraph{Int}(3)
+        add_edge!(g, 2, 3)
+        add_edge!(g, 1, 3)
+        add_edge!(g, 1, 2)
+
+        @test collect(outneighbors(g, 1)) == [3, 2]
+        @test collect(outneighbors(g, 2)) == [3]
+        @test isempty(outneighbors(g, 3))
+        @test Set(inneighbors(g, 3)) == Set([2, 1])
+        @test Set(inneighbors(g, 2)) == Set([1])
+    end
+
+    @testset "order is preserved through other mutations" begin
+        g = OrderedDiGraph{Int}(5)
+        add_edge!(g, 1, 5)
+        add_edge!(g, 1, 3)
+        add_edge!(g, 1, 2)
+        add_edge!(g, 1, 4)
+        @test collect(outneighbors(g, 1)) == [5, 3, 2, 4]
+
+        # Removing a non-1 edge does not disturb order
+        rem_edge!(g, 1, 3)
+        @test collect(outneighbors(g, 1)) == [5, 2, 4]
+
+        # Adding a new edge appends
+        add_edge!(g, 1, 3)
+        @test collect(outneighbors(g, 1)) == [5, 2, 4, 3]
+    end
+
+    @testset "differs from SimpleDiGraph sorted order" begin
+        # SimpleDiGraph would have sorted adjacency [2,3]; we should have [3,2]
+        g = OrderedDiGraph{Int}(3)
+        add_edge!(g, 1, 3)
+        add_edge!(g, 1, 2)
+        @test collect(outneighbors(g, 1)) == [3, 2]    # insertion order
+
+        sdg = SimpleDiGraph(3)
+        add_edge!(sdg, 1, 3)
+        add_edge!(sdg, 1, 2)
+        @test outneighbors(sdg, 1) == [2, 3]  # sorted
+    end
+end
+
+# ── fadjlist representation (NTuple / Vector) ──────────────────────────────────
+
+@testset "fadjlist NTuple/Vector representation" begin
+    @testset "0 out-edges → AdjView of length 0" begin
+        g = OrderedDiGraph{Int}(1)
+        nbrs = outneighbors(g, 1)
+        @test nbrs isa AdjView{Int}
+        @test length(nbrs) == 0
+        @test collect(nbrs) == Int[]
+    end
+
+    @testset "1 out-edge → AdjView of length 1" begin
+        g = OrderedDiGraph{Int}(2)
+        add_edge!(g, 1, 2)
+        nbrs = outneighbors(g, 1)
+        @test nbrs isa AdjView{Int}
+        @test length(nbrs) == 1
+        @test collect(nbrs) == [2]
+    end
+
+    @testset "2 out-edges → AdjView of length 2" begin
+        g = OrderedDiGraph{Int}(3)
+        add_edge!(g, 1, 3); add_edge!(g, 1, 2)
+        nbrs = outneighbors(g, 1)
+        @test nbrs isa AdjView{Int}
+        @test length(nbrs) == 2
+        @test collect(nbrs) == [3, 2]
+    end
+
+    @testset "3rd out-edge triggers transition to Vector" begin
+        g = OrderedDiGraph{Int}(4)
+        add_edge!(g, 1, 2); add_edge!(g, 1, 3); add_edge!(g, 1, 4)
+        @test g.fadjlist[1] isa Vector{Int}  # internal representation
+        @test outneighbors(g, 1) isa AdjView{Int}
+        @test collect(outneighbors(g, 1)) == [2, 3, 4]
+    end
+
+    @testset "no regression back to NTuple after rem_edge! on Vector" begin
+        g = OrderedDiGraph{Int}(4)
+        add_edge!(g, 1, 2); add_edge!(g, 1, 3); add_edge!(g, 1, 4)
+        rem_edge!(g, 1, 4)
+        # Vector is never shrunk back to NTuple
+        @test g.fadjlist[1] isa Vector{Int}  # internal representation
+        @test collect(outneighbors(g, 1)) == [2, 3]
+    end
+
+    @testset "rem_edge! on NTuple: 2→1 out-edges" begin
+        g = OrderedDiGraph{Int}(3)
+        add_edge!(g, 1, 3); add_edge!(g, 1, 2)
+        rem_edge!(g, 1, 3)
+        nbrs = outneighbors(g, 1)
+        @test nbrs isa AdjView{Int}
+        @test collect(nbrs) == [2]
+    end
+
+    @testset "rem_edge! on NTuple: 1→0 out-edges" begin
+        g = OrderedDiGraph{Int}(2)
+        add_edge!(g, 1, 2)
+        rem_edge!(g, 1, 2)
+        nbrs = outneighbors(g, 1)
+        @test nbrs isa AdjView{Int}
+        @test length(nbrs) == 0
+    end
+
+    @testset "AdjView supports in-operator" begin
+        g = OrderedDiGraph{Int}(3)
+        add_edge!(g, 1, 3); add_edge!(g, 1, 2)
+        nbrs = outneighbors(g, 1)
+        @test 3 in nbrs
+        @test 2 in nbrs
+        @test !(1 in nbrs)
+    end
+
+end
+
+# ── badjlist representation (NTuple / Set) ────────────────────────────────────
+
+@testset "badjlist NTuple/Set representation" begin
+    @testset "0 in-edges → AdjView of length 0" begin
+        g = OrderedDiGraph{Int}(1)
+        nbrs = inneighbors(g, 1)
+        @test nbrs isa AdjView{Int}
+        @test length(nbrs) == 0
+        @test collect(nbrs) == Int[]
+    end
+
+    @testset "1 in-edge → AdjView of length 1" begin
+        g = OrderedDiGraph{Int}(2)
+        add_edge!(g, 2, 1)
+        nbrs = inneighbors(g, 1)
+        @test nbrs isa AdjView{Int}
+        @test length(nbrs) == 1
+        @test 2 in nbrs
+    end
+
+    @testset "2 in-edges → AdjView backed by NTuple" begin
+        g = OrderedDiGraph{Int}(3)
+        add_edge!(g, 2, 1); add_edge!(g, 3, 1)
+        nbrs = inneighbors(g, 1)
+        @test nbrs isa AdjView{Int}
+        @test length(nbrs) == 2
+        @test g.badjlist[1] isa NTuple{2, Int}  # internal representation
+        @test 2 in nbrs && 3 in nbrs
+    end
+
+    @testset "3rd in-edge triggers transition to Set" begin
+        g = OrderedDiGraph{Int}(4)
+        add_edge!(g, 2, 1); add_edge!(g, 3, 1); add_edge!(g, 4, 1)
+        @test g.badjlist[1] isa Set{Int}         # internal representation
+        nbrs = inneighbors(g, 1)
+        @test nbrs isa AdjView{Int}
+        @test length(nbrs) == 3
+        @test Set(nbrs) == Set([2, 3, 4])
+    end
+
+    @testset "no regression back to NTuple after rem_edge! on Set" begin
+        g = OrderedDiGraph{Int}(4)
+        add_edge!(g, 2, 1); add_edge!(g, 3, 1); add_edge!(g, 4, 1)
+        rem_edge!(g, 4, 1)
+        @test g.badjlist[1] isa Set{Int}         # still Set after removal
+        @test Set(inneighbors(g, 1)) == Set([2, 3])
+    end
+
+    @testset "rem_edge! on NTuple: 2→1 in-edges" begin
+        g = OrderedDiGraph{Int}(3)
+        add_edge!(g, 2, 1); add_edge!(g, 3, 1)
+        rem_edge!(g, 3, 1)
+        @test g.badjlist[1] isa NTuple{2, Int}
+        nbrs = inneighbors(g, 1)
+        @test length(nbrs) == 1
+        @test 2 in nbrs
+    end
+
+    @testset "rem_edge! on NTuple: 1→0 in-edges" begin
+        g = OrderedDiGraph{Int}(2)
+        add_edge!(g, 2, 1)
+        rem_edge!(g, 2, 1)
+        @test g.badjlist[1] isa NTuple{2, Int}
+        @test length(inneighbors(g, 1)) == 0
+    end
+
+    @testset "AdjView supports in-operator (in-neighbors)" begin
+        g = OrderedDiGraph{Int}(3)
+        add_edge!(g, 2, 1); add_edge!(g, 3, 1)
+        nbrs = inneighbors(g, 1)
+        @test 2 in nbrs
+        @test 3 in nbrs
+        @test !(1 in nbrs)
+    end
+
+end
+
+# ── add_vertex! / add_vertices! ────────────────────────────────────────────────
+
+@testset "add_vertex! / add_vertices!" begin
+    g = OrderedDiGraph{Int}()
+
+    @test add_vertex!(g)
+    @test nv(g) == 1
+
+    @test add_vertex!(g)
+    @test nv(g) == 2
+
+    add_edge!(g, 1, 2)
+    @test ne(g) == 1
+
+    # add_vertices! returns count added
+    n_added = add_vertices!(g, 3)
+    @test n_added == 3
+    @test nv(g) == 5
+
+    # New vertices have empty adjacency
+    @test isempty(outneighbors(g, 5))
+    @test isempty(inneighbors(g, 5))
+
+    # UInt8 overflow guard
+    g8 = OrderedDiGraph{UInt8}(typemax(UInt8))
+    @test !add_vertex!(g8)
+    @test nv(g8) == typemax(UInt8)
+end
+
+# ── add_edge! ──────────────────────────────────────────────────────────────────
+
+@testset "add_edge!" begin
+    @testset "returns true on success, false otherwise" begin
+        g = OrderedDiGraph{Int}(3)
+        @test add_edge!(g, 1, 2)           == true
+        @test add_edge!(g, 1, 2)           == false  # duplicate
+        @test add_edge!(g, 0, 1)           == false  # src out of range
+        @test add_edge!(g, 1, 4)           == false  # dst out of range
+        @test ne(g) == 1
+    end
+
+    @testset "via Edge object" begin
+        g = OrderedDiGraph{Int}(2)
+        @test add_edge!(g, Graphs.Edge(1, 2))
+        @test has_edge(g, 1, 2)
+        @test ne(g) == 1
+    end
+
+    @testset "via AbstractEdge" begin
+        g = OrderedDiGraph{Int}(3)
+        e = Graphs.Edge{Int32}(1, 3)   # different integer type
+        @test add_edge!(g, e)
+        @test has_edge(g, 1, 3)
+    end
+
+    @testset "self-loops allowed" begin
+        g = OrderedDiGraph{Int}(2)
+        @test add_edge!(g, 1, 1)
+        @test has_edge(g, 1, 1)
+        @test 1 in outneighbors(g, 1)
+        @test 1 in inneighbors(g, 1)
+        # Duplicate self-loop blocked
+        @test !add_edge!(g, 1, 1)
+    end
+
+    @testset "adjacency state after insertion" begin
+        g = OrderedDiGraph{Int}(3)
+        add_edge!(g, 1, 2)
+        add_edge!(g, 1, 3)
+        @test collect(outneighbors(g, 1)) == [2, 3]
+        @test 1 in inneighbors(g, 2)
+        @test 1 in inneighbors(g, 3)
+        @test ne(g) == 2
+    end
+end
+
+# ── rem_edge! ──────────────────────────────────────────────────────────────────
+
+@testset "rem_edge!" begin
+    @testset "returns true on success, false otherwise" begin
+        g = make_graph(3, 1=>2, 1=>3)
+        @test rem_edge!(g, 1, 2)          == true
+        @test rem_edge!(g, 1, 2)          == false  # already gone
+        @test rem_edge!(g, 2, 1)          == false  # was never there
+        @test rem_edge!(g, 0, 1)          == false  # out of range
+        @test rem_edge!(g, 1, 5)          == false  # out of range
+        @test ne(g) == 1
+    end
+
+    @testset "forward and backward adjacency both updated" begin
+        g = make_graph(3, 1=>2, 1=>3, 2=>3)
+        rem_edge!(g, 1, 3)
+        @test collect(outneighbors(g, 1)) == [2]
+        @test !(1 in inneighbors(g, 3))
+        @test ne(g) == 2
+    end
+
+    @testset "via Edge object" begin
+        g = make_graph(2, 1=>2)
+        @test rem_edge!(g, Graphs.Edge(1, 2))
+        @test !has_edge(g, 1, 2)
+    end
+
+    @testset "via AbstractEdge" begin
+        g = make_graph(3, 1=>3)
+        @test rem_edge!(g, Graphs.Edge{Int32}(1, 3))
+        @test !has_edge(g, 1, 3)
+    end
+end
+
+# ── rem_vertex! / rem_vertices! ───────────────────────────────────────────────
+
+@testset "rem_vertex! and rem_vertices! are unsupported" begin
+    g = make_graph(3, 1=>2, 2=>3)
+    @test_throws ErrorException rem_vertex!(g, 1)
+    @test_throws ErrorException rem_vertex!(g, 3)
+    @test_throws ErrorException rem_vertices!(g, [1, 2])
+    @test_throws ErrorException rem_vertices!(g, Int[]; keep_order=true)
+end
+
+# ── edges iterator ─────────────────────────────────────────────────────────────
+
+@testset "edges iterator" begin
+    g = make_graph(3, 1=>3, 1=>2, 2=>3)
+
+    @testset "length" begin
+        @test length(edges(g)) == ne(g)
+    end
+
+    @testset "eltype" begin
+        @test eltype(edges(g)) == Graphs.Edge{Int}
+    end
+
+    @testset "contains all edges" begin
+        edge_set = Set(edges(g))
+        @test Graphs.Edge(1, 3) in edge_set
+        @test Graphs.Edge(1, 2) in edge_set
+        @test Graphs.Edge(2, 3) in edge_set
+        @test length(edge_set) == 3
+    end
+
+    @testset "in-operator uses has_edge" begin
+        es = edges(g)
+        @test Graphs.Edge(1, 3) in es
+        @test !(Graphs.Edge(3, 1) in es)
+    end
+
+    @testset "empty graph" begin
+        g0 = OrderedDiGraph{Int}()
+        @test length(edges(g0)) == 0
+        @test collect(edges(g0)) == Graphs.Edge{Int}[]
+    end
+
+    @testset "single vertex, no edges" begin
+        g1 = OrderedDiGraph{Int}(1)
+        @test collect(edges(g1)) == Graphs.Edge{Int}[]
+    end
+
+    @testset "iteration order follows fadjlist" begin
+        # Edges from vertex 1 should appear in insertion order
+        g2 = make_graph(4, 1=>4, 1=>2, 1=>3, 2=>4)
+        collected = collect(edges(g2))
+        from1 = [e for e in collected if src(e) == 1]
+        @test dst.(from1) == [4, 2, 3]
+    end
+end
+
+# ── copy and equality ──────────────────────────────────────────────────────────
+
+@testset "copy and ==" begin
+    g = make_graph(3, 1=>2, 2=>3)
+
+    @testset "copy is equal to original" begin
+        h = copy(g)
+        @test g == h
+    end
+
+    @testset "copy is independent" begin
+        h = copy(g)
+        add_edge!(h, 3, 1)
+        @test !has_edge(g, 3, 1)
+        @test g != h
+    end
+
+    @testset "badjlist independence" begin
+        h = copy(g)
+        rem_edge!(h, 1, 2)
+        @test has_edge(g, 1, 2)
+    end
+
+    @testset "inequality on different structure" begin
+        g1 = make_graph(3, 1=>2)
+        g2 = make_graph(3, 2=>1)
+        @test g1 != g2
+    end
+
+    @testset "inequality on different vertex count" begin
+        g1 = make_graph(3, 1=>2)
+        g2 = make_graph(4, 1=>2)
+        @test g1 != g2
+    end
+end
+
+# ── Graphs.jl algorithm compatibility ─────────────────────────────────────────
+
+@testset "Graphs.jl algorithm compatibility" begin
+    @testset "topological_sort_by_dfs on DAG" begin
+        g = make_graph(4, 1=>2, 1=>3, 2=>4, 3=>4)
+        topo = topological_sort_by_dfs(g)
+        # In a valid topological order every src comes before its dst
+        pos = Dict(v => i for (i, v) in enumerate(topo))
+        for e in edges(g)
+            @test pos[src(e)] < pos[dst(e)]
+        end
+    end
+
+    @testset "topological_sort on linear chain" begin
+        g = make_graph(5, 1=>2, 2=>3, 3=>4, 4=>5)
+        topo = topological_sort_by_dfs(g)
+        @test topo == [1, 2, 3, 4, 5]
+    end
+
+    @testset "indegree / outdegree" begin
+        g = make_graph(4, 1=>2, 1=>3, 2=>4, 3=>4)
+        @test indegree(g, 1) == 0
+        @test outdegree(g, 1) == 2
+        @test indegree(g, 4) == 2
+        @test outdegree(g, 4) == 0
+    end
+
+    @testset "neighbors / all_neighbors" begin
+        g = make_graph(3, 1=>2, 3=>1)
+        @test Set(all_neighbors(g, 1)) == Set([2, 3])
+    end
+end
+
+# ── show ───────────────────────────────────────────────────────────────────────
+
+@testset "show" begin
+    g = make_graph(3, 1=>2, 2=>3)
+    s = sprint(show, g)
+    @test occursin("directed ordered", s)
+    @test occursin("3", s)   # nv
+    @test occursin("2", s)   # ne
+end
+
+# ── Type parameterization ──────────────────────────────────────────────────────
+
+@testset "Int32 and UInt8 vertex types" begin
+    g32 = OrderedDiGraph{Int32}(3)
+    add_edge!(g32, 1, 2); add_edge!(g32, 1, 3)
+    @test collect(outneighbors(g32, 1)) == Int32[2, 3]
+    @test inneighbors(g32, 2)  isa AdjView{Int32}
+    @test has_edge(g32, 1, 2)
+
+    g8 = OrderedDiGraph{UInt8}(4)
+    add_edge!(g8, UInt8(1), UInt8(4))
+    @test collect(outneighbors(g8, 1)) == UInt8[4]
+    @test UInt8(1) in inneighbors(g8, 4)
+end
+
+# ── Internal consistency ───────────────────────────────────────────────────────
+
+@testset "Internal consistency (fadjlist ↔ badjlist)" begin
+    function check_consistent(g)
+        for v in vertices(g)
+            for u in outneighbors(g, v)
+                @test v in inneighbors(g, u)
+            end
+            for u in inneighbors(g, v)
+                @test v in outneighbors(g, u)
+            end
+        end
+        # ne matches sum of out-degrees
+        @test ne(g) == sum(outdegree(g, v) for v in vertices(g); init=0)
+    end
+
+    @testset "after insertions" begin
+        g = make_graph(5, 1=>2, 1=>3, 2=>4, 3=>4, 4=>5, 2=>5)
+        check_consistent(g)
+    end
+
+    @testset "after rem_edge!" begin
+        g = make_graph(4, 1=>2, 1=>3, 2=>3, 3=>4)
+        rem_edge!(g, 1, 3)
+        check_consistent(g)
+    end
+
+end
+
+# ── Type stability (@inferred) ─────────────────────────────────────────────────
+
+@testset "Type stability (@inferred)" begin
+    # `@inferred` requires typeof(result) === inferred_type, so it is only
+    # applicable to operations whose inferred return type is a concrete singleton
+    # (not a Union). `iterate` always infers to Union{Nothing, Tuple{...}}, so
+    # it is excluded here; JET covers iterate in adjview_jet.jl.
+
+    # ── AdjView primitives ────────────────────────────────────────────────────
+    ntup0 = AdjView{Int}((0, 0))
+    ntup2 = AdjView{Int}((3, 7))
+    vec3  = AdjView{Int}([4, 5, 6])
+    set3  = AdjView{Int}(Set([4, 5, 6]))
+
+    # length → Int
+    @test @inferred(length(ntup0)) === 0
+    @test @inferred(length(ntup2)) === 2
+    @test @inferred(length(vec3))  === 3
+    @test @inferred(length(set3))  === 3
+
+    # in → Bool
+    @test  @inferred(3 in ntup2)
+    @test !@inferred(5 in ntup2)
+    @test  @inferred(5 in vec3)
+    @test  @inferred(5 in set3)
+    @test !@inferred(9 in set3)
+
+    # getindex → T (ordered backing only)
+    @test @inferred(ntup2[1]) === 3
+    @test @inferred(ntup2[2]) === 7
+    @test @inferred(vec3[2])  === 5
+
+    # ── AdjView loop helpers ──────────────────────────────────────────────────
+    # outneighbors / inneighbors return the single concrete type AdjView{T}.
+    # A function accumulating an Int across the loop has a concrete inferred type.
+
+    g = OrderedDiGraph{Int}(5)
+    add_edge!(g, 1, 3); add_edge!(g, 1, 4)                      # NTuple out-adj for v=1
+    add_edge!(g, 2, 1); add_edge!(g, 3, 1); add_edge!(g, 5, 1)  # Set in-adj for v=1
+
+    @test @inferred(_sum_outneighbors(g, 1)) == 7        # 3 + 4
+    @test @inferred(_sum_inneighbors(g, 1))  == 10       # 2 + 3 + 5
+    @test @inferred(_has_any_outneighbor(g, 1, 3))
+
+    g2 = make_graph(4, 1=>2, 1=>3, 1=>4)                # Vector out-adj for v=1
+    @test @inferred(_sum_outneighbors(g2, 1)) == 9       # 2 + 3 + 4
+
+    # ── Graphs.jl API: basic queries ──────────────────────────────────────────
+    @test @inferred(nv(g))           === 5
+    @test @inferred(ne(g))           === 5
+    @test @inferred(vertices(g))     === Base.OneTo(5)
+    @test @inferred(is_directed(g))  === true
+    @test @inferred(is_directed(OrderedDiGraph{Int})) === true
+    @test @inferred(has_vertex(g, 1)) === true
+    @test @inferred(has_vertex(g, 6)) === false
+    @test @inferred(has_edge(g, 1, 3)) === true
+    @test @inferred(has_edge(g, 1, 2)) === false
+
+    # outneighbors / inneighbors return the single concrete type AdjView{T}
+    @test @inferred(outneighbors(g, 1)) isa AdjView{Int}
+    @test @inferred(inneighbors(g, 1))  isa AdjView{Int}
+
+    # ── Graphs.jl API: edges iterator ─────────────────────────────────────────
+    @test @inferred(edges(g))          isa OrderedDiGraphEdgeIter{Int}
+    @test @inferred(length(edges(g)))  === 5
+    @test @inferred(Graphs.Edge(1, 3) in edges(g)) === true
+
+    # ── Graphs.jl API: mutation ───────────────────────────────────────────────
+    gm = OrderedDiGraph{Int}(4)
+    add_edge!(gm, 1, 2)
+    @test @inferred(add_vertex!(gm))     === true
+    @test @inferred(add_edge!(gm, 2, 3)) === true
+    @test @inferred(rem_edge!(gm, 2, 3)) === true
+
+    # ── copy / zero / == ──────────────────────────────────────────────────────
+    @test @inferred(copy(g))                   isa OrderedDiGraph{Int}
+    @test @inferred(zero(OrderedDiGraph{Int})) isa OrderedDiGraph{Int}
+    h = copy(g)
+    @test @inferred(g == h) === true
+end

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"

--- a/test/qa/adjview_jet.jl
+++ b/test/qa/adjview_jet.jl
@@ -1,0 +1,139 @@
+using SymbolicUtils: OrderedDiGraph, AdjView, OrderedDiGraphEdgeIter
+using Graphs
+using Test
+using JET
+
+# Helper: build AdjView variants directly.
+const _ntup0 = AdjView{Int}((0, 0))
+const _ntup1 = AdjView{Int}((3, 0))
+const _ntup2 = AdjView{Int}((3, 7))
+const _vec3  = AdjView{Int}([4, 5, 6])
+const _set3  = AdjView{Int}(Set([4, 5, 6]))
+
+# ── AdjView iteration type-stability ──────────────────────────────────────────
+
+@testset "JET: AdjView NTuple variant" begin
+    @test_opt iterate(_ntup0)
+    @test_opt iterate(_ntup1)
+    @test_opt iterate(_ntup2)
+    @test_opt iterate(_ntup2, 2)
+    @test_opt length(_ntup2)
+    @test_opt (3 in _ntup2)
+end
+
+@testset "JET: AdjView Vector variant" begin
+    @test_opt iterate(_vec3)
+    @test_opt iterate(_vec3, 2)
+    @test_opt length(_vec3)
+    @test_opt (5 in _vec3)
+end
+
+@testset "JET: AdjView Set variant" begin
+    @test_opt iterate(_set3)
+    @test_opt length(_set3)
+    @test_opt (5 in _set3)
+end
+
+# ── Graph operations ───────────────────────────────────────────────────────────
+
+function _sum_outneighbors_jet(g::OrderedDiGraph{Int}, v::Int)
+    s = 0
+    for x in outneighbors(g, v)
+        s += x
+    end
+    return s
+end
+
+function _sum_inneighbors_jet(g::OrderedDiGraph{Int}, v::Int)
+    s = 0
+    for x in inneighbors(g, v)
+        s += x
+    end
+    return s
+end
+
+@testset "JET: loop over outneighbors (NTuple backing)" begin
+    g = OrderedDiGraph{Int}(3)
+    add_edge!(g, 1, 2); add_edge!(g, 1, 3)
+    @test_opt _sum_outneighbors_jet(g, 1)
+end
+
+@testset "JET: loop over outneighbors (Vector backing)" begin
+    g = OrderedDiGraph{Int}(4)
+    add_edge!(g, 1, 2); add_edge!(g, 1, 3); add_edge!(g, 1, 4)
+    @test_opt _sum_outneighbors_jet(g, 1)
+end
+
+@testset "JET: loop over inneighbors (NTuple backing)" begin
+    g = OrderedDiGraph{Int}(3)
+    add_edge!(g, 2, 1); add_edge!(g, 3, 1)
+    @test_opt _sum_inneighbors_jet(g, 1)
+end
+
+@testset "JET: loop over inneighbors (Set backing)" begin
+    g = OrderedDiGraph{Int}(4)
+    add_edge!(g, 2, 1); add_edge!(g, 3, 1); add_edge!(g, 4, 1)
+    @test_opt _sum_inneighbors_jet(g, 1)
+end
+
+# ── Graphs.jl API type-stability ───────────────────────────────────────────────
+
+function _edges_sum_jet(g::OrderedDiGraph{Int})
+    s = 0
+    for e in edges(g)
+        s += src(e) + dst(e)
+    end
+    return s
+end
+
+@testset "JET: nv, ne, vertices, is_directed" begin
+    g = OrderedDiGraph{Int}(4)
+    add_edge!(g, 1, 2); add_edge!(g, 1, 3)
+    @test_opt nv(g)
+    @test_opt ne(g)
+    @test_opt vertices(g)
+    @test_opt is_directed(g)
+    @test_opt is_directed(OrderedDiGraph{Int})
+end
+
+@testset "JET: has_vertex, has_edge" begin
+    g = OrderedDiGraph{Int}(4)
+    add_edge!(g, 1, 2)
+    @test_opt has_vertex(g, 1)
+    @test_opt has_edge(g, 1, 2)
+    @test_opt has_edge(g, 1, 4)
+end
+
+@testset "JET: outneighbors / inneighbors return AdjView{T}" begin
+    g = OrderedDiGraph{Int}(4)
+    add_edge!(g, 1, 2); add_edge!(g, 1, 3)
+    add_edge!(g, 2, 1); add_edge!(g, 3, 1); add_edge!(g, 4, 1)
+    @test_opt outneighbors(g, 1)
+    @test_opt inneighbors(g, 1)
+end
+
+@testset "JET: edges iterator" begin
+    g = OrderedDiGraph{Int}(4)
+    add_edge!(g, 1, 2); add_edge!(g, 1, 3); add_edge!(g, 2, 4)
+    @test_opt edges(g)
+    @test_opt length(edges(g))
+    @test_opt iterate(edges(g))
+    @test_opt (Graphs.Edge(1, 2) in edges(g))
+    @test_opt _edges_sum_jet(g)
+end
+
+@testset "JET: add_vertex!, add_edge!, rem_edge!" begin
+    g = OrderedDiGraph{Int}(4)
+    @test_opt add_vertex!(g)
+    @test_opt add_edge!(g, 1, 3)
+    @test_opt rem_edge!(g, 1, 3)
+end
+
+@testset "JET: copy, ==, zero" begin
+    g = OrderedDiGraph{Int}(3)
+    add_edge!(g, 1, 2); add_edge!(g, 2, 3)
+    h = copy(g)
+    @test_opt copy(g)
+    @test_opt (g == h)
+    @test_opt zero(OrderedDiGraph{Int})
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,37 +1,53 @@
 using Pkg, Test, SafeTestsets
 
-@testset begin
-    if haskey(ENV, "SU_BENCHMARK_ONLY")
-        @safetestset "Benchmark" begin include("benchmark.jl") end
-    else
-        if v"1.11" <= VERSION < v"1.12"
-            # as of this comment, `@snoop_inference` on 1.12 has a tendency to never
-            # end. I have kept a REPL going for 24 hours.
-            #
-            # The test is commented out because it behaves weirdly. It fails in CI,
-            # fails differently in Pkg.test locally, and is fine when run as a script.
-            # @safetestset "Precompilation" begin include("precompilation.jl") end
+const GROUP = get(ENV, "GROUP", "Core")
+
+function activate_qa_env()
+    Pkg.activate("qa")
+    Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    return Pkg.instantiate()
+end
+
+if GROUP == "Core"
+    @testset "Core" begin
+        if haskey(ENV, "SU_BENCHMARK_ONLY")
+            @safetestset "Benchmark" begin include("benchmark.jl") end
+        else
+            if v"1.11" <= VERSION < v"1.12"
+                # as of this comment, `@snoop_inference` on 1.12 has a tendency to never
+                # end. I have kept a REPL going for 24 hours.
+                #
+                # The test is commented out because it behaves weirdly. It fails in CI,
+                # fails differently in Pkg.test locally, and is fine when run as a script.
+                # @safetestset "Precompilation" begin include("precompilation.jl") end
+            end
+            @safetestset "Basics" begin include("basics.jl") end
+            @safetestset "ArrayOp" begin include("arrayop.jl") end
+            @safetestset "ArrayMaker" begin include("arraymaker.jl") end
+            @safetestset "Order" begin include("order.jl") end
+            @safetestset "PolyForm" begin include("polyform.jl") end
+            @safetestset "Rewrite" begin include("rewrite.jl") end
+            @safetestset "Rulesets" begin include("rulesets.jl") end
+            @safetestset "Inference" begin include("inference.jl") end
+            @safetestset "Code" begin include("code.jl") end
+            @safetestset "New codegen" begin include("new_code.jl") end
+            @safetestset "CSE" begin include("cse.jl") end
+            @safetestset "Interface" begin include("interface.jl") end
+            # Disabled until https://github.com/JuliaMath/SpecialFunctions.jl/issues/446 is fixed
+            @safetestset "Fuzz" begin include("fuzz.jl") end
+            @safetestset "Adjoints" begin include("adjoints.jl") end
+            @safetestset "Hash Consing" begin include("hash_consing.jl") end
+            @safetestset "Cache macro" begin include("cache_macro.jl") end
+            @safetestset "Recursive utilities" begin include("recursive_utils.jl") end
+            @safetestset "Misc" begin include("misc.jl") end
+            @safetestset "Method library" begin include("methods.jl") end
+            @safetestset "IRStructure" begin include("irstructure.jl") end
+            @safetestset "OrderedDiGraph" begin include("ordereddigraph.jl") end
         end
-        @safetestset "Basics" begin include("basics.jl") end
-        @safetestset "ArrayOp" begin include("arrayop.jl") end
-        @safetestset "ArrayMaker" begin include("arraymaker.jl") end
-        @safetestset "Order" begin include("order.jl") end
-        @safetestset "PolyForm" begin include("polyform.jl") end
-        @safetestset "Rewrite" begin include("rewrite.jl") end
-        @safetestset "Rulesets" begin include("rulesets.jl") end
-        @safetestset "Inference" begin include("inference.jl") end
-        @safetestset "Code" begin include("code.jl") end
-        @safetestset "New codegen" begin include("new_code.jl") end
-        @safetestset "CSE" begin include("cse.jl") end
-        @safetestset "Interface" begin include("interface.jl") end
-        # Disabled until https://github.com/JuliaMath/SpecialFunctions.jl/issues/446 is fixed
-        @safetestset "Fuzz" begin include("fuzz.jl") end
-        @safetestset "Adjoints" begin include("adjoints.jl") end
-        @safetestset "Hash Consing" begin include("hash_consing.jl") end
-        @safetestset "Cache macro" begin include("cache_macro.jl") end
-        @safetestset "Recursive utilities" begin include("recursive_utils.jl") end
-        @safetestset "Misc" begin include("misc.jl") end
-        @safetestset "Method library" begin include("methods.jl") end
-        @safetestset "IRStructure" begin include("irstructure.jl") end
     end
+end
+
+if GROUP == "QA"
+    activate_qa_env()
+    @safetestset "AdjView JET" begin include("qa/adjview_jet.jl") end
 end


### PR DESCRIPTION
The new graph is built specifically for the use cases that `IRStructure` cares about, and with some behavior (ordered `outneighbors`) which existing graph types do not provide. This may later be moved to a separate package once we settle on the design and it is extensively tested and benchmarked downstream.