### PR TITLE
refactor: avoid converting expressions to strings in codegen

### DIFF
--- a/src/faster_code.jl
+++ b/src/faster_code.jl
@@ -953,6 +953,16 @@ function (cs::CodegenState)(expr::Assignment)
     return declare!(cs, lhs, rhs)
 end
 
+const ARGNAME_PREFIX = Vector{UInt8}("__argₛᵧₘ")
+
+function add_arg_to_rewrites!(rewrites::Dict{Any, Any}, lhs::BasicSymbolic{T}) where {T}
+    rewrites[lhs] = if get(rewrites, :readable_variables, false)::Bool
+        Symbol(string(lhs)::String)
+    else
+        get_numbered_symbol_with_prefix(ARGNAME_PREFIX, hash(lhs))
+    end
+end
+
 function (cs::CodegenState{T})(l::Let) where {T}
     if all(x->x isa Assignment && !(x.lhs isa DestructuredArgs), l.pairs)
         dargs = Vector{Assignment}(l.pairs)
@@ -968,7 +978,7 @@ function (cs::CodegenState{T})(l::Let) where {T}
         for asg in dargs
             lhs = asg.lhs
             if lhs isa BasicSymbolic{T} && iscall(lhs)
-                scs.rewrites[lhs] = Symbol(string(lhs)::String)
+                add_arg_to_rewrites!(scs.rewrites, lhs)
             end
             scs(asg)
         end
@@ -985,7 +995,7 @@ function (cs::CodegenState{T})(l::Let) where {T}
     for asg in dargs
         lhs = asg.lhs
         if lhs isa BasicSymbolic{T} && iscall(lhs)
-            cs.rewrites[lhs] = Symbol(string(lhs)::String)
+            add_arg_to_rewrites!(cs.rewrites, lhs)
         end
         cs(asg)
     end
@@ -997,11 +1007,11 @@ function (cs::CodegenState{T})(fn::Func) where {T}
     dargs = Union{Assignment, DestructuredArgs}[]
     for arg in fn.args
         if arg isa BasicSymbolic{T}
-            cs.rewrites[arg] = Symbol(string(arg)::String)
+            add_arg_to_rewrites!(cs.rewrites, arg)
         elseif arg isa Assignment
             lhs = arg.lhs
             if lhs isa BasicSymbolic{T}
-                cs.rewrites[lhs] = Symbol(string(lhs)::String)
+                add_arg_to_rewrites!(cs.rewrites, lhs)
             end
         elseif arg isa DestructuredArgs
             push!(dargs, arg)
@@ -1010,6 +1020,7 @@ function (cs::CodegenState{T})(fn::Func) where {T}
     for kw in fn.kwargs
         lhs = kw.lhs
         if lhs isa BasicSymbolic{T}
+            # Does not use `add_arg_to_rewrites!` because kwarg names matter
             cs.rewrites[lhs] = Symbol(string(lhs)::String)
         end
     end

--- a/test/new_code.jl
+++ b/test/new_code.jl
@@ -329,7 +329,7 @@ test_repr(a, b) = @test repr(Base.remove_linenums!(a)) == repr(Base.remove_linen
             Let(
                 [DestructuredArgs([x(t), b, c], :foo) ← [3, 3, [1, 4]], DestructuredArgs([p, q], c)],
                 x(t) + a + b + c
-            ), ir, Dict()
+            ), ir, Dict{Any, Any}(:readable_variables => true)
         ),
         :(
             let __miscₛᵧₘ0 = Vector{Any}, __miscₛᵧₘ1 = 3, __miscₛᵧₘ2 = 3, __miscₛᵧₘ3 = Vector{Int64}, __miscₛᵧₘ4 = 1, __miscₛᵧₘ5 = 4, __miscₛᵧₘ6 = $(SymbolicUtils.Code.create_array)(__miscₛᵧₘ3, nothing, $(Val){1}(), $(Val){(2,)}(), __miscₛᵧₘ4, __miscₛᵧₘ5), __miscₛᵧₘ7 = $(SymbolicUtils.Code.create_array)(__miscₛᵧₘ0, nothing, $(Val){1}(), $(Val){(3,)}(), __miscₛᵧₘ1, __miscₛᵧₘ2, __miscₛᵧₘ6), foo = __miscₛᵧₘ7, __miscₛᵧₘ8 = foo[1], var"x(t)" = __miscₛᵧₘ8, __miscₛᵧₘ9 = foo[2], b = __miscₛᵧₘ9, __miscₛᵧₘ10 = foo[3], c = __miscₛᵧₘ10, __miscₛᵧₘ11 = c[1], p = __miscₛᵧₘ11, __miscₛᵧₘ12 = c[2], q = __miscₛᵧₘ12


### PR DESCRIPTION
This speeds up codegen by a measurable amount. It can be toggled off in case reading the code is necessary.