### PR TITLE
Cleanup Some Optimization Dispatches

### DIFF
--- a/src/code.jl
+++ b/src/code.jl
@@ -2026,6 +2026,7 @@ end
 
 apply_optimization_rules(expr, state, ::Nothing) = expr
 function apply_optimization_rules(expr, state, rules)
+    isnothing(rules) && return expr
     isempty(rules) && return expr
     for rule in sort(rules, by = x -> x.priority)
         expr_new = apply_optimization_rule(expr, state, rule)
@@ -2035,17 +2036,7 @@ function apply_optimization_rules(expr, state, rules)
     expr
 end
 
-function apply_optimization_rules(ir::IRStructure, expr, rules)
-    isnothing(rules) && return ir, expr
-    isempty(rules) && return ir, expr
-    for rule in sort(rules, by = x -> x.priority)
-        ir_new, expr_new = apply_optimization_rule(ir, expr, rule)
-        expr = expr_new
-        ir = ir_new
-    end
-    ir, expr
-end
-
+apply_optimization_rules(ir::IRStructure, expr::Any, ::Nothing) = ir, expr
 function apply_optimization_rule(ir::IRStructure, expr, rules)
     match_data = rules.detector(ir, expr)
     if match_data !== nothing
@@ -2068,14 +2059,4 @@ function apply_optimization_rules(ir::IRStructure, expr, rules)
     ir, expr
 end
 
-function apply_optimization_rule(ir::IRStructure, expr, rules)
-    match_data = rules.detector(ir, expr)
-    if match_data !== nothing
-        new_ir, new_expr = rules.transformer(ir, expr, match_data)
-        return new_ir, new_expr
-    end
-
-    return ir, expr
-
-end
 end


### PR DESCRIPTION
While passing `Code.apply_optimization_rules(::IRStructure, expr, ::Nothing)` returned `nothing` which breaks the contract of returning 2 quantities - the updated graph and the `expr`. This PR makes the fallback path consistently return the unchanged graph and `expr` when no optimization is requested.