### PR TITLE
 feat: make codegen work on non-canonical `IRStructure`

### DIFF
--- a/src/code.jl
+++ b/src/code.jl
@@ -21,6 +21,7 @@ import SymbolicUtils: @matchable, BasicSymbolic, Sym, Term, iscall, operation, a
                       AddMulVariant, _isone, _iszero, Fill, IRStructure, populate_ir!
 using Moshi.Match: @match
 import SymbolicIndexingInterface: symbolic_type, NotSymbolic
+import Graphs
 
 ##== state management ==##
 

--- a/src/faster_code.jl
+++ b/src/faster_code.jl
@@ -6,6 +6,16 @@ using Dictionaries
 # caching the length of the Dictionary at that point. This allows efficiently implementing
 # scoping behavior, for example for loop-local CSE variables.
 
+# NOTE:
+# Codegen relies on fewer invariants than `IRStructure` in general. It is designed to work
+# even when `ir.is_canonical[] == false`. The invariants that it relies on are:
+# 1. `operation(ir[idx::Integer])` is the correct operation to generate.
+# 2. `symtype(ir[idx])` and `shape(ir[idx])` are the correct symtype and shape of the expression.
+# 3. `outneighbors(ir.dependency_graph, idx)` corresponds in order to `arguments(ir[idx])`. In
+#    case `operation(ir[idx]) isa BasicSymbolic{T}`, it is the first element in `outneighbors`,
+#    followed by the arguments in order.
+# 4. If `isarrayop(ir[idx::Integer])`, then `ir[idx].term` is correct.
+
 """
     $TYPEDEF
 
@@ -337,12 +347,13 @@ function codegen_function! end
 function codegen_function!(::Type{ArrayOp{T}}, cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
     _allocator = get_allocator!(cs, zeros)
     output_buffer = codegen_allocator_call!(cs, _allocator, expr, expr_idx)
-    ranges, innerexpr, output_idx = @match expr begin
-        BSImpl.ArrayOp(; ranges, expr = innerexpr, output_idx) => begin
-            (ranges, innerexpr, output_idx)
-        end
-        _ => _unreachable()
-    end
+
+    # Use graph instead of destructuring `expr`
+    nbors = Graphs.outneighbors(cs.ir.dependency_graph, expr_idx)
+    innerexpr = cs.ir[nbors[2]]::BasicSymbolic{T}
+    reducer = unwrap_const(cs.ir[nbors[3]])
+    ranges = unwrap_const(cs.ir[nbors[5]])::SymbolicUtils.RangesT{T}
+
     new_ranges = RangesT{T}()
     new_expr = unidealize_indices(innerexpr, ranges, new_ranges)
 
@@ -351,18 +362,47 @@ function codegen_function!(::Type{ArrayOp{T}}, cs::CodegenState{T}, expr::BasicS
     inner_result = scoped_cs(new_expr)
 
     loopvar_order = BasicSymbolic{T}[]
-
     index_expr = Expr(:call, CartesianIndex)
-    @union_split_smallvec output_idx for i in output_idx
-        push!(index_expr.args, scoped_cs(i))
-        if i isa BasicSymbolic{T}
-            push!(loopvar_order, i)
+
+    # `output_idxs` can be empty/all integers/symbolic. The first two cases are captured by
+    # the `Const`, where all loops are reduction loops and we output a scalar or singleton
+    # array. If we have parallel loops, then `output_idxs` will contain symbolic entries and
+    # it will thus be present as an `array_literal`.
+    out_idx_sym = cs.ir[nbors[1]]
+    @match out_idx_sym begin
+        BSImpl.Const(; val) && if val isa SymbolicUtils.OutIdxT{T} end => begin
+            # If this is a `Const`, then none of the elements in `output_idx` are symbolic,
+            # so we never populate `loopvar_order`.
+            output_idx = val::SymbolicUtils.OutIdxT{T}
+            @union_split_smallvec output_idx for i in output_idx
+                push!(index_expr.args, scoped_cs(i))
+                if i isa BasicSymbolic{T}
+                    push!(loopvar_order, i)
+                end
+            end
+        end
+        BSImpl.Term(; f) && if f === SymbolicUtils.array_literal end => begin
+            # Get the neighbors of the `array_literal`.
+            out_idx_nbors = Graphs.outneighbors(cs.ir.dependency_graph, nbors[1])
+            # The first neighbor is the size tuple, so ignore it.
+            for out_idx_i in Iterators.drop(out_idx_nbors, 1)
+                out_idx = cs.ir[out_idx_i]
+                @match out_idx begin
+                    # Constant index - singleton dimension
+                    BSImpl.Const(; val) => push!(index_expr.args, val::Int)
+                    # Symbolic index - parallel loop
+                    _ => begin
+                        push!(index_expr.args, scoped_cs(out_idx))
+                        push!(loopvar_order, out_idx)
+                    end
+                end
+            end
         end
     end
     reverse!(loopvar_order)
     ref_expr = Expr(:ref, output_buffer, index_expr)
 
-    declare!(scoped_cs, :__accum, Expr(:call, :+, ref_expr, inner_result))
+    declare!(scoped_cs, :__accum, Expr(:call, reducer, ref_expr, inner_result))
     declare!(scoped_cs, :_, Expr(:(=), ref_expr, :__accum))
 
     merge!(new_ranges, ranges)
@@ -395,7 +435,8 @@ function codegen_function!(f::SymbolicUtils.Fill, cs::CodegenState{T}, expr::Bas
         output_buffer = codegen_allocator_call!(cs, _allocator, expr, expr_idx)
         push!(result.args, output_buffer)
     end
-    push!(result.args, cs(arguments(expr)[1]))
+
+    push!(result.args, cs(cs.ir[Graphs.outneighbors(cs.ir.dependency_graph, expr_idx)[1]]))
     if _allocator === nothing
         for ax in f.sh
             push!(result.args, length(ax))
@@ -452,10 +493,16 @@ end
 function codegen_function!(::Type{ArrayMaker{T}}, cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
     _allocator = get_allocator!(cs, zeros)
     len = length(expr)::Int
-    regions, values, sh = @match expr begin
-        BSImpl.ArrayMaker(; regions, values, shape) => (regions, values, shape)
-    end
+
+    expr_nbors = Graphs.outneighbors(cs.ir.dependency_graph, expr_idx)
+    regions = unwrap_const(cs.ir[expr_nbors[1]])::SymbolicUtils.RegionsT
+    values_expr_idx = expr_nbors[2]
+    values_args = Graphs.outneighbors(cs.ir.dependency_graph, values_expr_idx)
+    values_exprs_idxs = Iterators.drop(values_args, 1)
+    sh = shape(expr)
+
     if len <= FILL_ARR_LIMIT
+        expr = SymbolicUtils.get_canonical_expr(cs.ir, expr_idx)
         output_buffer = codegen_allocator_call!(cs, _allocator, expr, expr_idx)
         result = Expr(:call, fill_arr!, output_buffer)
         sz_expr = Expr(:tuple)
@@ -469,7 +516,7 @@ function codegen_function!(::Type{ArrayMaker{T}}, cs::CodegenState{T}, expr::Bas
         return declare!(cs, get_misc_identifier(cs), result)
     end
     
-    if _allocator !== zeros && isequal(regions[1], sh) && __is_fill_zero(values[1])
+    if _allocator !== zeros && isequal(regions[1], sh) && __is_fill_zero(cs.ir[first(values_exprs_idxs)])
         output_buffer = codegen_allocator_call!(
             cs, _allocator, expr, expr_idx;
             allocator_call_expr = __allocator_call_and_fill_expr
@@ -480,18 +527,34 @@ function codegen_function!(::Type{ArrayMaker{T}}, cs::CodegenState{T}, expr::Bas
         ndrop = 0
     end
     
-    @union_split_smallvec regions @union_split_smallvec values begin
-        for (region, val) in Iterators.drop(zip(regions, values), ndrop)
+    @union_split_smallvec regions begin
+        for (region, val_idx) in Iterators.drop(zip(regions, values_exprs_idxs), ndrop)
+            val = cs.ir[val_idx]
             # We are writing to a single element
             if all(isone ∘ length, region)
                 lhs = Expr(:ref, output_buffer)
                 @union_split_smallvec region for ax in region
                     push!(lhs.args, first(ax))
                 end
-                rhs = cs(val[SymbolicUtils.stable_eachindex(val)[1]])
+                # The most common case here is that `val` is an `array_literal` with one element.
+                # Instead of fetching the canonical expr for it, special case this to work on the
+                # graph.
+                rhs = @match val begin
+                    BSImpl.Term(; f) && if f === SymbolicUtils.array_literal end => begin
+                        first_val_idx = Graphs.outneighbors(cs.ir.dependency_graph, val_idx)[2]
+                        cs(cs.ir[first_val_idx])
+                    end
+                    _ => begin
+                        # Unfortunately, scalarizing `val` requires getting the canonical expr.
+                        val = cs(SymbolicUtils.get_canonical_expr(cs.ir, val_idx))
+                        cs(val[SymbolicUtils.stable_eachindex(val)[1]])
+                    end
+                end
                 declare!(cs, lhs, rhs)
                 continue
             end
+
+            # Materialize the view into the output buffer that we will write to.
             view_expr = Expr(:call, view, output_buffer)
             @union_split_smallvec region append!(view_expr.args, region)
             vw = declare!(cs, get_misc_identifier(cs), view_expr)
@@ -499,17 +562,23 @@ function codegen_function!(::Type{ArrayMaker{T}}, cs::CodegenState{T}, expr::Bas
                 # Replace the allocator. We want it to write directly to the output
                 # No point constructing a new expression, just do what `with_allocator`
                 # would do in `codegen_ir!`.
-                BSImpl.Term(; f, args) && if f === with_allocator end => begin
+                BSImpl.Term(; f) && if f === with_allocator end => begin
                     old_allocator = add_allocator!(cs, ExistingBufferAllocator(vw))
-                    cs(args[2])
+                    val_nbors = Graphs.outneighbors(cs.ir.dependency_graph, val_idx)
+                    cs(cs.ir[val_nbors[2]])
                     reset_allocator!(cs, old_allocator)
                 end
+                # Any other operation that supports `with_allocator` should be generated to
+                # write to the buffer directly.
                 _ && if supports_with_allocator(val) end => begin
                     old_allocator = add_allocator!(cs, ExistingBufferAllocator(vw))
                     cs(val)
                     reset_allocator!(cs, old_allocator)
                 end
+                # Constant arrays can special-case
                 BSImpl.Const(; val) => write_constant_array!(cs, vw, val)
+                # We don't have a fallback, so materialize the array corresponding to `val`
+                # and `copyto!` it into the output buffer.
                 _ => begin
                     temp_array = cs(val)
                     declare!(cs, get_misc_identifier(cs), Expr(:call, copyto!, vw, temp_array))
@@ -530,20 +599,21 @@ function codegen_function!(
         return codegen_function_no_nanmath!(SymbolicUtils.array_literal, cs, expr, expr_idx)
     end
     output_buffer = codegen_allocator_call!(cs, _allocator, expr, expr_idx)
-    args, sh = @match expr begin
-        BSImpl.Term(; args, shape) => (args, shape)
+    args_idxs = Graphs.outneighbors(cs.ir.dependency_graph, expr_idx)
+    sh = @match expr begin
+        BSImpl.Term(; shape) => shape
     end
 
     if length(expr)::Int <= FILL_ARR_LIMIT
-        result = Expr(:call, fill_arr!, output_buffer, Expr(:call, Val, unwrap_const(args[1])))
-        for arg in Iterators.drop(args, 1)
-            push!(result.args, cs(arg))
+        result = Expr(:call, fill_arr!, output_buffer, Expr(:call, Val, unwrap_const(cs.ir[first(args_idxs)])))
+        for arg_idx in Iterators.drop(args_idxs, 1)
+            push!(result.args, cs(cs.ir[arg_idx]))
         end
         return declare!(cs, get_misc_identifier(cs), result)
     end
 
-    @union_split_smallvec args for (idx, arg) in enumerate(Iterators.drop(args, 1))
-        declare!(cs, :_, Expr(:call, setindex!, output_buffer, cs(arg), idx))
+    for (idx, arg_idx) in enumerate(Iterators.drop(args_idxs, 1))
+        declare!(cs, :_, Expr(:call, setindex!, output_buffer, cs(cs.ir[arg_idx]), idx))
     end
 
     return output_buffer
@@ -557,37 +627,45 @@ const NARY_CALL_LIMIT = 12
 
 function codegen_function!(@nospecialize(op::Union{typeof(*), typeof(+)}), cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
     if get(cs.rewrites, :sort_addmul, true)::Bool
-        args = parent(sorted_arguments(expr))
+        @assert cs.ir.is_canonical[] "Sorted add/mul requires canonical IRStructure"
+        args_idxs = Int32[]
+        sargs = sorted_arguments(expr)
+        for arg in sargs
+            push!(args_idxs, cs.ir[arg])
+        end
+        # For type-stability, so it matches with the other branch
+        args_idxs = SymbolicUtils.AdjView{Int32}(args_idxs)
     else
-        args = parent(arguments(expr))
+        args_idxs = Graphs.outneighbors(cs.ir.dependency_graph, expr_idx)
     end
 
-    if length(args) == 1
-        return codegen!(cs, expr_idx, Expr(:call, op, cs(args[1])))
+    if length(args_idxs) == 1
+        return codegen!(cs, expr_idx, Expr(:call, op, cs(cs.ir[first(args_idxs)])))
     end
 
     if symtype(expr) <: Number
-        cur = Expr(:call, op, cs(args[1]))
-        for i in 2:length(args)
-            if i % NARY_CALL_LIMIT == 1
-                cur = Expr(:call, op, cur, cs(args[i]))
+        cur = Expr(:call, op)
+        for (i, idx) in enumerate(args_idxs)
+            if i % NARY_CALL_LIMIT == 0
+                cur = Expr(:call, op, cur, cs(cs.ir[idx]))
             else
-                push!(cur.args, cs(args[i]))
+                push!(cur.args, cs(cs.ir[idx]))
             end
         end
         return codegen!(cs, expr_idx, cur)
     end
 
     result = Expr(:call, op)
-    @union_split_smallvec args for arg in args
-        push!(result.args, cs(arg))
+    for idx in args_idxs
+        push!(result.args, cs(cs.ir[idx]))
     end
     return codegen!(cs, expr_idx, result)
 end
 
 function codegen_function!(op::typeof(^), cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
-    base, exp = arguments(expr)
-    base_sym = cs(base)
+    base_idx, exp_idx = Graphs.outneighbors(cs.ir.dependency_graph, expr_idx)
+    base_sym = cs(cs.ir[base_idx])
+    exp = cs.ir[exp_idx]
     @match exp begin
         BSImpl.Const(; val) => begin
             if val isa Real
@@ -616,21 +694,20 @@ function codegen_function!(op::typeof(^), cs::CodegenState{T}, expr::BasicSymbol
 end
 
 function codegen_function!(::typeof(ifelse), cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
-    cond, iftrue, iffalse = arguments(expr)
-    return codegen!(cs, expr_idx, Expr(:if, cs(cond), cs(iftrue), cs(iffalse)))
+    cond_idx, true_idx, false_idx = Graphs.outneighbors(cs.ir.dependency_graph, expr_idx)
+    return codegen!(cs, expr_idx, Expr(:if, cs(cs.ir[cond_idx]), cs(cs.ir[true_idx]), cs(cs.ir[false_idx])))
 end
 
 function codegen_function_no_nanmath!(@nospecialize(op), cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
     result = Expr(:call)
-    if op isa BasicSymbolic{T}
-        opsym = cs(op)
-        push!(result.args, opsym)
-    else
+    if !(op isa BasicSymbolic{T})
         push!(result.args, op)
     end
-    args = parent(arguments(expr))
-    @union_split_smallvec args for arg in args
-        push!(result.args, cs(arg))
+    # If the operation is symbolic, we'll push it as the function to call here.
+    # If it isn't symbolic, we'll push it above and here we add the arguments.
+    nbors = Graphs.outneighbors(cs.ir.dependency_graph, expr_idx)
+    for nbor in nbors
+        push!(result.args, cs(cs.ir[nbor]))
     end
     return codegen!(cs, expr_idx, result)
 end
@@ -674,14 +751,14 @@ function codegen_function!(@nospecialize(op), cs::CodegenState{T}, expr::BasicSy
 end
 
 function codegen_function!(::typeof(getindex), cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
-    args = parent(arguments(expr))
-    if isequal(args[1], SymbolicUtils.idxs_for_arrayop(T))
-        offset = unwrap_const(args[2])::Int
+    args_idxs = Graphs.outneighbors(cs.ir.dependency_graph, expr_idx)
+    if isequal(cs.ir[first(args_idxs)], SymbolicUtils.idxs_for_arrayop(T))
+        offset = unwrap_const(cs.ir[args_idxs[2]])::Int
         return codegen_arrayop_indexer(offset)
     end
     result = Expr(:ref)
-    @union_split_smallvec args for arg in args
-        push!(result.args, cs(arg))
+    for idx in args_idxs
+        push!(result.args, cs(cs.ir[idx]))
     end
     return codegen!(cs, expr_idx, result)
 end
@@ -694,11 +771,9 @@ function codegen_function!(@nospecialize(op::SymbolicUtils.Mapper), cs::CodegenS
     else
         push!(result.args, fn)
     end
-    args = @match expr begin
-        BSImpl.Term(; args) => args
-    end
-    @union_split_smallvec args for arg in args
-        push!(result.args, cs(arg))
+    args_idxs = Graphs.outneighbors(cs.ir.dependency_graph, expr_idx)
+    for idx in args_idxs
+        push!(result.args, cs(cs.ir[idx]))
     end
     return codegen!(cs, expr_idx, result)
 end
@@ -737,11 +812,9 @@ function codegen_function!(@nospecialize(op::SymbolicUtils.Mapreducer), cs::Code
     else
         push!(result.args, reducer)
     end
-    args = @match expr begin
-        BSImpl.Term(; args) => args
-    end
-    @union_split_smallvec args for arg in args
-        push!(result.args, cs(arg))
+    args_idxs = Graphs.outneighbors(cs.ir.dependency_graph, expr_idx)
+    for idx in args_idxs
+        push!(result.args, cs(cs.ir[idx]))
     end
     return codegen!(cs, expr_idx, result)
 end
@@ -792,7 +865,7 @@ function codegen_ir!(cs::CodegenState{T}, idx::Integer) where {T}
             return codegen_function!(ArrayOp{T}, cs, sym, idx)
         end
         BSImpl.ArrayMaker(;) => return codegen_function!(ArrayMaker{T}, cs, sym, idx)
-        BSImpl.Term(; f, args) => begin
+        BSImpl.Term(; f) => begin
             if f === (^)
                 return codegen_function!(^, cs, sym, idx)
             elseif f === ifelse
@@ -800,16 +873,19 @@ function codegen_ir!(cs::CodegenState{T}, idx::Integer) where {T}
             elseif f === getindex
                 return codegen_function!(getindex, cs, sym, idx)
             elseif f === with_allocator
-                old_allocator = add_allocator!(cs, args[1])
-                result = cs(args[2])
+                args_idxs = Graphs.outneighbors(ir.dependency_graph, idx)
+                new_allocator = ir[first(args_idxs)]
+                old_allocator = add_allocator!(cs, new_allocator)
+                result = cs(ir[args_idxs[2]])
                 reset_allocator!(cs, old_allocator)
                 return result
             else
                 return codegen_function!(f, cs, sym, idx)::Symbol
             end
         end
-        BSImpl.Div(; num, den) => begin
-            return codegen!(cs, idx, Expr(:call, /, cs(num), cs(den)))
+        BSImpl.Div(;) => begin
+            num_idx, den_idx = Graphs.outneighbors(ir.dependency_graph, idx)
+            return codegen!(cs, idx, Expr(:call, /, cs(ir[num_idx]), cs(ir[den_idx])))
         end
         BSImpl.AddMul(; variant) => if variant === AddMulVariant.ADD
             return codegen_function!((+), cs, sym, idx)

--- a/src/irstructure.jl
+++ b/src/irstructure.jl
@@ -343,31 +343,32 @@ function (pc::PopulateClosure{T})() where {T}
     # `outneighbors`
     expr_uses = Int32[]
     if iscall(expr)
+        # `op` must be processed before `args` to maintain the `outneighbors` ordering
+        # invariant: op prefixes the arg neighbors when op isa BasicSymbolic{T}.
+        op = operation(expr)
+        if op isa BasicSymbolic{T}
+            op_idx = populate_ir!(ir, op)
+            push!(expr_uses, op_idx)
+        end
         args = parent(arguments(expr))
-        # This avoids a lot of allocations
         sizehint!(expr_uses, length(args))
         @union_split_smallvec args for arg in args
             # Add each argument to the IR. This is effectively a postorder traversal.
             arg_idx = populate_ir!(ir, arg)
             push!(expr_uses, arg_idx)
         end
-        op = operation(expr)
-        if op isa BasicSymbolic{T}
-            op_idx = populate_ir!(ir, op)
-            push!(expr_uses, op_idx)
-        end
     end
-    # Sorting ensures `add_edge!` is a `push!`
-    sort!(expr_uses)
+    # Edges are added in argument order to preserve the outneighbors == arguments invariant.
     Graphs.add_vertex!(ir.dependency_graph)
     idx = Graphs.nv(ir.dependency_graph)
     for dst in expr_uses
         Graphs.add_edge!(ir.dependency_graph, idx, dst)
     end
+    empty!(expr_uses)
     # Add `expr` to the IR
     push!(ir.symbols, expr)
 
-    buffer = get!(() -> Int32[], ir.weak_definitions, expr)
+    buffer = get!(Returns(expr_uses), ir.weak_definitions, expr)
     push!(buffer, idx)
 
     return idx

--- a/src/irstructure.jl
+++ b/src/irstructure.jl
@@ -26,6 +26,10 @@ struct IRStructure{T}
     Dependency graph (DAG), where `Graphs.outneighbors(g, v)` denotes the nodes that the
     expression at index `v` depends on. In other words, `outneighbors` is the analogue of
     `arguments`.
+
+    Specifically, `outneighbors` is guaranteed to have the same order as `arguments`. In
+    case the operation is also symbolic, it will prefix the neighbors corresponding to the
+    arguments. This invariant is maintained even when the canonical form is broken.
     """
     dependency_graph::OrderedDiGraph{Int32}
     """
@@ -51,6 +55,15 @@ struct IRStructure{T}
     Similar to `cached_mask` but a `Vector{Int32}`.
     """
     cached_idxs::Vector{Int32}
