### PR TITLE
expand: fold literal `complex(re, im)` Terms in to_poly!

### DIFF
--- a/src/polyform.jl
+++ b/src/polyform.jl
@@ -120,6 +120,13 @@ function to_poly!(poly_to_bs::AbstractDict, bs_to_poly::AbstractDict, expr::Basi
                     MA.operate!(f, poly, to_poly!(poly_to_bs, bs_to_poly, arg))
                 end
                 return poly
+            elseif f === complex && length(args) == 2
+                # `Term(complex, [re, im])` (produced by
+                # `Symbolics.unwrap(::Complex{Num})` when either component is
+                # symbolic) is otherwise opaque to expansion. Treat it as
+                # `re + 1im * im` polynomially so identically-zero diffs that
+                # contain such a literal reduce under `simplify(...; expand=true)`.
+                return to_poly!(poly_to_bs, bs_to_poly, args[1] + 1im * args[2], recurse)
             else
                 if recurse
                     expr = BSImpl.Term{T}(f, map(expand, args); type, shape)

--- a/src/simplify_rules.jl
+++ b/src/simplify_rules.jl
@@ -70,15 +70,6 @@ const ASSORTED_RULES = (
     @rule(conj(~x::_isreal) => ~x),
     @rule(real(~x::_isreal) => ~x),
     @rule(imag(~x::_isreal) => zero(symtype(~x))),
-    # Fold `complex(re, im)` literals (produced e.g. by
-    # `Symbolics.unwrap(::Complex{Num})` when re/im are symbolic) into the
-    # additive form `re + 1im*im`. `Term(complex, [re, im])` is otherwise
-    # opaque to `expand` / `simplify(...; expand=true)`, so identically-zero
-    # diffs that contain it never reduce to 0. `unwrap(::Complex{Num})`
-    # always produces Real-typed re/im, so `1im * ~im` stays in clean
-    # `Complex{Bool} * BasicSymbolic{<:Real}` arithmetic and doesn't loop
-    # back into a literal.
-    @rule(complex(~re, ~im) => ~re + 1im * ~im),
     @rule(ifelse(~x::is_literal_number, ~y, ~z) => ~x ? ~y : ~z),
     @rule(ifelse(~x, ~y, ~y) => ~y),
 )

--- a/src/simplify_rules.jl
+++ b/src/simplify_rules.jl
@@ -70,6 +70,15 @@ const ASSORTED_RULES = (
     @rule(conj(~x::_isreal) => ~x),
     @rule(real(~x::_isreal) => ~x),
     @rule(imag(~x::_isreal) => zero(symtype(~x))),
+    # Fold `complex(re, im)` literals (produced e.g. by
+    # `Symbolics.unwrap(::Complex{Num})` when re/im are symbolic) into the
+    # additive form `re + 1im*im`. `Term(complex, [re, im])` is otherwise
+    # opaque to `expand` / `simplify(...; expand=true)`, so identically-zero
+    # diffs that contain it never reduce to 0. `unwrap(::Complex{Num})`
+    # always produces Real-typed re/im, so `1im * ~im` stays in clean
+    # `Complex{Bool} * BasicSymbolic{<:Real}` arithmetic and doesn't loop
+    # back into a literal.
+    @rule(complex(~re, ~im) => ~re + 1im * ~im),
     @rule(ifelse(~x::is_literal_number, ~y, ~z) => ~x ? ~y : ~z),
     @rule(ifelse(~x, ~y, ~y) => ~y),
 )

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -27,10 +27,14 @@ end
     @eqtest simplify(Term{SymReal}(imag, [y]; type = Real)) == imag(y)
 
     # `complex(re, im)` literal Terms (e.g. produced by
-    # `Symbolics.unwrap(::Complex{Num})`) are opaque to `expand`. Fold them
-    # into additive form so identically-zero diffs containing them reduce.
+    # `Symbolics.unwrap(::Complex{Num})`) are opaque to `expand`. The poly
+    # conversion treats them as `re + 1im*im` so identically-zero diffs that
+    # contain them reduce under `simplify(...; expand=true)`. Plain `simplify`
+    # leaves the literal alone so downstream eager dispatches on `real` /
+    # `imag` / `conj` of `Term(complex, ...)` keep working.
     c_term = Term{SymReal}(complex, [x, x]; type = Complex{Real})
-    @eqtest simplify(c_term) == x + 1im * x
+    @eqtest simplify(c_term) == c_term
+    @eqtest simplify(c_term; expand = true) == (1 + 1im) * x
     # The classic motivating case: a polynomial difference that contains a
     # literal `complex(0, c)` should reduce to zero under `expand=true`.
     @eqtest unwrap_const(

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -25,6 +25,19 @@ end
     @eqtest simplify(Term{SymReal}(real, [x]; type = Real)) == x
     @eqtest unwrap_const(simplify(Term{SymReal}(imag, [x]; type = Real))) == 0
     @eqtest simplify(Term{SymReal}(imag, [y]; type = Real)) == imag(y)
+
+    # `complex(re, im)` literal Terms (e.g. produced by
+    # `Symbolics.unwrap(::Complex{Num})`) are opaque to `expand`. Fold them
+    # into additive form so identically-zero diffs containing them reduce.
+    c_term = Term{SymReal}(complex, [x, x]; type = Complex{Real})
+    @eqtest simplify(c_term) == x + 1im * x
+    # The classic motivating case: a polynomial difference that contains a
+    # literal `complex(0, c)` should reduce to zero under `expand=true`.
+    @eqtest unwrap_const(
+        simplify(Term{SymReal}(complex, [Term{SymReal}(zero, [x]; type = Real), x];
+                               type = Complex{Real}) - 1im * x;
+                 expand = true),
+    ) == 0
     @eqtest simplify(x - y) == x + -1 * y
     @eqtest simplify(x - sin(y)) == x + -1 * sin(y)
     @eqtest simplify(-sin(x)) == -1 * sin(x)


### PR DESCRIPTION
Fixes #921.

`Term(complex, [re, im])` (from `Symbolics.unwrap(::Complex{Num})`) has no case in `to_poly!`, so `expand` treats it as an opaque `PolyVar`. Identically-zero diffs that contain one don't reduce:

```julia
simplify(1im * Δ * z - z * Δ * 1im; expand = true)
# was:  z*complex(0, Δ) + (0 - 1im)*z*Δ
# now:  0
```

Fix is a single case in `to_poly!`: treat `complex(re, im)` as `re + 1im * im` polynomially.

I originally tried this as a `simplify` rule but that broke downstream tests (Symbolics overloads, ODE solver) because the `Term(complex, ...)` literal is also the shape `Base.real/imag/conj` pattern-match for O(1) extraction and the shape `Complex{Num}` round-trips through. Keeping the rewrite local to `to_poly!` leaves that canonical form alone.