### PR TITLE
refactor: greatly improve performance of `get_canonical_expr`

### DIFF
--- a/src/faster_code.jl
+++ b/src/faster_code.jl
@@ -8,7 +8,7 @@ using Dictionaries
 
 # NOTE:
 # Codegen relies on fewer invariants than `IRStructure` in general. It is designed to work
-# even when `ir.is_canonical[] == false`. The invariants that it relies on are:
+# even when `ir.non_canonical_idxs` is non-empty. The invariants that it relies on are:
 # 1. `operation(ir[idx::Integer])` is the correct operation to generate.
 # 2. `symtype(ir[idx])` and `shape(ir[idx])` are the correct symtype and shape of the expression.
 # 3. `outneighbors(ir.dependency_graph, idx)` corresponds in order to `arguments(ir[idx])`. In
@@ -735,7 +735,7 @@ const NARY_CALL_LIMIT = 12
 
 function codegen_function!(@nospecialize(op::Union{typeof(*), typeof(+)}), cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
     if get(cs.rewrites, :sort_addmul, true)::Bool
-        @assert cs.ir.is_canonical[] "Sorted add/mul requires canonical IRStructure"
+        @assert isempty(cs.ir.non_canonical_idxs) "Sorted add/mul requires canonical IRStructure"
         args_idxs = Int32[]
         sargs = sorted_arguments(expr)
         for arg in sargs

--- a/src/irstructure.jl
+++ b/src/irstructure.jl
@@ -895,43 +895,51 @@ by recursively descending through the DAG.
 """
 function __get_canonical_expr(ir::IRStructure{T}, idx::Integer) where {T}
     i_sym = ir[idx]
-    nbors = Graphs.outneighbors(ir.dependency_graph, idx)
-    # If this is a leaf, there's nothing to do
-    isempty(nbors) && return i_sym
 
-    # Track whether the expression actually needs to change
-    dirty = false
-    n_drop = 0
-    op = operation(i_sym)
-    # If the operation is symbolic, it is the first entry in `nbors`.
-    if op isa BasicSymbolic{T}
-        n_drop = 1
-        new_op = __get_canonical_expr(ir, first(nbors))
-        # If the operation is different, the tree is dirty
-        if new_op !== op
-            op = new_op
-            dirty = true
-        end
-    end
-    new_args = parent(arguments(i_sym))
-    # Avoid copying and allocating a new buffer if possible
-    args_dirty = false
-    for (i, arg_idx) in enumerate(Iterators.drop(nbors, n_drop))
-        new_expr = __get_canonical_expr(ir, arg_idx)
-        # If the argument changed, then it is dirty
-        if new_expr !== new_args[i]
-            # Allocate a new buffer if we haven't already
-            if !args_dirty
-                new_args = copy(new_args)
+    reachability = get_cached_idxs!(ir)
+    empty!(reachability)
+    get_reachability!(reachability, ir, idx)
+    push!(reachability, idx)
+    # `reachability` is in topological order. We can iterate over it, and update
+    # any non-canonical nodes as we encounter them. Once we update a node, we mark
+    # all its `inneighbors` as non-canonical.
+    for node in reachability
+        node in ir.non_canonical_idxs || continue
+        i_sym = ir[node]
+        nbors = Graphs.outneighbors(ir.dependency_graph, node)
+        n_drop = 0
+        op = operation(i_sym)
+        # If the operation is symbolic, it is the first entry in `nbors`.
+        if op isa BasicSymbolic{T}
+            n_drop = 1
+            new_op = ir[first(nbors)]
+            # If the operation is different, the tree is dirty
+            if new_op !== op
+                op = new_op
             end
-            dirty = true
-            args_dirty = true
-            new_args[i] = new_expr
         end
+        new_args = parent(arguments(i_sym))
+        # Avoid copying and allocating a new buffer if possible
+        args_dirty = false
+        for (i, arg_idx) in enumerate(Iterators.drop(nbors, n_drop))
+            new_expr = ir[arg_idx]
+            # If the argument changed, then it is dirty
+            if new_expr !== new_args[i]
+                # Allocate a new buffer if we haven't already
+                if !args_dirty
+                    new_args = copy(new_args)
+                end
+                args_dirty = true
+                new_args[i] = new_expr
+            end
+        end
+        # Update the expression for this node
+        ir.symbols[node] = maketerm(BasicSymbolic{T}, op, new_args, metadata(i_sym))::BasicSymbolic{T}
+        # `node` is now canonical
+        delete!(ir.non_canonical_idxs, node)
+        # All its `inneighbors` are still non-canonical
+        union!(ir.non_canonical_idxs, Graphs.inneighbors(ir.dependency_graph, node))
     end
 
-    # If the expression is unchanged, no need to do anything
-    dirty || return i_sym
-    # Build the new canonical expression
-    return maketerm(BasicSymbolic{T}, op, new_args, metadata(i_sym))::BasicSymbolic{T}
+    return ir[idx]
 end

--- a/src/irstructure.jl
+++ b/src/irstructure.jl
@@ -850,7 +850,8 @@ the canonical form of `ir`.
 """
 function replace_node!(ir::IRStructure{T}, old::BasicSymbolic{T}, new::BasicSymbolic{T}) where {T}
     idx = ir[old]
-    push!(ir.non_canonical_idxs, idx)
+    # Any nodes that currently depend on `old` are non-canonical
+    union!(ir.non_canonical_idxs, Graphs.inneighbors(ir.dependency_graph, idx))
     ir.symbols[idx] = new
     delete!(ir.definition, old)
     weakdefs = ir.weak_definitions[old]

--- a/src/irstructure.jl
+++ b/src/irstructure.jl
@@ -56,14 +56,14 @@ struct IRStructure{T}
     """
     cached_idxs::Vector{Int32}
     """
-    Flag indicating whether the struct is in canonical form. Canonical form implies that
+    Set of indices whose expressions have been replaced via [`SymbolicUtils.replace_node!`](@ref).
+    The `IRStructure` is in canonical form when this set is empty. Canonical form implies that
     for an expression `ex` at index `idx` in `ir::IRStructure`, there exists an edge
     from `idx` to `ir[arguments(ex)[j]]` for all valid `j` and that
-    `arguments(ex)[j] === ir[ir[arguments(ex)[j]]]`. This is typically broken by
-    [`SymbolicUtils.replace_node!`](@ref). The graph invariants are still maintained
+    `arguments(ex)[j] === ir[ir[arguments(ex)[j]]]`. The graph invariants are still maintained
     after the canonical form is broken.
     """
-    is_canonical::Base.RefValue{Bool}
+    non_canonical_idxs::BitSet
 end
 
 """
@@ -75,7 +75,7 @@ function IRStructure{T}() where {T}
     ir = IRStructure{T}(
         OrderedDiGraph{Int32}(), BasicSymbolic{T}[],
         IdDict{BasicSymbolic{T}, Int32}(), Dict{BasicSymbolic{T}, Vector{Int32}}(),
-        BitVector(), Int32[], Ref{Bool}(true)
+        BitVector(), Int32[], BitSet()
     )
     # It's pretty easy to hit this
     sizehint!(ir, 100)
@@ -127,7 +127,7 @@ function Base.showerror(io::IO, err::IRStructureNotCanonicalError)
 end
 
 @noinline function require_canonical(ir::IRStructure)
-    ir.is_canonical[] && return
+    isempty(ir.non_canonical_idxs) && return
     throw(IRStructureNotCanonicalError())
 end
 
@@ -191,7 +191,7 @@ function Base.copy(ir::IRStructure{T}) where {T}
         Dict(k => copy(v) for (k, v) in ir.weak_definitions),
         copy(ir.cached_mask),
         copy(ir.cached_idxs),
-        Ref{Bool}(ir.is_canonical[]),
+        copy(ir.non_canonical_idxs),
     )
 end
 
