### PR TITLE
feat: special-case `Returns(buf)` allocators in new codegen 

### DIFF
--- a/src/faster_code.jl
+++ b/src/faster_code.jl
@@ -267,6 +267,16 @@ function codegen_allocator_call!(
     ) where {T}
     allocator isa ExistingBufferAllocator && return allocator.name
     allocator_sym::Symbol = if allocator isa BasicSymbolic{T}
+        # If the allocator is a `Returns(buf)` expression, don't bother calling it. Just generate
+        # `buf` and use it.
+        @match allocator begin
+            BSImpl.Term(; f) && if f === Returns || f isa DataType && f <: Returns end => begin
+                allocator_idx = populate_ir!(cs.ir, allocator)
+                buffer_sym = cs(cs.ir[Graphs.outneighbors(cs.ir.dependency_graph, allocator_idx)[1]])
+                return codegen!(cs, expr_idx, buffer_sym)
+            end
+            _ => nothing
+        end
         cs(allocator)
     else
         declare!(cs, get_misc_identifier(cs), allocator)
@@ -490,6 +500,16 @@ function __is_fill_zero(ex::BasicSymbolic{T}) where {T}
     end
 end
 
+function __allocator_is_returns_expr(::Type{T}, @nospecialize(ex)) where {T}
+    if ex isa BasicSymbolic{T}
+        @match ex begin
+            BSImpl.Term(; f) => return f === Returns || f isa DataType && f <: Returns
+            _ => return false
+        end
+    end
+    return false
+end
+
 function codegen_function!(::Type{ArrayMaker{T}}, cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
     _allocator = get_allocator!(cs, zeros)
     len = length(expr)::Int
@@ -516,7 +536,8 @@ function codegen_function!(::Type{ArrayMaker{T}}, cs::CodegenState{T}, expr::Bas
         return declare!(cs, get_misc_identifier(cs), result)
     end
     
-    if _allocator !== zeros && isequal(regions[1], sh) && __is_fill_zero(cs.ir[first(values_exprs_idxs)])
+    if _allocator !== zeros && !__allocator_is_returns_expr(T, _allocator) &&
+            isequal(regions[1], sh) && __is_fill_zero(cs.ir[first(values_exprs_idxs)])
         output_buffer = codegen_allocator_call!(
             cs, _allocator, expr, expr_idx;
             allocator_call_expr = __allocator_call_and_fill_expr

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -1725,3 +1725,11 @@ end
 function Base.round(::Type{T}, ex::BasicSymbolic{R}, mode::Base.RoundingMode) where {T, R}
     SymbolicRound{T, typeof(mode)}(mode)(ex)
 end
+
+function promote_symtype(::Type{T}, R::TypeT) where {T <: Returns}
+    return FnType{Tuple, R, Nothing}
+end
+
+function promote_shape(::Type{T}, @nospecialize(sh::ShapeT)) where {T <: Returns}
+    return sh
+end

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -1,5 +1,5 @@
 using SymbolicUtils
-using SymbolicUtils: Sym, Term, symtype, BasicSymbolic, Const, ArgsT, promote_symtype, promote_shape, ShapeVecT, Unknown, array_literal, Fill, SymbolicRound
+using SymbolicUtils: Sym, Term, symtype, BasicSymbolic, Const, ArgsT, promote_symtype, promote_shape, ShapeVecT, Unknown, array_literal, Fill, SymbolicRound, FnType
 using Test
 import NaNMath
 import LinearAlgebra
@@ -454,4 +454,17 @@ end
     @test occursin("Int", str)
     @test occursin(string(x), str)
     @test occursin("Nearest", str)
+end
+
+@testset "promote_symtype and promote_shape for Returns" begin
+    @test promote_symtype(Returns{Float64}, Vector{Float64}) == FnType{Tuple, Vector{Float64}, Nothing}
+    @test promote_symtype(Returns{Int}, Matrix{Int}) == FnType{Tuple, Matrix{Int}, Nothing}
+    @test promote_symtype(Returns{Nothing}, Int) == FnType{Tuple, Int, Nothing}
+
+    sh1d = ShapeVecT((1:3,))
+    sh2d = ShapeVecT((1:2, 1:4))
+    @test promote_shape(Returns{Float64}, sh1d) === sh1d
+    @test promote_shape(Returns{Float64}, sh2d) === sh2d
+    @test promote_shape(Returns{Int}, Unknown(1)) == Unknown(1)
+    @test promote_shape(Returns{Int}, Unknown(-1)) == Unknown(-1)
 end

--- a/test/new_code.jl
+++ b/test/new_code.jl
@@ -759,6 +759,37 @@ end
         end)
         @test result2d_wa == fill(xv, 2, 4)
     end
+
+    @testset "`Returns(buf)` allocator" begin
+        @syms x y z buf[1:3]
+        ir = IRStructure{SymReal}()
+        arr = SymbolicUtils.Const{SymReal}([x, y, z])
+        returns_alloc = SymbolicUtils.Term{SymReal}(Returns{SymReal}, (buf,))
+
+        test_repr(
+            Code.fast_toexpr(arr, ir, Dict{Any,Any}(Code.ALLOCATOR_REWRITES_KEY => returns_alloc)),
+            quote
+                var"##cse#0" = buf
+                var"##cse#1" = var"##cse#0"
+                var"##cse#2" = x
+                var"##cse#3" = y
+                var"##cse#4" = z
+                __miscₛᵧₘ0 = $(Code.fill_arr!)(var"##cse#1", $Val($((3,))), var"##cse#2", var"##cse#3", var"##cse#4")
+            end
+        )
+
+        reference = eval(quote
+            let x = 1.0, y = 2.0, z = 3.0
+                $(Code.fast_toexpr(arr, ir, Dict{Any,Any}()))
+            end
+        end)
+        result = eval(quote
+            let x = 1.0, y = 2.0, z = 3.0, buf = zeros(3)
+                $(Code.fast_toexpr(arr, ir, Dict{Any,Any}(Code.ALLOCATOR_REWRITES_KEY => SymbolicUtils.Term{SymReal}(Returns{SymReal}, (buf,)))))
+            end
+        end)
+        @test isequal(reference, result)
+    end
 end
 
 @testset "fast_toexpr" begin


### PR DESCRIPTION
This allows specifying a buffer to write to without going through the hoops of creating and calling a `Returns` object.