+    """
+    Flag indicating whether the struct is in canonical form. Canonical form implies that
+    for an expression `ex` at index `idx` in `ir::IRStructure`, there exists an edge
+    from `idx` to `ir[arguments(ex)[j]]` for all valid `j` and that
+    `arguments(ex)[j] === ir[ir[arguments(ex)[j]]]`. This is typically broken by
+    [`SymbolicUtils.replace_node!`](@ref). The graph invariants are still maintained
+    after the canonical form is broken.
+    """
+    is_canonical::Base.RefValue{Bool}
 end
 
 """
@@ -62,7 +75,7 @@ function IRStructure{T}() where {T}
     ir = IRStructure{T}(
         OrderedDiGraph{Int32}(), BasicSymbolic{T}[],
         IdDict{BasicSymbolic{T}, Int32}(), Dict{BasicSymbolic{T}, Vector{Int32}}(),
-        BitVector(), Int32[]
+        BitVector(), Int32[], Ref{Bool}(true)
     )
     # It's pretty easy to hit this
     sizehint!(ir, 100)
@@ -100,6 +113,22 @@ Get the cached `Vector{Int32}` inside IR.
 """
 function get_cached_idxs!(ir::IRStructure)
     return ir.cached_idxs
+end
+
+struct IRStructureNotCanonicalError <: Exception
+end
+
+function Base.showerror(io::IO, err::IRStructureNotCanonicalError)
+    print(io, """
+    This operation requires the `IRStructure` to be in canonical form. Canonical form \
+    is typically broken when `SymbolicUtils.replace_node!` is used. Prefer using \
+    `SymbolicUtils.IRSubstituter` to maintain canonical form at the cost of performance.
+    """)
+end
+
+@noinline function require_canonical(ir::IRStructure)
+    ir.is_canonical[] && return
+    throw(IRStructureNotCanonicalError())
 end
 
 """
@@ -652,6 +681,12 @@ Perform the substitution on element `idx` in the IR, returning the index of the 
 element.
 """
 function substitute_ir!(sub::IRSubstituter{Fold, T}, idx::Int32) where {Fold, T}
