### PR TITLE
refactor: use new `batched_setindex!` to improve `ArrayMaker` codegen

### DIFF
--- a/src/faster_code.jl
+++ b/src/faster_code.jl
@@ -510,18 +510,18 @@ function __allocator_is_returns_expr(::Type{T}, @nospecialize(ex)) where {T}
     return false
 end
 
-function batched_setindex!(buffer::AbstractArray{T, D}, values::Tuple{Vararg{Any, N}}, idxs::NTuple{N, CartesianIndex{D}}) where {T, D, N}
+function batched_setindex!(buffer::AbstractArray{T, D}, values::NTuple{N, T}, idxs::NTuple{N, CartesianIndex{D}}) where {T, D, N}
     @inbounds for i in 1:N
         buffer[idxs[i]] = values[i]
     end
 end
-function batched_setindex!(buffer::AbstractArray{T, D}, value, idxs::AbstractArray{CartesianIndex{D}}) where {T, D}
+function batched_setindex!(buffer::AbstractArray{T, D}, value::T, idxs::AbstractArray{CartesianIndex{D}}) where {T, D}
     @inbounds for idx in idxs
         buffer[idx] = value
     end
 end
 
-BATCHED_SETINDEX_BATCH_SIZE::Int = 32
+BATCHED_SETINDEX_BATCH_SIZE::Int = 64
 
 function codegen_function!(::Type{ArrayMaker{T}}, cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
     _allocator = get_allocator!(cs, zeros)
@@ -574,6 +574,10 @@ function codegen_function!(::Type{ArrayMaker{T}}, cs::CodegenState{T}, expr::Bas
     other_regions = ShapeVecT[]
     other_values = Any[]
 
+    eltype_expr = declare!(cs, get_misc_identifier(cs), Expr(:call, eltype, output_buffer))
+    one_expr = Expr(:call, one, eltype_expr)
+    negone_expr = Expr(:call, :(-), one_expr)
+
     function materialize_scalar_writes()
         empty!(one_regions)
         empty!(negone_regions)
@@ -594,11 +598,11 @@ function codegen_function!(::Type{ArrayMaker{T}}, cs::CodegenState{T}, expr::Bas
         if !isempty(one_regions)
             idxs_buffer = Vector{CartesianIndex{D}}(map(CartesianIndex{D} ∘ Tuple ∘ Base.Fix1(map, first), one_regions))
             # Directly interpolating an array into an expression avoids the allocation.
-            declare!(cs, :_, Expr(:call, batched_setindex!, output_buffer, 1, idxs_buffer))
+            declare!(cs, :_, Expr(:call, batched_setindex!, output_buffer, one_expr, idxs_buffer))
         end
         if !isempty(negone_regions)
             idxs_buffer = Vector{CartesianIndex{D}}(map(CartesianIndex{D} ∘ Tuple ∘ Base.Fix1(map, first), negone_regions))
-            declare!(cs, :_, Expr(:call, batched_setindex!, output_buffer, -1, idxs_buffer))
+            declare!(cs, :_, Expr(:call, batched_setindex!, output_buffer, negone_expr, idxs_buffer))
         end
         # Use `Iterators.partition` to avoid creating overly large tuples
         for (regs, vals) in zip(
@@ -606,7 +610,9 @@ function codegen_function!(::Type{ArrayMaker{T}}, cs::CodegenState{T}, expr::Bas
                 Iterators.partition(other_values, BATCHED_SETINDEX_BATCH_SIZE)
             )
             vals_expr = Expr(:tuple)
-            append!(vals_expr.args, vals)
+            for val in vals
+                push!(vals_expr.args, Expr(:call, eltype_expr, val))
+            end
             idxs_expr = Expr(:tuple)
             for reg in regs
                 push!(idxs_expr.args, CartesianIndex{D}(Tuple(map(first, reg))))

--- a/src/faster_code.jl
+++ b/src/faster_code.jl
@@ -510,17 +510,34 @@ function __allocator_is_returns_expr(::Type{T}, @nospecialize(ex)) where {T}
     return false
 end
 
+function batched_setindex!(buffer::AbstractArray{T, D}, values::Tuple{Vararg{Any, N}}, idxs::NTuple{N, CartesianIndex{D}}) where {T, D, N}
+    @inbounds for i in 1:N
+        buffer[idxs[i]] = values[i]
+    end
+end
+function batched_setindex!(buffer::AbstractArray{T, D}, value, idxs::AbstractArray{CartesianIndex{D}}) where {T, D}
+    @inbounds for idx in idxs
+        buffer[idx] = value
+    end
+end
+
+BATCHED_SETINDEX_BATCH_SIZE::Int = 32
+
 function codegen_function!(::Type{ArrayMaker{T}}, cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
     _allocator = get_allocator!(cs, zeros)
     len = length(expr)::Int
 
+    # We can only rely on the graph during codegen, so this is a roundabout way of obtaining
+    # the `regions` and `values` fields of the `ArrayMaker`.
     expr_nbors = Graphs.outneighbors(cs.ir.dependency_graph, expr_idx)
     regions = unwrap_const(cs.ir[expr_nbors[1]])::SymbolicUtils.RegionsT
     values_expr_idx = expr_nbors[2]
     values_args = Graphs.outneighbors(cs.ir.dependency_graph, values_expr_idx)
-    values_exprs_idxs = Iterators.drop(values_args, 1)
+    # Indices of the expressions in `values`.
+    values_exprs_idxs = collect(Iterators.drop(values_args, 1))
     sh = shape(expr)
 
+    # The array is small enough, so scalarize it and use `fill_arr!`.
     if len <= FILL_ARR_LIMIT
         expr = SymbolicUtils.get_canonical_expr(cs.ir, expr_idx)
         output_buffer = codegen_allocator_call!(cs, _allocator, expr, expr_idx)
@@ -547,67 +564,131 @@ function codegen_function!(::Type{ArrayMaker{T}}, cs::CodegenState{T}, expr::Bas
         output_buffer = codegen_allocator_call!(cs, _allocator, expr, expr_idx)
         ndrop = 0
     end
-    
-    @union_split_smallvec regions begin
-        for (region, val_idx) in Iterators.drop(zip(regions, values_exprs_idxs), ndrop)
-            val = cs.ir[val_idx]
-            # We are writing to a single element
-            if all(isone ∘ length, region)
-                lhs = Expr(:ref, output_buffer)
-                @union_split_smallvec region for ax in region
-                    push!(lhs.args, first(ax))
-                end
-                # The most common case here is that `val` is an `array_literal` with one element.
-                # Instead of fetching the canonical expr for it, special case this to work on the
-                # graph.
-                rhs = @match val begin
-                    BSImpl.Term(; f) && if f === SymbolicUtils.array_literal end => begin
-                        first_val_idx = Graphs.outneighbors(cs.ir.dependency_graph, val_idx)[2]
-                        cs(cs.ir[first_val_idx])
-                    end
-                    _ => begin
-                        # Unfortunately, scalarizing `val` requires getting the canonical expr.
-                        val = cs(SymbolicUtils.get_canonical_expr(cs.ir, val_idx))
-                        cs(val[SymbolicUtils.stable_eachindex(val)[1]])
-                    end
-                end
-                declare!(cs, lhs, rhs)
-                continue
-            end
 
-            # Materialize the view into the output buffer that we will write to.
-            view_expr = Expr(:call, view, output_buffer)
-            @union_split_smallvec region append!(view_expr.args, region)
-            vw = declare!(cs, get_misc_identifier(cs), view_expr)
-            @match val begin
-                # Replace the allocator. We want it to write directly to the output
-                # No point constructing a new expression, just do what `with_allocator`
-                # would do in `codegen_ir!`.
-                BSImpl.Term(; f) && if f === with_allocator end => begin
-                    old_allocator = add_allocator!(cs, ExistingBufferAllocator(vw))
-                    val_nbors = Graphs.outneighbors(cs.ir.dependency_graph, val_idx)
-                    cs(cs.ir[val_nbors[2]])
-                    reset_allocator!(cs, old_allocator)
-                end
-                # Any other operation that supports `with_allocator` should be generated to
-                # write to the buffer directly.
-                _ && if supports_with_allocator(val) end => begin
-                    old_allocator = add_allocator!(cs, ExistingBufferAllocator(vw))
-                    cs(val)
-                    reset_allocator!(cs, old_allocator)
-                end
-                # Constant arrays can special-case
-                BSImpl.Const(; val) => write_constant_array!(cs, vw, val)
-                # We don't have a fallback, so materialize the array corresponding to `val`
-                # and `copyto!` it into the output buffer.
-                _ => begin
-                    temp_array = cs(val)
-                    declare!(cs, get_misc_identifier(cs), Expr(:call, copyto!, vw, temp_array))
-                end
+    # Indices and values of regions that write to a scalar
+    scalar_idxs = Dict{ShapeVecT, Any}()
+    D = length(sh)::Int
+    # Utility buffers
+    one_regions = ShapeVecT[]
+    negone_regions = ShapeVecT[]
+    other_regions = ShapeVecT[]
+    other_values = Any[]
+
+    function materialize_scalar_writes()
+        empty!(one_regions)
+        empty!(negone_regions)
+        empty!(other_regions)
+        empty!(other_values)
+        # Batch all writes of +-1 together
+        for region in keys(scalar_idxs)
+            _val = scalar_idxs[region]
+            if _val === 1
+                push!(one_regions, region)
+            elseif _val === -1
+                push!(negone_regions, region)
+            else
+                push!(other_regions, region)
+                push!(other_values, _val)
             end
+        end
+        if !isempty(one_regions)
+            idxs_buffer = Vector{CartesianIndex{D}}(map(CartesianIndex{D} ∘ Tuple ∘ Base.Fix1(map, first), one_regions))
+            # Directly interpolating an array into an expression avoids the allocation.
+            declare!(cs, :_, Expr(:call, batched_setindex!, output_buffer, 1, idxs_buffer))
+        end
+        if !isempty(negone_regions)
+            idxs_buffer = Vector{CartesianIndex{D}}(map(CartesianIndex{D} ∘ Tuple ∘ Base.Fix1(map, first), negone_regions))
+            declare!(cs, :_, Expr(:call, batched_setindex!, output_buffer, -1, idxs_buffer))
+        end
+        # Use `Iterators.partition` to avoid creating overly large tuples
+        for (regs, vals) in zip(
+                Iterators.partition(other_regions, BATCHED_SETINDEX_BATCH_SIZE),
+                Iterators.partition(other_values, BATCHED_SETINDEX_BATCH_SIZE)
+            )
+            vals_expr = Expr(:tuple)
+            append!(vals_expr.args, vals)
+            idxs_expr = Expr(:tuple)
+            for reg in regs
+                push!(idxs_expr.args, CartesianIndex{D}(Tuple(map(first, reg))))
+            end
+            declare!(cs, :_, Expr(:call, batched_setindex!, output_buffer, vals_expr, idxs_expr))
         end
     end
 
+    for cur_region in Iterators.drop(eachindex(regions), ndrop)
+        region = regions[cur_region]
+        val_idx = values_exprs_idxs[cur_region]
+        val = cs.ir[val_idx]
+        # We are writing to a single element
+        if all(isone ∘ length, region)
+            # The goal is to batch scalar writes, so we defer them. Storing them in a
+            # `Dict` allows later writes to overwrite earlier ones without additional
+            # codegen.
+            @match val begin
+                BSImpl.Const(; val = _val) => begin
+                    _inner = first(_val)
+                    if _isone(_inner)
+                        scalar_idxs[region] = 1
+                    elseif _isone(-_inner)
+                        scalar_idxs[region] = -1
+                    else
+                        scalar_idxs[region] = _inner
+                    end
+                end
+                BSImpl.Term(; f) && if f === SymbolicUtils.array_literal end => begin
+                    first_val_idx = Graphs.outneighbors(cs.ir.dependency_graph, val_idx)[2]
+                    scalar_idxs[region] = cs(cs.ir[first_val_idx])
+                end
+                _ => begin
+                    # Unfortunately, scalarizing `val` requires getting the canonical expr.
+                    val = cs(SymbolicUtils.get_canonical_expr(cs.ir, val_idx))
+                    scalar_idxs[region] = cs(val[SymbolicUtils.stable_eachindex(val)[1]])
+                end
+            end
+            continue
+        end
+
+        # We are writing to a block. First, materialize all scalar writes that happened until now.
+        # This is operating on the assumption that non-scalar writes conflict with all scalar writes.
+        # If this case is hit frequently, it might be useful to check for actual conflicts.
+        if !isempty(scalar_idxs)
+            materialize_scalar_writes()
+        end
+        empty!(scalar_idxs)
+        # Materialize the view into the output buffer that we will write to.
+        view_expr = Expr(:call, view, output_buffer)
+        @union_split_smallvec region append!(view_expr.args, region)
+        vw = declare!(cs, get_misc_identifier(cs), view_expr)
+        @match val begin
+            # Replace the allocator. We want it to write directly to the output
+            # No point constructing a new expression, just do what `with_allocator`
+            # would do in `codegen_ir!`.
+            BSImpl.Term(; f) && if f === with_allocator end => begin
+                old_allocator = add_allocator!(cs, ExistingBufferAllocator(vw))
+                val_nbors = Graphs.outneighbors(cs.ir.dependency_graph, val_idx)
+                cs(cs.ir[val_nbors[2]])
+                reset_allocator!(cs, old_allocator)
+            end
+            # Any other operation that supports `with_allocator` should be generated to
+            # write to the buffer directly.
+            _ && if supports_with_allocator(val) end => begin
+                old_allocator = add_allocator!(cs, ExistingBufferAllocator(vw))
+                cs(val)
+                reset_allocator!(cs, old_allocator)
+            end
+            # Constant arrays can special-case
+            BSImpl.Const(; val) => write_constant_array!(cs, vw, val)
+            # We don't have a fallback, so materialize the array corresponding to `val`
+            # and `copyto!` it into the output buffer.
+            _ => begin
+                temp_array = cs(val)
+                declare!(cs, get_misc_identifier(cs), Expr(:call, copyto!, vw, temp_array))
+            end
+        end
+    end
+    if !isempty(scalar_idxs)
+        materialize_scalar_writes()
+    end
     return declare!(cs, get_misc_identifier(cs), output_buffer)
 end
 

--- a/test/new_code.jl
+++ b/test/new_code.jl
@@ -1047,3 +1047,142 @@ end
     end
 end
 
+@testset "batched_setindex!" begin
+    # NTuple of values, NTuple of CartesianIndex (1D)
+    buf = zeros(Int, 5)
+    Code.batched_setindex!(buf, (10, 20, 30), (CartesianIndex(1), CartesianIndex(3), CartesianIndex(5)))
+    @test buf == [10, 0, 20, 0, 30]
+
+    # NTuple of values, NTuple of CartesianIndex (2D)
+    buf2d = zeros(Int, 3, 3)
+    Code.batched_setindex!(buf2d, (7, 8), (CartesianIndex(1, 2), CartesianIndex(3, 2)))
+    @test buf2d[1, 2] == 7
+    @test buf2d[3, 2] == 8
+    @test count(!iszero, buf2d) == 2
+
+    # Broadcast single value, array of CartesianIndex (1D)
+    buf = zeros(Int, 5)
+    Code.batched_setindex!(buf, 42, [CartesianIndex(1), CartesianIndex(3), CartesianIndex(5)])
+    @test buf == [42, 0, 42, 0, 42]
+
+    # Broadcast single value, array of CartesianIndex (2D)
+    buf2d = zeros(Int, 3, 3)
+    Code.batched_setindex!(buf2d, -1, [CartesianIndex(1, 1), CartesianIndex(2, 2), CartesianIndex(3, 3)])
+    @test buf2d == [-1 0 0; 0 -1 0; 0 0 -1]
+
+    # Empty index array is a no-op
+    buf = zeros(Int, 3)
+    Code.batched_setindex!(buf, 99, CartesianIndex{1}[])
+    @test buf == [0, 0, 0]
+end
+
+@testset "ArrayMaker batched scalar-write codegen" begin
+    @syms a::Real b::Real
+
+    # 20-element array: exercises the batched_setindex! codegen path.
+    # FILL_ARR_LIMIT == 16, so arrays of size > 16 use batched_setindex! for scalar writes.
+    # Entries 1–3 are 1 (→ idxs_buffer broadcast path for value 1).
+    # Entries 4–5 are -1 (→ idxs_buffer broadcast path for value -1).
+    # Entries 6–20 are symbolic (→ NTuple batching, split across multiple calls because
+    # BATCHED_SETINDEX_BATCH_SIZE == 8).
+    w = @makearray w[1:20] begin
+        w[1:1]   => [1]
+        w[2:2]   => [1]
+        w[3:3]   => [1]
+        w[4:4]   => [-1]
+        w[5:5]   => [-1]
+        w[6:6]   => [a]
+        w[7:7]   => [b]
+        w[8:8]   => [a + b]
+        w[9:9]   => [2a]
+        w[10:10] => [2b]
+        w[11:11] => [a - b]
+        w[12:12] => [3a]
+        w[13:13] => [a^2]
+        w[14:14] => [b^2]
+        w[15:15] => [a + 1]
+        w[16:16] => [b + 1]
+        w[17:17] => [a * b]
+        w[18:18] => [a - 1]
+        w[19:19] => [b - 1]
+        w[20:20] => Const{SymReal}([a + b + 1])
+    end
+    av = 3.0
+    bv = 2.0
+    result = eval(quote
+        let a = $av, b = $bv
+            $(Code.fast_toexpr(w, Dict{Any,Any}()))
+        end
+    end)
+    expected = [1.0, 1.0, 1.0, -1.0, -1.0, av, bv, av+bv, 2av, 2bv, av-bv, 3av, av^2, bv^2, av+1, bv+1, av*bv, av-1, bv-1, av+bv+1]
+    @test result ≈ expected
+
+    @testset "later scalar writes overwrite earlier ones" begin
+        # Scalar writes to the same index are stored in a Dict; later entries win.
+        w2 = @makearray w2[1:20] begin
+            w2[1:1]  => [a]
+            w2[2:2]  => [1]
+            w2[3:3]  => [1]
+            w2[4:4]  => [1]
+            w2[5:5]  => [1]
+            w2[6:6]  => [1]
+            w2[7:7]  => [1]
+            w2[8:8]  => [1]
+            w2[9:9]  => [1]
+            w2[10:10] => [1]
+            w2[11:11] => [1]
+            w2[12:12] => [1]
+            w2[13:13] => [1]
+            w2[14:14] => [1]
+            w2[15:15] => [1]
+            w2[16:16] => [1]
+            w2[17:17] => [1]
+            w2[18:18] => [1]
+            w2[19:19] => [1]
+            w2[20:20] => [1]
+            w2[1:1]  => Const{SymReal}([b])
+        end
+        result2 = eval(quote
+            let a = $av, b = $bv
+                $(Code.fast_toexpr(w2, Dict{Any,Any}()))
+            end
+        end)
+        @test result2[1] ≈ bv
+        @test all(result2[2:end] .≈ 1.0)
+    end
+
+    @testset "scalar writes flushed before block write" begin
+        @syms xv[1:3]::Real
+        # Scalar writes at indices 1–17 followed by a block write at 18–20.
+        # The block write must trigger flushing of all preceding scalar writes.
+        w3 = @makearray w3[1:20] begin
+            w3[1:1]   => [1]
+            w3[2:2]   => [1]
+            w3[3:3]   => [1]
+            w3[4:4]   => [1]
+            w3[5:5]   => [1]
+            w3[6:6]   => [1]
+            w3[7:7]   => [1]
+            w3[8:8]   => [1]
+            w3[9:9]   => [1]
+            w3[10:10] => [1]
+            w3[11:11] => [1]
+            w3[12:12] => [1]
+            w3[13:13] => [1]
+            w3[14:14] => [1]
+            w3[15:15] => [1]
+            w3[16:16] => [1]
+            w3[17:17] => [1]
+            w3[18:20] => xv
+        end
+        xdata = [10.0, 20.0, 30.0]
+        result3 = eval(quote
+            let xv = $xdata
+                $(Code.fast_toexpr(w3, Dict{Any,Any}()))
+            end
+        end)
+        @test all(result3[1:17] .≈ 1.0)
+        @test result3[18:20] ≈ xdata
+    end
+end
+


### PR DESCRIPTION
This aims to reduce the size of the generated code for large `ArrayMaker`s and subsequently improve compilation times.