### PR TITLE
feat: [AI] add codegen benchmarks

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,11 +1,56 @@
 using BenchmarkTools, SymbolicUtils
-using SymbolicUtils: is_literal_number, @rule
+using SymbolicUtils: is_literal_number, @rule, ArrayMaker, IRStructure, populate_ir!, BasicSymbolic
 
 using Random
 
 SUITE = BenchmarkGroup()
+SUITE["printing"] = BenchmarkGroup()
 
 @syms a b c d x y[1:3] z[1:2, 1:2]; Random.seed!(123);
+
+_make_bench_ir(expr::BasicSymbolic{T}) where {T} =
+    (ir = IRStructure{T}(); populate_ir!(ir, expr); ir)
+
+_symtype_param(::BasicSymbolic{T}) where {T} = T
+
+@syms _poly_x::Real _poly_y::Real _poly_z::Real _poly_w::Real
+@syms _wide_xs[1:100]::Real _wide_ys[1:100]::Real
+@syms _ma_xs[1:400]::Real _ma_ys[1:400]::Real _ma_zs[1:400]::Real
+
+function make_bench_makearray(n::Int; seed::Int = 42)
+    T   = _symtype_param(_ma_xs[1])
+    rng = Random.MersenneTwister(seed)
+
+    n_regions = clamp(
+        n ÷ 5 + round(Int, randn(rng) * sqrt(n / 5)),
+        4, n ÷ 2
+    )
+
+    split_pts = sort(Random.shuffle!(rng, collect(2:n))[1:n_regions - 1])
+    starts    = [1; split_pts]
+    stops     = [split_pts .- 1; n]
+    regions   = [(starts[i]:stops[i],) for i in 1:n_regions]
+
+    values = map(1:n_regions) do i
+        start, stop = starts[i], stops[i]
+        len = stop - start + 1
+        if len == 1
+            return [_ma_xs[mod1(start, 10)] + _ma_ys[mod1(start, 10)]]
+        end
+        choice = rand(rng, 1:3)
+        if choice == 1
+            return @arrayop (k,) _ma_xs[k] * _ma_ys[k] k in 1:len
+        elseif choice == 2
+            return [iseven(k) ? _ma_xs[mod1(k, 10)] : _ma_ys[mod1(k, 10)] for k in 1:len]
+        else
+            sub_v1 = [_ma_zs[1] + _ma_xs[1]]
+            sub_v2 = @arrayop (k,) _ma_ys[k] k in 1:(len - 1)
+            return ArrayMaker{T}([(1:1,), (2:len,)], (sub_v1, sub_v2))
+        end
+    end
+
+    return ArrayMaker{T}(regions, values)
+end
 
 function random_term(len; atoms, funs, fallback_atom=1)
     xs = rand(atoms, len)
@@ -168,4 +213,54 @@ let
     ir = IRStructure{SymReal}()
     subber = SymbolicUtils.IRSubstituter{false}(ir, rules)
     SUITE["irstructure"]["substitute"]["sparse IRSubstituter"] = @benchmarkable bench_sub($subber, $ex)
+end
+
+let
+    codegen = SUITE["codegen"] = BenchmarkGroup()
+
+    codegen["wide_poly"] = BenchmarkGroup()
+    for n_terms in (25, 50, 100)
+        expr     = sum(_wide_xs[i] * _wide_ys[i] for i in 1:n_terms)
+        cse_expr = SymbolicUtils.Code.cse(expr)
+        ir       = _make_bench_ir(expr)
+        codegen["wide_poly"]["n=$n_terms:toexpr"]      = @benchmarkable SymbolicUtils.Code.toexpr($cse_expr)
+        codegen["wide_poly"]["n=$n_terms:fast_toexpr"] = @benchmarkable SymbolicUtils.Code.fast_toexpr($expr, $ir, Dict{Any,Any}())
+    end
+
+    codegen["deep_poly"] = BenchmarkGroup()
+    for deg in (6, 10, 14)
+        expr     = SymbolicUtils.expand((_poly_x + _poly_y + _poly_z)^deg)
+        cse_expr = SymbolicUtils.Code.cse(expr)
+        ir       = _make_bench_ir(expr)
+        codegen["deep_poly"]["deg=$deg:toexpr"]      = @benchmarkable SymbolicUtils.Code.toexpr($cse_expr)
+        codegen["deep_poly"]["deg=$deg:fast_toexpr"] = @benchmarkable SymbolicUtils.Code.fast_toexpr($expr, $ir, Dict{Any,Any}())
+    end
+
+    let
+        expr     = SymbolicUtils.expand((_poly_x + _poly_y + _poly_z + _poly_w)^12)
+        cse_expr = SymbolicUtils.Code.cse(expr)
+        ir       = _make_bench_ir(expr)
+        codegen["wide_deep_poly"] = BenchmarkGroup()
+        codegen["wide_deep_poly"]["toexpr"]      = @benchmarkable SymbolicUtils.Code.toexpr($cse_expr)
+        codegen["wide_deep_poly"]["fast_toexpr"] = @benchmarkable SymbolicUtils.Code.fast_toexpr($expr, $ir, Dict{Any,Any}())
+    end
+
+    codegen["makearray"] = BenchmarkGroup()
+    for n in (100, 200, 400)
+        expr     = make_bench_makearray(n)
+        cse_expr = SymbolicUtils.Code.cse(expr)
+        ir       = _make_bench_ir(expr)
+        codegen["makearray"]["n=$n:toexpr"]      = @benchmarkable SymbolicUtils.Code.toexpr($cse_expr)
+        codegen["makearray"]["n=$n:fast_toexpr"] = @benchmarkable SymbolicUtils.Code.fast_toexpr($expr, $ir, Dict{Any,Any}())
+    end
+
+    let
+        @syms _ao_A[1:8, 1:8, 1:8]::Real _ao_B[1:8, 1:8, 1:8]::Real
+        expr     = @arrayop (i, j) _ao_A[i, k, l] * _ao_B[j, k, l]
+        cse_expr = SymbolicUtils.Code.cse(expr)
+        ir       = _make_bench_ir(expr)
+        codegen["arrayop_nested"] = BenchmarkGroup()
+        codegen["arrayop_nested"]["toexpr"]      = @benchmarkable SymbolicUtils.Code.toexpr($cse_expr)
+        codegen["arrayop_nested"]["fast_toexpr"] = @benchmarkable SymbolicUtils.Code.fast_toexpr($expr, $ir, Dict{Any,Any}())
+    end
 end


### PR DESCRIPTION
Benchmarks comparing the old and new codegen. This also acts as a proxy for additional `IRStructure` benchmarks.