+    # Substitution requires checking if argument expressions are present in the
+    # substitution rules. If canonical form is violated, the symbolic expressions
+    # are not necessarily accurate and thus substitution cannot be guaranteed to
+    # work correctly.
+    require_canonical(sub.ir)
+
     (; rules, filterer, ir) = sub
 
     # Check the cache, filter, and rules for `idx`

--- a/src/irstructure.jl
+++ b/src/irstructure.jl
@@ -850,3 +850,63 @@ function replace_node!(ir::IRStructure{T}, old::BasicSymbolic{T}, new::BasicSymb
     return nothing
 end
 
+"""
+    $TYPEDSIGNATURES
+
+If `ir.is_canonical[]`, return `ir[idx]`. Otherwise, find the canonical expression that `ir[idx]`
+should be, were `IRSubstituter` used instead of `replace_node!`.
+"""
+function get_canonical_expr(ir::IRStructure{T}, idx::Integer) where {T}
+    ir.is_canonical[] && return ir[idx]
+
+    return __get_canonical_expr(ir, idx)
+end
+
+"""
+    $TYPEDSIGNATURES
+
+Helper function for `get_canonical_expr`. Returns the canonical expression at index `idx`
+by recursively descending through the DAG.
+"""
+function __get_canonical_expr(ir::IRStructure{T}, idx::Integer) where {T}
+    i_sym = ir[idx]
+    nbors = Graphs.outneighbors(ir.dependency_graph, idx)
+    # If this is a leaf, there's nothing to do
+    isempty(nbors) && return i_sym
+
+    # Track whether the expression actually needs to change
+    dirty = false
+    n_drop = 0
+    op = operation(i_sym)
+    # If the operation is symbolic, it is the first entry in `nbors`.
+    if op isa BasicSymbolic{T}
+        n_drop = 1
+        new_op = __get_canonical_expr(ir, first(nbors))
+        # If the operation is different, the tree is dirty
+        if new_op !== op
+            op = new_op
+            dirty = true
+        end
+    end
+    new_args = parent(arguments(i_sym))
+    # Avoid copying and allocating a new buffer if possible
+    args_dirty = false
+    for (i, arg_idx) in enumerate(Iterators.drop(nbors, n_drop))
+        new_expr = __get_canonical_expr(ir, arg_idx)
+        # If the argument changed, then it is dirty
+        if new_expr !== new_args[i]
+            # Allocate a new buffer if we haven't already
+            if !args_dirty
+                new_args = copy(new_args)
+            end
+            dirty = true
+            args_dirty = true
+            new_args[i] = new_expr
+        end
+    end
+
+    # If the expression is unchanged, no need to do anything
+    dirty || return i_sym
+    # Build the new canonical expression
+    return maketerm(BasicSymbolic{T}, op, new_args, metadata(i_sym))::BasicSymbolic{T}
+end

--- a/src/irstructure.jl
+++ b/src/irstructure.jl
@@ -814,3 +814,38 @@ function (sub::IRSubstituter{Fold, T})(expr::BasicSymbolic{T}) where {Fold, T}
     return ir[newidx]
 end
 
+"""
+    $TYPEDSIGNATURES
+
+Replace the expression `old` in `ir` with the expression `new`. `old` must already exist in `ir`.
+Note that this is not symbolic substitution, since any expressions that depend on `old` will not
+be updated. This will simply update the internal graph data structure such that the expression
+at `old` is now `new`, and the arguments of `new` form the out-neighbors of the vertex. This breaks
+the canonical form of `ir`.
+"""
+function replace_node!(ir::IRStructure{T}, old::BasicSymbolic{T}, new::BasicSymbolic{T}) where {T}
+    ir.is_canonical[] = false
+    idx = ir[old]
+    ir.symbols[idx] = new
+    delete!(ir.definition, old)
+    weakdefs = ir.weak_definitions[old]
+    filter!(!isequal(idx), weakdefs)
+    isempty(weakdefs) && delete!(ir.weak_definitions, old)
+
+    buffer = get!(() -> Int32[], ir.weak_definitions, new)
+    push!(buffer, idx)
+
+    iszero(Graphs.outdegree(ir.dependency_graph, idx)) && return
+
+    rem_outedges!(ir.dependency_graph, idx)
+    op = operation(new)
+    if op isa BasicSymbolic{T}
+        Graphs.add_edge!(ir.dependency_graph, idx, populate_ir!(ir, op))
+    end
+    args = parent(arguments(new))
+    @union_split_smallvec args for arg in args
+        Graphs.add_edge!(ir.dependency_graph, idx, populate_ir!(ir, arg))
+    end
+    return nothing
+end
+

--- a/src/ordereddigraph.jl
+++ b/src/ordereddigraph.jl
@@ -5,6 +5,8 @@ A directed graph where the forward adjacency list preserves edge insertion
 order. Mirrors `Graphs.SimpleDiGraph` with two differences:
 - `outneighbors(g, v)` returns neighbors in the order edges were inserted.
 - `inneighbors(g, v)` returns an `AdjView` (unordered); membership tests are O(1).
+- Multi-edges are supported: the same `(src, dst)` pair may appear more than
+  once in `fadjlist`, each occurrence representing a distinct edge.
 
 ### Adjacency representation
 
@@ -12,12 +14,13 @@ Each entry of `fadjlist` is a `Union{NTuple{2,T}, Vector{T}}`:
 - `NTuple{2,T}` for vertices with 0, 1, or 2 out-edges. `zero(T)` is a
   sentinel: `(0,0)` means 0 edges, `(dst,0)` means 1 edge, `(a,b)` (both
   non-zero) means 2 edges. Non-zero entries always occupy the front slots.
-- `Vector{T}` once a vertex acquires a third out-edge. The vector is never
-  shrunk back to a tuple after removal.
+- `Vector{T}` once a vertex acquires a third out-edge.
 
 Each entry of `badjlist` is a `Union{NTuple{2,T}, Set{T}}`:
 - `NTuple{2,T}` for vertices with 0, 1, or 2 in-edges (same sentinel convention).
-- `Set{T}` once a vertex acquires a third in-edge. Never shrunk back to a tuple.
+- `Set{T}` once a vertex acquires a third in-edge.
+- Each source vertex is recorded **at most once**, regardless of how many
+  parallel edges connect it to the destination.
 
 For example, after inserting edges `2 => 3`, `1 => 3`, `1 => 2` in that order:
 - `outneighbors(g, 1)` returns `[3, 2]`
@@ -103,11 +106,14 @@ end
 Base.eltype(::Type{AdjView{T}}) where {T} = T
 
 # length and membership dispatch through _flen / _fin (defined for all three).
-Base.length(v::AdjView) = _flen(v.entry)
-Base.in(x, v::AdjView) = _fin(v.entry, x)
+@inline Base.length(v::AdjView) = _flen(v.entry)
+@inline Base.in(x, v::AdjView) = _fin(v.entry, x)
 
 # getindex: valid only for ordered backing (NTuple / Vector).
-Base.getindex(v::AdjView, i::Int) = _fget(v.entry, i)
+Base.@propagate_inbounds function Base.getindex(v::AdjView, i::Int)
+    @boundscheck 1 <= i <= length(v)
+    _fget(v.entry, i)
+end
 
 # --- iterate: manual union-split on entry type ---
 # NTuple and Vector use sequential Int indices as state; Set uses its internal
@@ -317,8 +323,6 @@ function Graphs.add_edge!(g::OrderedDiGraph{T}, e::Graphs.Edge{T}) where {T}
 
     @inbounds entry = g.fadjlist[s]
     @inbounds bentry = g.badjlist[d]
-    # Parallel edge guard. This checks `bentry` since it is a `Set`.
-    _fin(bentry, s) && return false  # parallel edge guard
 
     if entry isa Vector{T}
         push!(entry, d)
@@ -334,16 +338,19 @@ function Graphs.add_edge!(g::OrderedDiGraph{T}, e::Graphs.Edge{T}) where {T}
     end
 
     g.ne += 1
-    if bentry isa Set{T}
-        push!(bentry, s)
-    else
-        a, b = bentry
-        if iszero(a)
-            @inbounds g.badjlist[d] = (s, zero(T))
-        elseif iszero(b)
-            @inbounds g.badjlist[d] = (a, s)
+    # Record s in badjlist[d] only if not already present (deduplication).
+    if !_fin(bentry, s)
+        if bentry isa Set{T}
+            push!(bentry, s)
         else
-            @inbounds g.badjlist[d] = Set{T}((a, b, s))
+            a, b = bentry
+            if iszero(a)
+                @inbounds g.badjlist[d] = (s, zero(T))
+            elseif iszero(b)
+                @inbounds g.badjlist[d] = (a, s)
+            else
+                @inbounds g.badjlist[d] = Set{T}((a, b, s))
+            end
         end
     end
     return true
@@ -355,57 +362,6 @@ end
 
 function Graphs.add_edge!(g::OrderedDiGraph{T}, e::Graphs.AbstractEdge) where {T}
     return Graphs.add_edge!(g, T(Graphs.src(e)), T(Graphs.dst(e)))
-end
-
-function Graphs.rem_edge!(g::OrderedDiGraph{T}, e::Graphs.Edge{T}) where {T}
-    s, d = Graphs.src(e), Graphs.dst(e)
-    verts = Graphs.vertices(g)
-    (s in verts && d in verts) || return false
-
-    @inbounds entry = g.fadjlist[s]
-    if entry isa Vector{T}
-        idx = findfirst(==(d), entry)
-        idx === nothing && return false
-        deleteat!(entry, idx)
-    else
-        a, b = entry
-        if iszero(a)
-            return false
-        elseif iszero(b)
-            a == d || return false
-            @inbounds g.fadjlist[s] = (zero(T), zero(T))
-        else
-            if a == d
-                @inbounds g.fadjlist[s] = (b, zero(T))
-            elseif b == d
-                @inbounds g.fadjlist[s] = (a, zero(T))
-            else
-                return false
-            end
-        end
-    end
-
-    g.ne -= 1
-    @inbounds bentry = g.badjlist[d]
-    if bentry isa Set{T}
-        delete!(bentry, s)
-    else
-        a, b = bentry
-        if iszero(b)
-            @inbounds g.badjlist[d] = (zero(T), zero(T))
-        else
-            @inbounds g.badjlist[d] = a == s ? (b, zero(T)) : (a, zero(T))
-        end
-    end
-    return true
-end
-
-function Graphs.rem_edge!(g::OrderedDiGraph{T}, s::Integer, d::Integer) where {T}
-    return Graphs.rem_edge!(g, Graphs.Edge{T}(T(s), T(d)))
-end
-
-function Graphs.rem_edge!(g::OrderedDiGraph{T}, e::Graphs.AbstractEdge) where {T}
-    return Graphs.rem_edge!(g, T(Graphs.src(e)), T(Graphs.dst(e)))
 end
 
 """
@@ -426,13 +382,17 @@ function rem_outedges!(g::OrderedDiGraph{T}, v::Integer) where {T}
         if iszero(b)
             g.ne -= 1
         else
-            _rem_badjlist_entry!(g, b, T(v))
+            # Skip badjlist removal for b if it equals a (multi-edge: already removed).
+            a != b && _rem_badjlist_entry!(g, b, T(v))
             g.ne -= 2
         end
     else
         n = length(entry::Vector{T})
         for d in entry::Vector{T}
-            _rem_badjlist_entry!(g, d, T(v))
+            # Guard against double-removal for duplicate destinations (multi-edges).
+            if _fin(@inbounds(g.badjlist[d]), T(v))
+                _rem_badjlist_entry!(g, d, T(v))
+            end
         end
         g.ne -= n
     end

--- a/src/ordereddigraph.jl
+++ b/src/ordereddigraph.jl
@@ -66,6 +66,21 @@ end
 @inline _fin(v::Vector, x) = x in v
 @inline _fin(s::Set, x) = x in s
 
+# Remove s from badjlist[d]. Assumes the edge s→d exists.
+@inline function _rem_badjlist_entry!(g::OrderedDiGraph{T}, d::T, s::T) where {T}
+    @inbounds bentry = g.badjlist[d]
+    if bentry isa Set{T}
+        delete!(bentry, s)
+    else
+        a, b = bentry
+        if iszero(b)
+            @inbounds g.badjlist[d] = (zero(T), zero(T))
+        else
+            @inbounds g.badjlist[d] = a == s ? (b, zero(T)) : (a, zero(T))
+        end
+    end
+end
+
 #
 # AdjView{T}: lightweight non-allocating view over an adjacency list entry.
 # The entry field stores one of three concrete backing types:
@@ -391,6 +406,39 @@ end
 
 function Graphs.rem_edge!(g::OrderedDiGraph{T}, e::Graphs.AbstractEdge) where {T}
     return Graphs.rem_edge!(g, T(Graphs.src(e)), T(Graphs.dst(e)))
+end
+
+"""
+    rem_outedges!(g::OrderedDiGraph, v) -> Bool
+
+Remove all outgoing edges from vertex `v` in `g`. The backward adjacency lists
+of every out-neighbor of `v` are updated accordingly. Returns `true` on success,
+`false` if `v` is not a vertex of `g`.
+"""
+function rem_outedges!(g::OrderedDiGraph{T}, v::Integer) where {T}
+    Graphs.has_vertex(g, v) || return false
+    @inbounds entry = g.fadjlist[v]
+
+    if entry isa NTuple{2, T}
+        a, b = entry
+        iszero(a) && return true
+        _rem_badjlist_entry!(g, a, T(v))
+        if iszero(b)
+            g.ne -= 1
+        else
+            _rem_badjlist_entry!(g, b, T(v))
+            g.ne -= 2
+        end
+    else
+        n = length(entry::Vector{T})
+        for d in entry::Vector{T}
+            _rem_badjlist_entry!(g, d, T(v))
+        end
+        g.ne -= n
+    end
+
+    @inbounds g.fadjlist[v] = (zero(T), zero(T))
+    return true
 end
 
 Graphs.rem_vertex!(g::OrderedDiGraph, v::Integer) =

--- a/test/irstructure.jl
+++ b/test/irstructure.jl
@@ -329,6 +329,56 @@ end
     end
 end
 
+@testset "`get_canonical_expr`" begin
+    @testset "Canonical IR: returns ir[idx] directly" begin
+        ir = IRStructure{SymReal}()
+        expr = x + sin(y)
+        populate_ir!(ir, expr)
+        @test ir.is_canonical[]
+        idx = ir[expr]
+        @test SU.get_canonical_expr(ir, idx) === ir[idx]
+    end
+
+    @testset "Non-canonical, unaffected subtree: returns same object" begin
+        ir = IRStructure{SymReal}()
+        populate_ir!(ir, sin(x))
+        populate_ir!(ir, cos(y))
+        sin_idx = ir[sin(x)]
+        replace_node!(ir, y, x)   # affects cos(y) only, not sin(x)
+        @test !ir.is_canonical[]
+        @test SU.get_canonical_expr(ir, sin_idx) === ir[sin_idx]
+    end
+
+    @testset "After leaf replacement: parent argument updated" begin
+        ir = IRStructure{SymReal}()
+        populate_ir!(ir, sin(x))
+        sin_idx = ir[sin(x)]
+        replace_node!(ir, x, y)
+        @test !ir.is_canonical[]
+        @test isequal(SU.get_canonical_expr(ir, sin_idx), sin(y))
+    end
+
+    @testset "After callable replacement: grandparent updated" begin
+        ir = IRStructure{SymReal}()
+        populate_ir!(ir, cos(x + y))
+        cos_idx = ir[cos(x + y)]
+        replace_node!(ir, x + y, x * y)
+        @test !ir.is_canonical[]
+        @test isequal(SU.get_canonical_expr(ir, cos_idx), cos(x * y))
+    end
+
+    @testset "Symbolic operation: arg replaced (n_drop=1 path)" begin
+        # fn is a symbolic function; operation(fn(x)) isa BasicSymbolic, so the op
+        # node is the first outneighbor and must be skipped when iterating args.
+        ir = IRStructure{SymReal}()
+        populate_ir!(ir, fn(x))
+        fn_x_idx = ir[fn(x)]
+        replace_node!(ir, x, y)
+        @test !ir.is_canonical[]
+        @test isequal(SU.get_canonical_expr(ir, fn_x_idx), fn(y))
+    end
+end
+
 @testset "`IRSubstituter`" begin
     expr = x + 2y + 3sin(z + fn(w[1] + sum(w) * tanh(w'w)))
     ir = IRStructure{SymReal}()

--- a/test/irstructure.jl
+++ b/test/irstructure.jl
@@ -218,6 +218,24 @@ end
         check_edge_ordering_invariant(ir)
     end
 
+    @testset "array_literal with duplicated arguments" begin
+        # Const{T}([x, y, x]) creates an array_literal Term whose argument list is
+        # [Const((3,)), x, y, x].  Because x appears twice, the dependency graph
+        # must have two edges from the array_literal node to ir[x] (multi-edges).
+        arr = SU.Const{SymReal}([x, y, x])
+        @test operation(arr) === SymbolicUtils.array_literal
+        ir = IRStructure{SymReal}()
+        populate_ir!(ir, arr)
+        check_edge_ordering_invariant(ir)
+        arr_idx = ir[arr]
+        nbors = collect(Graphs.outneighbors(ir.dependency_graph, arr_idx))
+        x_idx = ir.definition[x]
+        # x must appear at position 2 and 4 of outneighbors (after the size Const)
+        @test count(==(x_idx), nbors) == 2
+        @test nbors[2] == x_idx
+        @test nbors[4] == x_idx
+    end
+
     @testset "After replace_node! (symbolic op)" begin
         @syms ordtest_replace_fn(..)
         ir = IRStructure{SymReal}()

--- a/test/irstructure.jl
+++ b/test/irstructure.jl
@@ -230,6 +230,105 @@ end
     end
 end
 
+@testset "`replace_node!`" begin
+    @testset "Leaf replacement" begin
+        # Replacing a leaf: edges unchanged (early return after symbol update)
+        ir = IRStructure{SymReal}()
+        populate_ir!(ir, sin(x))
+        x_idx = ir[x]
+        n_before = length(ir)
+
+        replace_node!(ir, x, y)
+
+        @test isequal(ir[x_idx], y)
+        @test length(ir) == n_before          # no new node created
+        @test !haskey(ir.definition, x)       # old removed from definition
+        @test x_idx in ir.weak_definitions[y] # new registered at same index
+        @test !ir.is_canonical[]
+        # leaf had no outgoing edges; they are still absent
+        @test isempty(Graphs.outneighbors(ir.dependency_graph, x_idx))
+    end
+
+    @testset "Callable → callable, non-symbolic op" begin
+        ir = IRStructure{SymReal}()
+        populate_ir!(ir, x + y)
+        idx    = ir[x + y]
+        n_before = length(ir)
+
+        replace_node!(ir, x + y, x * y)
+
+        @test isequal(ir[idx], x * y)
+        @test length(ir) == n_before          # no new node for the expression itself
+        @test !haskey(ir.definition, x + y)
+        @test idx in ir.weak_definitions[x * y]
+        @test !ir.is_canonical[]
+        # outneighbors now match x*y's arguments in argument order
+        nbors    = collect(Graphs.outneighbors(ir.dependency_graph, idx))
+        expected = [ir.definition[arg] for arg in arguments(x * y)
+                    if arg isa BasicSymbolic{SymReal}]
+        @test nbors == expected
+    end
+
+    @testset "Callable → callable, symbolic op" begin
+        @syms rn_symfn(..)
+        ir = IRStructure{SymReal}()
+        populate_ir!(ir, x + y)
+        idx = ir[x + y]
+
+        replace_node!(ir, x + y, rn_symfn(x, y))
+
+        @test isequal(ir[idx], rn_symfn(x, y))
+        @test !haskey(ir.definition, x + y)
+        @test !ir.is_canonical[]
+        # symbolic op must be first outneighbor, then args in order
+        nbors = collect(Graphs.outneighbors(ir.dependency_graph, idx))
+        @test nbors[1] == ir.definition[rn_symfn]
+        @test nbors[2] == ir.definition[x]
+        @test nbors[3] == ir.definition[y]
+    end
+
+    @testset "Missing arguments are added to IR" begin
+        ir = IRStructure{SymReal}()
+        populate_ir!(ir, x + y)          # IR contains x, y, x+y; t absent
+        @test !haskey(ir.definition, t)
+        n_before = length(ir)
+
+        replace_node!(ir, x + y, x + t)
+
+        @test haskey(ir.definition, t)   # t was inserted by populate_ir! inside replace_node!
+        @test length(ir) == n_before + 1
+    end
+
+    @testset "old weak_definitions entry is pruned" begin
+        ir = IRStructure{SymReal}()
+        populate_ir!(ir, x + y)
+        idx = ir[x + y]
+        @test idx in ir.weak_definitions[x + y]
+
+        replace_node!(ir, x + y, x * y)
+
+        old_defs = get(ir.weak_definitions, x + y, Int32[])
+        @test !(idx in old_defs)
+    end
+
+    @testset "Old outgoing edges are removed" begin
+        ir = IRStructure{SymReal}()
+        populate_ir!(ir, x + y)
+        idx   = ir[x + y]
+        x_idx = ir[x]
+        y_idx = ir[y]
+        # Before: idx → x_idx and idx → y_idx
+        @test x_idx in Graphs.outneighbors(ir.dependency_graph, idx)
+        @test y_idx in Graphs.outneighbors(ir.dependency_graph, idx)
+
+        replace_node!(ir, x + y, sin(x))   # different arg set
+
+        nbors = collect(Graphs.outneighbors(ir.dependency_graph, idx))
+        @test !(y_idx in nbors)             # y is no longer a dependency
+        @test x_idx in nbors               # x is still used
+    end
+end
+
 @testset "`IRSubstituter`" begin
     expr = x + 2y + 3sin(z + fn(w[1] + sum(w) * tanh(w'w)))
     ir = IRStructure{SymReal}()

--- a/test/irstructure.jl
+++ b/test/irstructure.jl
@@ -220,7 +220,7 @@ function make_reversed_ir(T, root_expr::BasicSymbolic)
             end
         end
     end
-    IRStructure{T}(dep_graph, reversed_symbols, reversed_def, Dict{BasicSymbolic{T}, Int32}(), BitVector(), Int32[])
+    IRStructure{T}(dep_graph, reversed_symbols, reversed_def, Dict{BasicSymbolic{T}, Vector{Int32}}(), BitVector(), Int32[], Ref{Bool}(true))
 end
 
 @testset "Out-of-order IRStructure" begin

--- a/test/irstructure.jl
+++ b/test/irstructure.jl
@@ -1,5 +1,5 @@
 using SymbolicUtils
-using SymbolicUtils: BasicSymbolic, IRStructure, IRSubstituter, populate_ir!, subset_ir, get_reachability
+using SymbolicUtils: BasicSymbolic, IRStructure, IRSubstituter, populate_ir!, subset_ir, get_reachability, replace_node!
 import SymbolicUtils as SU
 import Graphs
 
@@ -159,6 +159,75 @@ end
     @test occursin("\e[33m%", colored)
     # Plain output (no color context) must not contain escape codes
     @test !occursin('\e', atomic_output)
+end
+
+@testset "Edge/outneighbor ordering invariant" begin
+    # Verify that outneighbors of each callable node agree with the invariant:
+    # - For a non-symbolic op:  outneighbors == [ir[arg] for arg in arguments(expr)]
+    # - For a symbolic op:       outneighbors == [ir[op], ir[arg1], ir[arg2], ...]
+    function check_edge_ordering_invariant(ir::IRStructure{T}) where {T}
+        g = ir.dependency_graph
+        for i in eachindex(ir)
+            sym = ir[i]
+            iscall(sym) || continue
+            nbors = collect(Graphs.outneighbors(g, i))
+            op = operation(sym)
+            expected = Int32[]
+            if op isa BasicSymbolic{T}
+                push!(expected, ir.definition[op])
+            end
+            for arg in arguments(sym)
+                arg isa BasicSymbolic{T} || continue
+                push!(expected, ir.definition[arg])
+            end
+            @test nbors == expected
+        end
+    end
+
+    @testset "Non-symbolic operation" begin
+        ir = IRStructure{SymReal}()
+        populate_ir!(ir, sin(x + y))
+        check_edge_ordering_invariant(ir)
+    end
+
+    @testset "Symbolic operation prefixes arguments" begin
+        @syms ordtest_fn(..)
+        ir = IRStructure{SymReal}()
+        expr = ordtest_fn(x, y)
+        @test operation(expr) isa BasicSymbolic{SymReal}
+        populate_ir!(ir, expr)
+        check_edge_ordering_invariant(ir)
+        # The symbolic op must be the first outneighbor after sorting
+        idx = ir[expr]
+        nbors = collect(Graphs.outneighbors(ir.dependency_graph, idx))
+        @test nbors[1] == ir.definition[operation(expr)]
+    end
+
+    @testset "Complex expression" begin
+        ir = IRStructure{SymReal}()
+        # z = z(t) so operation(z) isa BasicSymbolic{SymReal}; exercises the symbolic-op path
+        populate_ir!(ir, x + 2y + 3sin(z + fn(w[1] + sum(w) * tanh(w'w))))
+        check_edge_ordering_invariant(ir)
+    end
+
+    @testset "After replace_node! (non-symbolic op)" begin
+        ir = IRStructure{SymReal}()
+        populate_ir!(ir, x + y)
+        idx = ir[x + y]
+        replace_node!(ir, x + y, x * y)
+        check_edge_ordering_invariant(ir)
+    end
+
+    @testset "After replace_node! (symbolic op)" begin
+        @syms ordtest_replace_fn(..)
+        ir = IRStructure{SymReal}()
+        populate_ir!(ir, x + y)
+        idx = ir[x + y]
+        replace_node!(ir, x + y, ordtest_replace_fn(x, y))
+        check_edge_ordering_invariant(ir)
+        nbors = collect(Graphs.outneighbors(ir.dependency_graph, idx))
+        @test nbors[1] == ir.definition[ordtest_replace_fn]
+    end
 end
 
 @testset "`IRSubstituter`" begin

--- a/test/new_code.jl
+++ b/test/new_code.jl
@@ -708,7 +708,7 @@ end
                             var"##cse#4" = y
                             var"##cse#5" = var"##cse#4"[_1]
                             var"##cse#6" = $(*)(var"##cse#3", var"##cse#5")
-                            __accum = var"##cse#1"[$(CartesianIndex)(_1)] + var"##cse#6"
+                            __accum = $(+)(var"##cse#1"[$(CartesianIndex)(_1)], var"##cse#6")
                             _ = (var"##cse#1"[$(CartesianIndex)(_1)] = __accum)
                         end
                     end

--- a/test/new_code.jl
+++ b/test/new_code.jl
@@ -8,6 +8,9 @@ using ReverseDiff
 using LinearAlgebra
 
 using SymbolicUtils: Const
+import SymbolicUtils: replace_node!
+using Moshi.Match: @match
+import SymbolicUtils.BasicSymbolicImpl as BSImpl
 
 test_repr(a, b) = @test repr(Base.remove_linenums!(a)) == repr(Base.remove_linenums!(b))
 
@@ -799,5 +802,217 @@ end
     end)
     @test wv[1:3] == fill(av, 3)
     @test wv[4:6] == fill(bv, 3)
+end
+
+# Helper: build a CodegenState, run codegen for `expr`, and append the result symbol so the
+# block evaluates to the generated buffer (needed for ArrayOp / Fill whose codegen writes
+# into a buffer rather than returning it as the last block statement).
+function _codegen_to_block(ir, expr, rewrites = Dict{Any,Any}())
+    block = Expr(:block)
+    cs = Code.CodegenState(block, block, ir, rewrites)
+    result_sym = cs(expr)
+    push!(block.args, result_sym)
+    return block
+end
+
+@testset "codegen on non-canonical `IRStructure`" begin
+    # Extract the `term` field from an ArrayOp (used by Fill / map / mapreduce).
+    # That inner Term must be pre-populated before replace_node! so that its
+    # outneighbors in the graph already point to the replaced node.
+    function _arrayop_term(expr)
+        @match expr begin
+            BSImpl.ArrayOp(; term) => term
+            _ => error("expected ArrayOp")
+        end
+    end
+
+    @testset "generic op" begin
+        # sin(a + b) with a+b → a*b: codegen should produce sin(a*b)
+        @syms a::Real b::Real
+        ir = IRStructure{SymReal}()
+        populate_ir!(ir, sin(a + b))
+        replace_node!(ir, a + b, a * b)
+        @test !ir.is_canonical[]
+        expr = Code.fast_toexpr(sin(a + b), ir, Dict{Any,Any}(:sort_addmul => false))
+        result = eval(quote let a = 2.0, b = 3.0; $expr end end)
+        @test result ≈ sin(2.0 * 3.0)
+    end
+
+    @testset "nanmath op" begin
+        @syms a::Real b::Real
+        ir = IRStructure{SymReal}()
+        populate_ir!(ir, sin(a + b))
+        replace_node!(ir, a + b, a * b)
+        @test !ir.is_canonical[]
+        expr = Code.fast_toexpr(
+            sin(a + b), ir, Dict{Any,Any}(:nanmath => true, :sort_addmul => false)
+        )
+        result = eval(quote let a = 2.0, b = 3.0; $expr end end)
+        @test result ≈ sin(2.0 * 3.0)
+    end
+
+    @testset "`+` and `*`" begin
+        @syms a::Real b::Real c::Real d::Real
+        let ir = IRStructure{SymReal}()
+            populate_ir!(ir, a + b + c)
+            replace_node!(ir, a, d)
+            @test !ir.is_canonical[]
+            expr = Code.fast_toexpr(a + b + c, ir, Dict{Any,Any}(:sort_addmul => false))
+            result = eval(quote let a = 1.0, b = 2.0, c = 3.0, d = 10.0; $expr end end)
+            @test result ≈ 10.0 + 2.0 + 3.0
+        end
+
+        let ir = IRStructure{SymReal}()
+            populate_ir!(ir, a * b * c)
+            replace_node!(ir, a, d)
+            @test !ir.is_canonical[]
+            expr = Code.fast_toexpr(a * b * c, ir, Dict{Any,Any}(:sort_addmul => false))
+            result = eval(quote let a = 1.0, b = 2.0, c = 3.0, d = 10.0; $expr end end)
+            @test result ≈ 10.0 * 2.0 * 3.0
+        end
+    end
+
+    @testset "`^`" begin
+        @syms a::Real b::Real c::Real
+        # symbolic exponent: a^b with a → c
+        let ir = IRStructure{SymReal}()
+            populate_ir!(ir, a^b)
+            replace_node!(ir, a, c)
+            @test !ir.is_canonical[]
+            expr = Code.fast_toexpr(a^b, ir, Dict{Any,Any}(:sort_addmul => false))
+            result = eval(quote let a = 2.0, b = 3.0, c = 4.0; $expr end end)
+            @test result ≈ 4.0^3.0
+        end
+        # constant exponent: a^2 with a → c
+        let ir = IRStructure{SymReal}()
+            populate_ir!(ir, a^2)
+            replace_node!(ir, a, c)
+            @test !ir.is_canonical[]
+            expr = Code.fast_toexpr(a^2, ir, Dict{Any,Any}(:sort_addmul => false))
+            result = eval(quote let a = 2.0, c = 3.0; $expr end end)
+            @test result ≈ 3.0^2
+        end
+    end
+
+    @testset "`ifelse`" begin
+        @syms a::Real b::Real c::Real d::Real
+        cond = a < 0
+        ir = IRStructure{SymReal}()
+        populate_ir!(ir, ifelse(cond, b, c))
+        replace_node!(ir, b, d)
+        @test !ir.is_canonical[]
+        expr = Code.fast_toexpr(ifelse(cond, b, c), ir, Dict{Any,Any}(:sort_addmul => false))
+        result = eval(quote let a = -1.0, b = 10.0, c = 20.0, d = 30.0; $expr end end)
+        @test result ≈ 30.0  # a < 0 is true, so uses d (replaced from b)
+    end
+
+    @testset "`getindex`" begin
+        @syms x[1:3]::Real idx1::Int idx2::Int
+        ir = IRStructure{SymReal}()
+        populate_ir!(ir, x[idx1])
+        replace_node!(ir, idx1, idx2)
+        @test !ir.is_canonical[]
+        expr = Code.fast_toexpr(x[idx1], ir, Dict{Any,Any}())
+        result = eval(quote let x = [10, 20, 30], idx1 = 1, idx2 = 2; $expr end end)
+        @test result == 20  # x[idx2] = x[2] = 20
+    end
+
+    @testset "`ArrayOp`" begin
+        @syms xv[1:3]::Real yv[1:3]::Real zv[1:3]::Real
+        arr = @arrayop (i,) xv[i] * yv[i]
+        ir = IRStructure{SymReal}()
+        populate_ir!(ir, arr)
+        replace_node!(ir, Const{SymReal}(yv), Const{SymReal}(zv))
+        @test !ir.is_canonical[]
+        block = _codegen_to_block(ir, arr, Dict{Any,Any}(:sort_addmul => false))
+        xdata = [1.0, 2.0, 3.0]; ydata = [10.0, 10.0, 10.0]; zdata = [4.0, 5.0, 6.0]
+        result = eval(quote let xv = $xdata, yv = $ydata, zv = $zdata; $block end end)
+        @test result ≈ xdata .* zdata
+    end
+
+    @testset "`Fill`" begin
+        @syms a::Real b::Real
+        f = SymbolicUtils.Fill(SymbolicUtils.ShapeVecT((1:3,)))
+        fill_expr = f(a)
+        ir = IRStructure{SymReal}()
+        populate_ir!(ir, fill_expr)
+        # Pre-populate the inner Term so its graph edges already exist before replace_node!
+        populate_ir!(ir, _arrayop_term(fill_expr))
+        replace_node!(ir, a, b)
+        @test !ir.is_canonical[]
+        block = _codegen_to_block(ir, fill_expr)
+        result = eval(quote let a = 2.0, b = 5.0; $block end end)
+        @test result == fill(5.0, 3)
+    end
+
+    @testset "`ArrayMaker`" begin
+        @syms a::Real b::Real c::Real
+        f = SymbolicUtils.Fill(SymbolicUtils.ShapeVecT((1:3,)))
+        w = @makearray w[1:6] begin
+            w[1:3] => f(a)
+            w[4:6] => f(b)
+        end
+        ir = IRStructure{SymReal}()
+        populate_ir!(ir, w)
+        replace_node!(ir, a, c)
+        @test !ir.is_canonical[]
+        expr = Code.fast_toexpr(w, ir, Dict{Any,Any}(:sort_addmul => false))
+        av = 2.0; bv = 5.0; cv = 7.0
+        result = eval(quote let a = $av, b = $bv, c = $cv; $expr end end)
+        @test result[1:3] == fill(cv, 3)
+        @test result[4:6] == fill(bv, 3)
+    end
+
+    @testset "`array_literal`" begin
+        @syms a::Real b::Real c::Real d::Real
+        # without allocator
+        arr_lit = Const{SymReal}([a, b, c])
+        let ir = IRStructure{SymReal}()
+            populate_ir!(ir, arr_lit)
+            replace_node!(ir, a, d)
+            @test !ir.is_canonical[]
+            expr = Code.fast_toexpr(arr_lit, ir, Dict{Any,Any}())
+            result = eval(quote let a = 1.0, b = 2.0, c = 3.0, d = 10.0; $expr end end)
+            @test result ≈ [10.0, 2.0, 3.0]
+        end
+        # with allocator
+        let ir = IRStructure{SymReal}()
+            populate_ir!(ir, arr_lit)
+            replace_node!(ir, a, d)
+            @test !ir.is_canonical[]
+            wrapped = Code.with_allocator(ones, arr_lit)
+            expr = Code.fast_toexpr(wrapped, ir, Dict{Any,Any}(:sort_addmul => false))
+            result = eval(quote let a = 1.0, b = 2.0, c = 3.0, d = 10.0; $expr end end)
+            @test result ≈ [10.0, 2.0, 3.0]
+        end
+    end
+
+    @testset "`Mapper`" begin
+        @syms av[1:3]::Real bv[1:3]::Real cv[1:3]::Real
+        ex_map = map(+, av, bv)
+        ir = IRStructure{SymReal}()
+        populate_ir!(ir, ex_map)
+        populate_ir!(ir, _arrayop_term(ex_map))
+        replace_node!(ir, Const{SymReal}(bv), Const{SymReal}(cv))
+        @test !ir.is_canonical[]
+        block = _codegen_to_block(ir, ex_map, Dict{Any,Any}(:sort_addmul => false))
+        xdata = [1.0, 2.0, 3.0]; ydata = [10.0, 10.0, 10.0]; zdata = [4.0, 5.0, 6.0]
+        result = eval(quote let av = $xdata, bv = $ydata, cv = $zdata; $block end end)
+        @test result ≈ xdata .+ zdata
+    end
+
+    @testset "`Mapreducer`" begin
+        @syms av[1:3]::Real bv[1:3]::Real cv[1:3]::Real
+        ex_mapred = mapreduce(+, +, av, bv)
+        ir = IRStructure{SymReal}()
+        populate_ir!(ir, ex_mapred)
+        populate_ir!(ir, _arrayop_term(ex_mapred))
+        replace_node!(ir, Const{SymReal}(bv), Const{SymReal}(cv))
+        @test !ir.is_canonical[]
+        block = _codegen_to_block(ir, ex_mapred, Dict{Any,Any}(:sort_addmul => false))
+        xdata = [1.0, 2.0, 3.0]; ydata = [10.0, 10.0, 10.0]; zdata = [4.0, 5.0, 6.0]
+        result = eval(quote let av = $xdata, bv = $ydata, cv = $zdata; $block end end)
+        @test result ≈ sum(xdata .+ zdata)
+    end
 end
 

--- a/test/ordereddigraph.jl
+++ b/test/ordereddigraph.jl
@@ -172,7 +172,7 @@ end
         @test Set(inneighbors(g, 2)) == Set([1])
     end
 
-    @testset "order is preserved through other mutations" begin
+    @testset "order is preserved through insertions" begin
         g = OrderedDiGraph{Int}(5)
         add_edge!(g, 1, 5)
         add_edge!(g, 1, 3)
@@ -180,13 +180,9 @@ end
         add_edge!(g, 1, 4)
         @test collect(outneighbors(g, 1)) == [5, 3, 2, 4]
 
-        # Removing a non-1 edge does not disturb order
-        rem_edge!(g, 1, 3)
-        @test collect(outneighbors(g, 1)) == [5, 2, 4]
-
-        # Adding a new edge appends
+        # Adding another edge appends
         add_edge!(g, 1, 3)
-        @test collect(outneighbors(g, 1)) == [5, 2, 4, 3]
+        @test collect(outneighbors(g, 1)) == [5, 3, 2, 4, 3]
     end
 
     @testset "differs from SimpleDiGraph sorted order" begin
@@ -240,33 +236,6 @@ end
         @test collect(outneighbors(g, 1)) == [2, 3, 4]
     end
 
-    @testset "no regression back to NTuple after rem_edge! on Vector" begin
-        g = OrderedDiGraph{Int}(4)
-        add_edge!(g, 1, 2); add_edge!(g, 1, 3); add_edge!(g, 1, 4)
-        rem_edge!(g, 1, 4)
-        # Vector is never shrunk back to NTuple
-        @test g.fadjlist[1] isa Vector{Int}  # internal representation
-        @test collect(outneighbors(g, 1)) == [2, 3]
-    end
-
-    @testset "rem_edge! on NTuple: 2→1 out-edges" begin
-        g = OrderedDiGraph{Int}(3)
-        add_edge!(g, 1, 3); add_edge!(g, 1, 2)
-        rem_edge!(g, 1, 3)
-        nbrs = outneighbors(g, 1)
-        @test nbrs isa AdjView{Int}
-        @test collect(nbrs) == [2]
-    end
-
-    @testset "rem_edge! on NTuple: 1→0 out-edges" begin
-        g = OrderedDiGraph{Int}(2)
-        add_edge!(g, 1, 2)
-        rem_edge!(g, 1, 2)
-        nbrs = outneighbors(g, 1)
-        @test nbrs isa AdjView{Int}
-        @test length(nbrs) == 0
-    end
-
     @testset "AdjView supports in-operator" begin
         g = OrderedDiGraph{Int}(3)
         add_edge!(g, 1, 3); add_edge!(g, 1, 2)
@@ -318,32 +287,6 @@ end
         @test Set(nbrs) == Set([2, 3, 4])
     end
 
-    @testset "no regression back to NTuple after rem_edge! on Set" begin
-        g = OrderedDiGraph{Int}(4)
-        add_edge!(g, 2, 1); add_edge!(g, 3, 1); add_edge!(g, 4, 1)
-        rem_edge!(g, 4, 1)
-        @test g.badjlist[1] isa Set{Int}         # still Set after removal
-        @test Set(inneighbors(g, 1)) == Set([2, 3])
-    end
-
-    @testset "rem_edge! on NTuple: 2→1 in-edges" begin
-        g = OrderedDiGraph{Int}(3)
-        add_edge!(g, 2, 1); add_edge!(g, 3, 1)
-        rem_edge!(g, 3, 1)
-        @test g.badjlist[1] isa NTuple{2, Int}
-        nbrs = inneighbors(g, 1)
-        @test length(nbrs) == 1
-        @test 2 in nbrs
-    end
-
-    @testset "rem_edge! on NTuple: 1→0 in-edges" begin
-        g = OrderedDiGraph{Int}(2)
-        add_edge!(g, 2, 1)
-        rem_edge!(g, 2, 1)
-        @test g.badjlist[1] isa NTuple{2, Int}
-        @test length(inneighbors(g, 1)) == 0
-    end
-
     @testset "AdjView supports in-operator (in-neighbors)" begin
         g = OrderedDiGraph{Int}(3)
         add_edge!(g, 2, 1); add_edge!(g, 3, 1)
@@ -387,13 +330,13 @@ end
 # ── add_edge! ──────────────────────────────────────────────────────────────────
 
 @testset "add_edge!" begin
-    @testset "returns true on success, false otherwise" begin
+    @testset "returns true on success, false for out-of-range vertices" begin
         g = OrderedDiGraph{Int}(3)
         @test add_edge!(g, 1, 2)           == true
-        @test add_edge!(g, 1, 2)           == false  # duplicate
+        @test add_edge!(g, 1, 2)           == true   # multi-edge allowed
         @test add_edge!(g, 0, 1)           == false  # src out of range
         @test add_edge!(g, 1, 4)           == false  # dst out of range
-        @test ne(g) == 1
+        @test ne(g) == 2
     end
 
     @testset "via Edge object" begin
@@ -416,8 +359,9 @@ end
         @test has_edge(g, 1, 1)
         @test 1 in outneighbors(g, 1)
         @test 1 in inneighbors(g, 1)
-        # Duplicate self-loop blocked
-        @test !add_edge!(g, 1, 1)
+        # Duplicate self-loop is a multi-edge, also allowed
+        @test add_edge!(g, 1, 1)
+        @test ne(g) == 2
     end
 
     @testset "adjacency state after insertion" begin
@@ -431,37 +375,68 @@ end
     end
 end
 
-# ── rem_edge! ──────────────────────────────────────────────────────────────────
+# ── multi-edges ────────────────────────────────────────────────────────────────
 
-@testset "rem_edge!" begin
-    @testset "returns true on success, false otherwise" begin
-        g = make_graph(3, 1=>2, 1=>3)
-        @test rem_edge!(g, 1, 2)          == true
-        @test rem_edge!(g, 1, 2)          == false  # already gone
-        @test rem_edge!(g, 2, 1)          == false  # was never there
-        @test rem_edge!(g, 0, 1)          == false  # out of range
-        @test rem_edge!(g, 1, 5)          == false  # out of range
-        @test ne(g) == 1
+@testset "multi-edges" begin
+    @testset "same src→dst edge can be added multiple times" begin
+        g = OrderedDiGraph{Int}(3)
+        @test add_edge!(g, 1, 2) == true
+        @test add_edge!(g, 1, 2) == true   # second edge allowed
+        @test ne(g) == 2
+        @test collect(outneighbors(g, 1)) == [2, 2]
+        # badjlist records src only once
+        @test length(inneighbors(g, 2)) == 1
+        @test 1 in inneighbors(g, 2)
     end
 
-    @testset "forward and backward adjacency both updated" begin
-        g = make_graph(3, 1=>2, 1=>3, 2=>3)
-        rem_edge!(g, 1, 3)
-        @test collect(outneighbors(g, 1)) == [2]
-        @test !(1 in inneighbors(g, 3))
+    @testset "has_edge returns true with multi-edges" begin
+        g = make_graph(2, 1=>2)
+        add_edge!(g, 1, 2)
+        @test has_edge(g, 1, 2)
         @test ne(g) == 2
     end
 
-    @testset "via Edge object" begin
-        g = make_graph(2, 1=>2)
-        @test rem_edge!(g, Graphs.Edge(1, 2))
-        @test !has_edge(g, 1, 2)
+    @testset "rem_outedges! correctly handles NTuple-backed multi-edge" begin
+        g = OrderedDiGraph{Int}(3)
+        add_edge!(g, 1, 2); add_edge!(g, 1, 2)
+        @test g.fadjlist[1] isa NTuple{2, Int}
+        rem_outedges!(g, 1)
+        @test ne(g) == 0
+        @test isempty(outneighbors(g, 1))
+        @test !(1 in inneighbors(g, 2))
     end
 
-    @testset "via AbstractEdge" begin
-        g = make_graph(3, 1=>3)
-        @test rem_edge!(g, Graphs.Edge{Int32}(1, 3))
-        @test !has_edge(g, 1, 3)
+    @testset "rem_outedges! correctly handles Vector-backed multi-edge" begin
+        g = OrderedDiGraph{Int}(3)
+        add_edge!(g, 1, 2); add_edge!(g, 1, 2); add_edge!(g, 1, 3)
+        @test g.fadjlist[1] isa Vector{Int}
+        rem_outedges!(g, 1)
+        @test ne(g) == 0
+        @test isempty(outneighbors(g, 1))
+        @test !(1 in inneighbors(g, 2))
+        @test !(1 in inneighbors(g, 3))
+    end
+
+    @testset "multi-edge self-loop" begin
+        g = OrderedDiGraph{Int}(2)
+        @test add_edge!(g, 1, 1) == true
+        @test add_edge!(g, 1, 1) == true
+        @test ne(g) == 2
+        @test collect(outneighbors(g, 1)) == [1, 1]
+        @test length(inneighbors(g, 1)) == 1
+    end
+
+    @testset "three or more identical edges" begin
+        g = OrderedDiGraph{Int}(2)
+        for _ in 1:4
+            add_edge!(g, 1, 2)
+        end
+        @test ne(g) == 4
+        @test collect(outneighbors(g, 1)) == [2, 2, 2, 2]
+        @test length(inneighbors(g, 2)) == 1
+        rem_outedges!(g, 1)
+        @test ne(g) == 0
+        @test !(1 in inneighbors(g, 2))
     end
 end
 
@@ -620,8 +595,10 @@ end
 
     @testset "badjlist independence" begin
         h = copy(g)
-        rem_edge!(h, 1, 2)
-        @test has_edge(g, 1, 2)
+        add_edge!(h, 3, 1)
+        @test !has_edge(g, 3, 1)
+        @test 3 in inneighbors(h, 1)
+        @test !(3 in inneighbors(g, 1))
     end
 
     @testset "inequality on different structure" begin
@@ -716,12 +693,6 @@ end
         check_consistent(g)
     end
 
-    @testset "after rem_edge!" begin
-        g = make_graph(4, 1=>2, 1=>3, 2=>3, 3=>4)
-        rem_edge!(g, 1, 3)
-        check_consistent(g)
-    end
-
 end
 
 # ── Type stability (@inferred) ─────────────────────────────────────────────────
@@ -796,7 +767,6 @@ end
     add_edge!(gm, 1, 2)
     @test @inferred(add_vertex!(gm))        === true
     @test @inferred(add_edge!(gm, 2, 3))    === true
-    @test @inferred(rem_edge!(gm, 2, 3))    === true
     @test @inferred(rem_outedges!(gm, 1))   === true
 
     # ── copy / zero / == ──────────────────────────────────────────────────────

--- a/test/ordereddigraph.jl
+++ b/test/ordereddigraph.jl
@@ -1,4 +1,4 @@
-using SymbolicUtils: OrderedDiGraph, AdjView, OrderedDiGraphEdgeIter
+using SymbolicUtils: OrderedDiGraph, AdjView, OrderedDiGraphEdgeIter, rem_outedges!
 using Graphs
 using Test
 
@@ -465,6 +465,85 @@ end
     end
 end
 
+# ── rem_outedges! ─────────────────────────────────────────────────────────────
+
+@testset "rem_outedges!" begin
+    @testset "returns true on success, false for invalid vertex" begin
+        g = make_graph(3, 1=>2, 1=>3)
+        @test rem_outedges!(g, 1) == true
+        @test rem_outedges!(g, 0) == false
+        @test rem_outedges!(g, 4) == false
+    end
+
+    @testset "empty vertex: returns true without changing ne" begin
+        g = make_graph(3, 2=>3)
+        @test rem_outedges!(g, 1) == true
+        @test ne(g) == 1
+        @test isempty(outneighbors(g, 1))
+    end
+
+    @testset "NTuple backing: 1 out-edge" begin
+        g = make_graph(2, 1=>2)
+        @test rem_outedges!(g, 1) == true
+        @test ne(g) == 0
+        @test isempty(outneighbors(g, 1))
+        @test !(1 in inneighbors(g, 2))
+    end
+
+    @testset "NTuple backing: 2 out-edges" begin
+        g = make_graph(3, 1=>2, 1=>3)
+        @test rem_outedges!(g, 1) == true
+        @test ne(g) == 0
+        @test isempty(outneighbors(g, 1))
+        @test !(1 in inneighbors(g, 2))
+        @test !(1 in inneighbors(g, 3))
+    end
+
+    @testset "Vector backing: 3+ out-edges" begin
+        g = make_graph(5, 1=>2, 1=>3, 1=>4, 1=>5)
+        @test rem_outedges!(g, 1) == true
+        @test ne(g) == 0
+        @test isempty(outneighbors(g, 1))
+        for d in 2:5
+            @test !(1 in inneighbors(g, d))
+        end
+    end
+
+    @testset "destination with Set-backed badjlist" begin
+        # vertex 5 acquires 4 in-edges, so its badjlist transitions to Set
+        g = make_graph(5, 1=>5, 2=>5, 3=>5, 4=>5)
+        @test g.badjlist[5] isa Set{Int}
+        @test rem_outedges!(g, 1) == true
+        @test ne(g) == 3
+        @test !(1 in inneighbors(g, 5))
+        @test 2 in inneighbors(g, 5)
+        @test 3 in inneighbors(g, 5)
+        @test 4 in inneighbors(g, 5)
+    end
+
+    @testset "unrelated edges are unaffected" begin
+        g = make_graph(4, 1=>2, 1=>3, 4=>2)
+        rem_outedges!(g, 1)
+        @test ne(g) == 1
+        @test has_edge(g, 4, 2)
+        @test 4 in inneighbors(g, 2)
+    end
+
+    @testset "internal consistency after rem_outedges!" begin
+        g = make_graph(5, 1=>2, 1=>3, 1=>4, 2=>3, 3=>5)
+        rem_outedges!(g, 1)
+        for v in vertices(g)
+            for u in outneighbors(g, v)
+                @test v in inneighbors(g, u)
+            end
+            for u in inneighbors(g, v)
+                @test v in outneighbors(g, u)
+            end
+        end
+        @test ne(g) == sum(outdegree(g, v) for v in vertices(g); init=0)
+    end
+end
+
 # ── rem_vertex! / rem_vertices! ───────────────────────────────────────────────
 
 @testset "rem_vertex! and rem_vertices! are unsupported" begin
@@ -715,9 +794,10 @@ end
     # ── Graphs.jl API: mutation ───────────────────────────────────────────────
     gm = OrderedDiGraph{Int}(4)
     add_edge!(gm, 1, 2)
-    @test @inferred(add_vertex!(gm))     === true
-    @test @inferred(add_edge!(gm, 2, 3)) === true
-    @test @inferred(rem_edge!(gm, 2, 3)) === true
+    @test @inferred(add_vertex!(gm))        === true
+    @test @inferred(add_edge!(gm, 2, 3))    === true
+    @test @inferred(rem_edge!(gm, 2, 3))    === true
+    @test @inferred(rem_outedges!(gm, 1))   === true
 
     # ── copy / zero / == ──────────────────────────────────────────────────────
     @test @inferred(copy(g))                   isa OrderedDiGraph{Int}

--- a/test/qa/adjview_jet.jl
+++ b/test/qa/adjview_jet.jl
@@ -122,11 +122,10 @@ end
     @test_opt _edges_sum_jet(g)
 end
 
-@testset "JET: add_vertex!, add_edge!, rem_edge!" begin
+@testset "JET: add_vertex!, add_edge!" begin
     g = OrderedDiGraph{Int}(4)
     @test_opt add_vertex!(g)
     @test_opt add_edge!(g, 1, 3)
-    @test_opt rem_edge!(g, 1, 3)
 end
 
 @testset "JET: copy, ==, zero" begin


### PR DESCRIPTION
This allows codegen passes to use `replace_node!` to efficiently update the IR, and then codegen from the mutated IR.