### PR TITLE
feat: register `Base.round`

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -1697,3 +1697,31 @@ function promote_shape(f::Fill, ::ShapeT)
     @nospecialize sh
     return f.sh
 end
+
+struct SymbolicRound{T, R <: RoundingMode}
+    mode::R
+end
+
+function promote_symtype(::SymbolicRound{T}, ::TypeT) where {T}
+    return T::TypeT
+end
+
+function promote_shape(::SymbolicRound{T}, sh::ShapeT) where {T}
+    @nospecialize sh
+    return sh
+end
+
+function (fn::SymbolicRound{T})(ex::BasicSymbolic{R}) where {T, R}
+    return BSImpl.Term{R}(fn, ArgsT{R}((ex,)); type = T, shape = shape(ex))
+end
+function (fn::SymbolicRound{T})(val) where {T}
+    uval = unwrap(val)
+    if uval === val
+        return round(T, uval, fn.mode)
+    end
+    return fn(uval)
+end
+
+function Base.round(::Type{T}, ex::BasicSymbolic{R}, mode::Base.RoundingMode) where {T, R}
+    SymbolicRound{T, typeof(mode)}(mode)(ex)
+end

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -97,6 +97,17 @@ function show_call(io::IO, @nospecialize(f), x::BasicSymbolic; @nospecialize(kw.
     print(io, ")")
 end
 
+function show_call(io::IO, @nospecialize(f::SymbolicRound), x::BasicSymbolic{T}) where {T}
+    inner = first(arguments(x))
+    print(io, "round(")
+    printstyled(io, symtype(x); color = :blue)
+    print(io, ", ")
+    print(io, inner)
+    print(io, ", ")
+    printstyled(io, f.mode; color = :blue)
+    print(io, ")")
+end
+
 function show_call(io::IO, @nospecialize(f::Mapper), x::BasicSymbolic{T}) where {T}
     _args = arguments(x)
     args = ArgsT{T}()

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -1,5 +1,5 @@
 using SymbolicUtils
-using SymbolicUtils: Sym, Term, symtype, BasicSymbolic, Const, ArgsT, promote_symtype, promote_shape, ShapeVecT, Unknown, array_literal, Fill
+using SymbolicUtils: Sym, Term, symtype, BasicSymbolic, Const, ArgsT, promote_symtype, promote_shape, ShapeVecT, Unknown, array_literal, Fill, SymbolicRound
 using Test
 import NaNMath
 import LinearAlgebra
@@ -399,4 +399,59 @@ end
         @test SymbolicUtils.operation(expr) === f1
         @test isequal(SymbolicUtils.arguments(expr), [x])
     end
+end
+
+@testset "SymbolicRound promote_symtype" begin
+    sr = SymbolicRound{Int, typeof(RoundNearest)}(RoundNearest)
+    @test promote_symtype(sr, Float64) == Int
+    @test promote_symtype(sr, Real) == Int
+
+    sr2 = SymbolicRound{Float32, typeof(RoundDown)}(RoundDown)
+    @test promote_symtype(sr2, Float64) == Float32
+end
+
+@testset "SymbolicRound promote_shape" begin
+    sr = SymbolicRound{Int, typeof(RoundNearest)}(RoundNearest)
+    @test promote_shape(sr, ShapeVecT()) == ShapeVecT()
+    @test promote_shape(sr, ShapeVecT((1:3,))) == ShapeVecT((1:3,))
+    @test promote_shape(sr, ShapeVecT((1:2, 1:4))) == ShapeVecT((1:2, 1:4))
+end
+
+@testset "Base.round on symbolic" begin
+    @syms x::Float64
+
+    expr = round(Int, x, RoundNearest)
+    @test isa(expr, BasicSymbolic)
+    @test symtype(expr) == Int
+    @test isa(operation(expr), SymbolicRound{Int, typeof(RoundNearest)})
+    @test isequal(arguments(expr), [x])
+
+    expr_down = round(Int, x, RoundDown)
+    @test isa(expr_down, BasicSymbolic)
+    @test symtype(expr_down) == Int
+    @test isa(operation(expr_down), SymbolicRound{Int, typeof(RoundDown)})
+
+    expr_up = round(Float32, x, RoundUp)
+    @test isa(expr_up, BasicSymbolic)
+    @test symtype(expr_up) == Float32
+end
+
+@testset "Base.round on concrete value via SymbolicRound" begin
+    sr = SymbolicRound{Int, typeof(RoundNearest)}(RoundNearest)
+    @test sr(3.7) == 4
+    @test sr(3.2) == 3
+
+    sr_down = SymbolicRound{Int, typeof(RoundDown)}(RoundDown)
+    @test sr_down(3.9) == 3
+    @test sr_down(-3.1) == -4
+end
+
+@testset "Base.round printing" begin
+    @syms x::Float64
+    expr = round(Int, x, RoundNearest)
+    str = string(expr)
+    @test occursin("round", str)
+    @test occursin("Int", str)
+    @test occursin(string(x), str)
+    @test occursin("Nearest", str)
 end


### PR DESCRIPTION
This allows symtype conversion via `round(Int, x)`/`floor(Int, x)`/`ceil(Int, x)`, etc.