### PR TITLE
Fix poly_to_gcd_form to produce concrete coefficient eltypes

### DIFF
--- a/src/polyform.jl
+++ b/src/polyform.jl
@@ -220,15 +220,31 @@ function poly_to_gcd_form(p::PolynomialT)
         any_complex |= c isa Complex
         all_int || all_rat || break
     end
-    if all_int
-        return DP.Polynomial(Integer.(MP.coefficients(p)), MP.monomials(p))
+    cs = if all_int
+        Integer.(MP.coefficients(p))
     elseif all_rat
-        return DP.Polynomial(rationalize.(MP.coefficients(p)), MP.monomials(p))
+        rationalize.(MP.coefficients(p))
     elseif any_complex
-        return DP.Polynomial((complex ∘ float).(MP.coefficients(p)), MP.monomials(p))
+        (complex ∘ float).(MP.coefficients(p))
     else
-        return DP.Polynomial(float.(MP.coefficients(p)), MP.monomials(p))
+        float.(MP.coefficients(p))
     end
+    # Broadcast preserves the abstractness of the input vector's eltype:
+    # `Integer.(::Vector{Number})` returns `Vector{Number}` if the values
+    # are heterogeneous concrete subtypes of Integer (e.g. `Int8 + Int64`
+    # broadcasts to `Vector{Signed}`). The resulting `DP.Polynomial` then
+    # carries an abstract type parameter (`Integer`/`Signed`/`AbstractFloat`/
+    # `Real`), which crashes `MP.gcd`'s `isolate_variable` reconstruction.
+    # Narrow to a concrete eltype here when needed; on the homogeneous fast
+    # path (eltype already concrete) this is a single `isconcretetype` check
+    # and no extra allocation.
+    if !isconcretetype(eltype(cs))
+        T = isempty(cs) ? (all_int ? Int : all_rat ? Rational{Int} :
+                           any_complex ? ComplexF64 : Float64) :
+            mapreduce(typeof, promote_type, cs)
+        cs = Vector{T}(cs)
+    end
+    return DP.Polynomial(cs, MP.monomials(p))
 end
 
 function safe_gcd(p1::Union{PolyVarT, PolynomialT}, p2::Union{PolyVarT, PolynomialT})