@@ -849,8 +849,8 @@ at `old` is now `new`, and the arguments of `new` form the out-neighbors of the 
 the canonical form of `ir`.
 """
 function replace_node!(ir::IRStructure{T}, old::BasicSymbolic{T}, new::BasicSymbolic{T}) where {T}
-    ir.is_canonical[] = false
     idx = ir[old]
+    push!(ir.non_canonical_idxs, idx)
     ir.symbols[idx] = new
     delete!(ir.definition, old)
     weakdefs = ir.weak_definitions[old]
@@ -877,11 +877,11 @@ end
 """
     $TYPEDSIGNATURES
 
-If `ir.is_canonical[]`, return `ir[idx]`. Otherwise, find the canonical expression that `ir[idx]`
-should be, were `IRSubstituter` used instead of `replace_node!`.
+If `ir.non_canonical_idxs` is empty, return `ir[idx]`. Otherwise, find the canonical expression
+that `ir[idx]` should be, were `IRSubstituter` used instead of `replace_node!`.
 """
 function get_canonical_expr(ir::IRStructure{T}, idx::Integer) where {T}
-    ir.is_canonical[] && return ir[idx]
+    isempty(ir.non_canonical_idxs) && return ir[idx]
 
     return __get_canonical_expr(ir, idx)
 end

--- a/test/irstructure.jl
+++ b/test/irstructure.jl
@@ -262,7 +262,7 @@ end
         @test length(ir) == n_before          # no new node created
         @test !haskey(ir.definition, x)       # old removed from definition
         @test x_idx in ir.weak_definitions[y] # new registered at same index
-        @test !ir.is_canonical[]
+        @test !isempty(ir.non_canonical_idxs)
         # leaf had no outgoing edges; they are still absent
         @test isempty(Graphs.outneighbors(ir.dependency_graph, x_idx))
     end
@@ -279,7 +279,8 @@ end
         @test length(ir) == n_before          # no new node for the expression itself
         @test !haskey(ir.definition, x + y)
         @test idx in ir.weak_definitions[x * y]
-        @test !ir.is_canonical[]
+        # Nothing depends on `idx`, so the IR is still canonical
+        @test isempty(ir.non_canonical_idxs)
         # outneighbors now match x*y's arguments in argument order
         nbors    = collect(Graphs.outneighbors(ir.dependency_graph, idx))
         expected = [ir.definition[arg] for arg in arguments(x * y)
@@ -297,7 +298,7 @@ end
 
         @test isequal(ir[idx], rn_symfn(x, y))
         @test !haskey(ir.definition, x + y)
-        @test !ir.is_canonical[]
+        @test isempty(ir.non_canonical_idxs)
         # symbolic op must be first outneighbor, then args in order
         nbors = collect(Graphs.outneighbors(ir.dependency_graph, idx))
         @test nbors[1] == ir.definition[rn_symfn]
@@ -352,7 +353,7 @@ end
         ir = IRStructure{SymReal}()
         expr = x + sin(y)
         populate_ir!(ir, expr)
-        @test ir.is_canonical[]
+        @test isempty(ir.non_canonical_idxs)
         idx = ir[expr]
         @test SU.get_canonical_expr(ir, idx) === ir[idx]
     end
@@ -363,7 +364,7 @@ end
         populate_ir!(ir, cos(y))
         sin_idx = ir[sin(x)]
         replace_node!(ir, y, x)   # affects cos(y) only, not sin(x)
-        @test !ir.is_canonical[]
+        @test !isempty(ir.non_canonical_idxs)
         @test SU.get_canonical_expr(ir, sin_idx) === ir[sin_idx]
     end
 
@@ -372,7 +373,7 @@ end
         populate_ir!(ir, sin(x))
         sin_idx = ir[sin(x)]
         replace_node!(ir, x, y)
-        @test !ir.is_canonical[]
+        @test !isempty(ir.non_canonical_idxs)
         @test isequal(SU.get_canonical_expr(ir, sin_idx), sin(y))
     end
 
@@ -381,7 +382,7 @@ end
         populate_ir!(ir, cos(x + y))
         cos_idx = ir[cos(x + y)]
         replace_node!(ir, x + y, x * y)
-        @test !ir.is_canonical[]
+        @test !isempty(ir.non_canonical_idxs)
         @test isequal(SU.get_canonical_expr(ir, cos_idx), cos(x * y))
     end
 
@@ -392,7 +393,7 @@ end
         populate_ir!(ir, fn(x))
         fn_x_idx = ir[fn(x)]
         replace_node!(ir, x, y)
-        @test !ir.is_canonical[]
+        @test !isempty(ir.non_canonical_idxs)
         @test isequal(SU.get_canonical_expr(ir, fn_x_idx), fn(y))
     end
 end
@@ -456,7 +457,7 @@ function make_reversed_ir(T, root_expr::BasicSymbolic)
             end
         end
     end
-    IRStructure{T}(dep_graph, reversed_symbols, reversed_def, Dict{BasicSymbolic{T}, Vector{Int32}}(), BitVector(), Int32[], Ref{Bool}(true))
+    IRStructure{T}(dep_graph, reversed_symbols, reversed_def, Dict{BasicSymbolic{T}, Vector{Int32}}(), BitVector(), Int32[], BitSet())
 end
 
 @testset "Out-of-order IRStructure" begin

--- a/test/new_code.jl
+++ b/test/new_code.jl
@@ -863,7 +863,7 @@ end
         ir = IRStructure{SymReal}()
         populate_ir!(ir, sin(a + b))
         replace_node!(ir, a + b, a * b)
-        @test !ir.is_canonical[]
+        @test !isempty(ir.non_canonical_idxs)
         expr = Code.fast_toexpr(sin(a + b), ir, Dict{Any,Any}(:sort_addmul => false))
         result = eval(quote let a = 2.0, b = 3.0; $expr end end)
         @test result ≈ sin(2.0 * 3.0)
@@ -874,7 +874,7 @@ end
         ir = IRStructure{SymReal}()
         populate_ir!(ir, sin(a + b))
         replace_node!(ir, a + b, a * b)
-        @test !ir.is_canonical[]
+        @test !isempty(ir.non_canonical_idxs)
         expr = Code.fast_toexpr(
             sin(a + b), ir, Dict{Any,Any}(:nanmath => true, :sort_addmul => false)
         )
@@ -887,7 +887,7 @@ end
         let ir = IRStructure{SymReal}()
             populate_ir!(ir, a + b + c)
             replace_node!(ir, a, d)
-            @test !ir.is_canonical[]
+            @test !isempty(ir.non_canonical_idxs)
             expr = Code.fast_toexpr(a + b + c, ir, Dict{Any,Any}(:sort_addmul => false))
             result = eval(quote let a = 1.0, b = 2.0, c = 3.0, d = 10.0; $expr end end)
             @test result ≈ 10.0 + 2.0 + 3.0
@@ -896,7 +896,7 @@ end
         let ir = IRStructure{SymReal}()
             populate_ir!(ir, a * b * c)
             replace_node!(ir, a, d)
-            @test !ir.is_canonical[]
+            @test !isempty(ir.non_canonical_idxs)
             expr = Code.fast_toexpr(a * b * c, ir, Dict{Any,Any}(:sort_addmul => false))
             result = eval(quote let a = 1.0, b = 2.0, c = 3.0, d = 10.0; $expr end end)
             @test result ≈ 10.0 * 2.0 * 3.0
@@ -909,7 +909,7 @@ end
         let ir = IRStructure{SymReal}()
             populate_ir!(ir, a^b)
             replace_node!(ir, a, c)
-            @test !ir.is_canonical[]
+            @test !isempty(ir.non_canonical_idxs)
             expr = Code.fast_toexpr(a^b, ir, Dict{Any,Any}(:sort_addmul => false))
             result = eval(quote let a = 2.0, b = 3.0, c = 4.0; $expr end end)
             @test result ≈ 4.0^3.0
@@ -918,7 +918,7 @@ end
         let ir = IRStructure{SymReal}()
             populate_ir!(ir, a^2)
             replace_node!(ir, a, c)
-            @test !ir.is_canonical[]
+            @test !isempty(ir.non_canonical_idxs)
             expr = Code.fast_toexpr(a^2, ir, Dict{Any,Any}(:sort_addmul => false))
             result = eval(quote let a = 2.0, c = 3.0; $expr end end)
             @test result ≈ 3.0^2
@@ -931,7 +931,7 @@ end
         ir = IRStructure{SymReal}()
         populate_ir!(ir, ifelse(cond, b, c))
         replace_node!(ir, b, d)
-        @test !ir.is_canonical[]
+        @test !isempty(ir.non_canonical_idxs)
         expr = Code.fast_toexpr(ifelse(cond, b, c), ir, Dict{Any,Any}(:sort_addmul => false))
         result = eval(quote let a = -1.0, b = 10.0, c = 20.0, d = 30.0; $expr end end)
         @test result ≈ 30.0  # a < 0 is true, so uses d (replaced from b)
@@ -942,7 +942,7 @@ end
         ir = IRStructure{SymReal}()
         populate_ir!(ir, x[idx1])
         replace_node!(ir, idx1, idx2)
-        @test !ir.is_canonical[]
+        @test !isempty(ir.non_canonical_idxs)
         expr = Code.fast_toexpr(x[idx1], ir, Dict{Any,Any}())
         result = eval(quote let x = [10, 20, 30], idx1 = 1, idx2 = 2; $expr end end)
         @test result == 20  # x[idx2] = x[2] = 20
@@ -954,7 +954,7 @@ end
         ir = IRStructure{SymReal}()
         populate_ir!(ir, arr)
         replace_node!(ir, Const{SymReal}(yv), Const{SymReal}(zv))
-        @test !ir.is_canonical[]
+        @test !isempty(ir.non_canonical_idxs)
         block = _codegen_to_block(ir, arr, Dict{Any,Any}(:sort_addmul => false))
         xdata = [1.0, 2.0, 3.0]; ydata = [10.0, 10.0, 10.0]; zdata = [4.0, 5.0, 6.0]
         result = eval(quote let xv = $xdata, yv = $ydata, zv = $zdata; $block end end)
@@ -970,7 +970,7 @@ end
         # Pre-populate the inner Term so its graph edges already exist before replace_node!
         populate_ir!(ir, _arrayop_term(fill_expr))
         replace_node!(ir, a, b)
-        @test !ir.is_canonical[]
+        @test !isempty(ir.non_canonical_idxs)
         block = _codegen_to_block(ir, fill_expr)
         result = eval(quote let a = 2.0, b = 5.0; $block end end)
         @test result == fill(5.0, 3)
@@ -986,7 +986,7 @@ end
         ir = IRStructure{SymReal}()
         populate_ir!(ir, w)
         replace_node!(ir, a, c)
-        @test !ir.is_canonical[]
+        @test !isempty(ir.non_canonical_idxs)
         expr = Code.fast_toexpr(w, ir, Dict{Any,Any}(:sort_addmul => false))
         av = 2.0; bv = 5.0; cv = 7.0
         result = eval(quote let a = $av, b = $bv, c = $cv; $expr end end)
@@ -1001,7 +1001,7 @@ end
         let ir = IRStructure{SymReal}()
             populate_ir!(ir, arr_lit)
             replace_node!(ir, a, d)
-            @test !ir.is_canonical[]
+            @test !isempty(ir.non_canonical_idxs)
             expr = Code.fast_toexpr(arr_lit, ir, Dict{Any,Any}())
             result = eval(quote let a = 1.0, b = 2.0, c = 3.0, d = 10.0; $expr end end)
             @test result ≈ [10.0, 2.0, 3.0]
@@ -1010,7 +1010,7 @@ end
         let ir = IRStructure{SymReal}()
             populate_ir!(ir, arr_lit)
             replace_node!(ir, a, d)
-            @test !ir.is_canonical[]
+            @test !isempty(ir.non_canonical_idxs)
             wrapped = Code.with_allocator(ones, arr_lit)
             expr = Code.fast_toexpr(wrapped, ir, Dict{Any,Any}(:sort_addmul => false))
             result = eval(quote let a = 1.0, b = 2.0, c = 3.0, d = 10.0; $expr end end)
@@ -1025,7 +1025,7 @@ end
         populate_ir!(ir, ex_map)
         populate_ir!(ir, _arrayop_term(ex_map))
         replace_node!(ir, Const{SymReal}(bv), Const{SymReal}(cv))
-        @test !ir.is_canonical[]
+        @test !isempty(ir.non_canonical_idxs)
         block = _codegen_to_block(ir, ex_map, Dict{Any,Any}(:sort_addmul => false))
         xdata = [1.0, 2.0, 3.0]; ydata = [10.0, 10.0, 10.0]; zdata = [4.0, 5.0, 6.0]
         result = eval(quote let av = $xdata, bv = $ydata, cv = $zdata; $block end end)
@@ -1039,7 +1039,7 @@ end
         populate_ir!(ir, ex_mapred)
         populate_ir!(ir, _arrayop_term(ex_mapred))
         replace_node!(ir, Const{SymReal}(bv), Const{SymReal}(cv))
-        @test !ir.is_canonical[]
+        @test !isempty(ir.non_canonical_idxs)
         block = _codegen_to_block(ir, ex_mapred, Dict{Any,Any}(:sort_addmul => false))
         xdata = [1.0, 2.0, 3.0]; ydata = [10.0, 10.0, 10.0]; zdata = [4.0, 5.0, 6.0]
         result = eval(quote let av = $xdata, bv = $ydata, cv = $zdata; $block end end)


### PR DESCRIPTION
Without this change, if codegen happened to call `get_canonical_expr` it would take ridiculous amounts of time on large expressions.