--- a/test/polyform.jl
+++ b/test/polyform.jl
@@ -67,6 +67,109 @@ end
     @eqtest simplify_fractions((x * y + (1//2) * x) / (2 * x)) == (1//2 + y) / 2
 end
 
+import DynamicPolynomials as DP
+import MultivariatePolynomials as MP
+using SymbolicUtils: PolynomialT, poly_to_gcd_form, MonomialOrder
+
+# `to_poly!` returns `PolynomialT = DP.Polynomial{V,M,Number}` — the
+# coefficient eltype is the abstract `Number`. The previous broadcast form in
+# `poly_to_gcd_form` (`Integer.(coeffs)`, `rationalize.(...)`, `float.(...)`,
+# `(complex ∘ float).(...)`) preserved abstractness whenever the underlying
+# concrete element types were *heterogeneous* — e.g.
+# `Integer.(Number[Int8(1), Int64(-2), Int64(1)])` returns
+# `Vector{Signed}` rather than `Vector{Int64}`. The resulting
+# `DP.Polynomial` then carried an abstract type parameter
+# (`Signed` / `Integer` / `AbstractFloat` / `Real`), and `MP.gcd`'s
+# `isolate_variable` crashed downstream with a
+# `MethodError(Term{T,M} where T, (::Vector{Term{<:Any, M}},))`.
+#
+# Guard: each branch of `poly_to_gcd_form` must return a polynomial with a
+# *concrete* coefficient type even when the input vector is heterogeneous
+# within the relevant numeric kind.
+let v = only(DP.@polyvar __PolyToGcdFormTest__ monomial_order = MonomialOrder)
+    # CRITICAL: build the coefficient vector with the typed-literal form
+    # `Number[Int8(1), Int64(-2), Int64(1)]` rather than going through
+    # `Vector{Number}([…])` — the latter passes through an inner untyped
+    # literal which `promote_type`-normalises to the LUB element type
+    # (collapsing Int8+Int64 down to Int64 before reaching `Vector{Number}`),
+    # so the heterogeneity is gone and the bug doesn't reproduce.
+    function poly_with_coeffs(coeffs::Vector{Number}, monos_template)
+        DP.Polynomial(coeffs, MP.monomials(monos_template))
+    end
+
+    @testset "poly_to_gcd_form gives concrete coefficient eltype" begin
+        @testset "heterogeneous integer kinds (Int8 + Int64)" begin
+            # Pre-fix: `Integer.(Number[Int8(1), Int64(-2), Int64(1)])` →
+            # `Vector{Signed}` → polynomial type parameter `Signed` (abstract).
+            p = poly_with_coeffs(Number[Int8(1), Int64(-2), Int64(1)],
+                                  (1 - v) * (1 - v))   # 1 - 2v + v^2
+            @test p isa PolynomialT
+            g = poly_to_gcd_form(p)
+            T = eltype(MP.coefficients(g))
+            @test isconcretetype(T)
+            @test T <: Integer
+            @test MP.coefficients(g) == [1, -2, 1]
+        end
+
+        @testset "heterogeneous rational kinds (Rational{Int8} + Rational{Int64})" begin
+            p = poly_with_coeffs(Number[Rational{Int8}(1, 2), Rational{Int64}(-1, 3)],
+                                  (1//2 - v))
+            g = poly_to_gcd_form(p)
+            T = eltype(MP.coefficients(g))
+            @test isconcretetype(T)
+            @test T <: Rational
+        end
+
+        @testset "heterogeneous float kinds (Float32 + Float64)" begin
+            p = poly_with_coeffs(Number[Float32(1.5), Float64(-2.5)], (1.5 - v))
+            g = poly_to_gcd_form(p)
+            T = eltype(MP.coefficients(g))
+            @test isconcretetype(T)
+            @test T <: AbstractFloat
+        end
+
+        @testset "heterogeneous complex kinds (ComplexF32 + ComplexF64)" begin
+            p = poly_with_coeffs(Number[ComplexF32(1, 2), ComplexF64(0, 0.5)],
+                                  (1.0 + 2.0im - v))
+            g = poly_to_gcd_form(p)
+            T = eltype(MP.coefficients(g))
+            @test isconcretetype(T)
+            @test T <: Complex
+        end
+
+        @testset "MP.gcd works on heterogeneous-coefficient polynomials" begin
+            # On the buggy version this used to throw
+            # `MethodError(Term{T,M} where T, (::Vector{Term{<:Any, M}},))`
+            # via the `isolate_variable` path inside `multivariate_gcd`.
+            p1 = poly_with_coeffs(Number[Int8(1), Int64(-2), Int64(1)],
+                                   (1 - v) * (1 - v))     # 1 - 2v + v^2
+            p2 = poly_with_coeffs(Number[Int8(1), Int64(-1)],
+                                   (1 + v^2))             # 1 + v^2 (template; coeffs replaced)
+            g1 = poly_to_gcd_form(p1)
+            g2 = poly_to_gcd_form(p2)
+            @test gcd(g1, g2) isa DP.Polynomial
+        end
+    end
+end
+
+@testset "simplify_fractions doesn't crash on heterogeneous coefficients" begin
+    # End-to-end repro of the crash surfaced via SymbolicIntegration.jl's
+    # difficult-test verifier: a `simplify(num/den; expand=true)` whose num/den
+    # both go through `to_poly!` → `safe_gcd` → `poly_to_gcd_form`, where
+    # heterogeneous coefficient types (e.g. integers in `num` mixed with
+    # rationals/floats in `den`) used to send `MP.gcd` into the abstract-eltype
+    # `MethodError` path.
+    @syms x
+
+    # Mix of integer, rational, and float coefficients across num and den.
+    num = (x^4 - x^3 + 2x^2 - x + 2)
+    den = (x - 1) * (x^2 + 2)^2
+    @test simplify_fractions(num / den) isa Any   # just must not throw
+
+    # Float ↔ rational mix.
+    @test simplify_fractions((1.0 + 0.5*x - x^2) / ((1//2)*x^2 - 1)) isa Any
+end
+
 @testset "isone iszero" begin
     @syms a b c d e f g h i
     x = (f + ((((g*(c^2)*(e^2)) / d - e*h*(c^2)) / b + (-c*e*f*g) / d + c*e*i) /


### PR DESCRIPTION
## Summary

`poly_to_gcd_form` re-packs a polynomial via broadcast — `Integer.(MP.coefficients(p))`, `rationalize.(...)`, `(complex ∘ float).(...)`, `float.(...)`. Broadcast preserves the abstractness of the input vector's eltype: `Integer.(::Vector{Integer})` returns `Vector{Integer}`, not `Vector{Int}`. So when `to_poly!` produces a `DP.Polynomial` with an abstract coefficient eltype (which it does in plenty of `simplify_div` paths), we feed `MP.gcd` polynomials whose type parameter is `Integer` / `Signed` / `AbstractFloat` / `Real`, and `MP.gcd` crashes:

- in `isolate_variable`, the reconstructed `Vector{Term{<:Any, M}}` hits a `MethodError(Term{T,M} where T, (::Vector{Term{<:Any, M}},))` when MP tries to dispatch `Polynomial{V,M}(::Vector{Term})` through the generic fallback at `DP.poly.jl:100` (`Polynomial{V,M}(α) = Polynomial(_Term{V,M}(α))`), which in turn calls `Term{T,M}(::Vector{Term})` — a method that doesn't exist;
- or, when both sides were `AbstractFloat` / `Signed`, internal arithmetic eventually falls through to `gcd(::Float64, ::Float64)` (intentionally unimplemented).

Re-pack each branch's coefficients into a `Vector{T}` where `T` is the `promote_type` over the concrete element types — or a sane default for the empty-input edge case. The resulting `DP.Polynomial` then always carries a concrete type parameter and `MP.gcd` runs cleanly.

## Surfaced via SymbolicIntegration.jl

`simplify(integral_diff; expand=true)` inside [SymbolicIntegration.jl's difficult-test verifier](https://github.com/JuliaSymbolics/SymbolicIntegration.jl/blob/main/test/rundifficulttests.jl#L107) crashes with the `MethodError(MP.Term{T,M} where T, (::Vector{Term{_A, M} where _A},))` for several rationals in the Apostol corpus, e.g.

- `(2 - x + 2x^2 - x^3 + x^4) / ((-1 + x)·(2 + x^2)^2)`
- `1/(-1 + x^2)^2`
- `x^2 / (2 + 2x + x^2)^2`

The integration itself succeeds; only the symbolic equivalence check throws. With this patch the same `simplify` returns a real expression instead.

## Test plan

- [x] Locally reduced to a minimal bad input — abstract `Polynomial{V,M,Signed}` × `Polynomial{V,M,AbstractFloat}` going through `MP.gcd` reproduces the failure on `master`.
- [x] After the fix, the same `MP.gcd` call runs to completion and `simplify((x^4 - x^3 + 2x^2 - x + 2)/((x-1)·(x^2+2)^2) - <expected antiderivative>; expand=true)` no longer throws.
- [ ] CI green here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)