### PR TITLE
set `max_methods` on SymbolicUtils to 1 to reduce sensitivity to invalidations

### DIFF
--- a/src/SymbolicUtils.jl
+++ b/src/SymbolicUtils.jl
@@ -3,6 +3,10 @@ $(DocStringExtensions.README)
 """
 module SymbolicUtils
 
+if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@max_methods"))
+    @eval Base.Experimental.@compiler_options max_methods=1
+end
+
 using DocStringExtensions
 
 export @syms, term, hasmetadata, getmetadata, setmetadata
@@ -221,5 +225,10 @@ end
 
 precompile(Tuple{typeof(Base.show), Base.TTY, SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymbolicUtils.SymReal}})
 precompile(Tuple{typeof(Core.kwcall), NamedTuple{(:color,), Tuple{Symbol}}, typeof(Base.printstyled), Base.TTY, Int64})
+
+let BS = BasicSymbolic{SymReal}
+    precompile(Tuple{typeof(Base.collect), BS})
+    precompile(Tuple{typeof(SymbolicUtils._getindex), Type{SymReal}, BS, Int64, Vararg{Int64}})
+end
 
 end # module


### PR DESCRIPTION
SymbolicUtils has quite a bit of untyped code and therefore easily get invalidated based on random new definitions. Setting `max_methods` to 1 reduces the vulnerability.

As an example, on main, the `collect` and `_getindex` precompile statements added here gets immidiately invalidated upon loading SentinelArrays while on this PR they are not.

As an effect, creating a model (in a proprietary package) goes from

```
14.621059 seconds (87.68 M allocations: 4.293 GiB, 9.44% gc time, 99.19% compilation time: 22% of which was recompilation)
```

to

```
10.415004 seconds (54.97 M allocations: 2.700 GiB, 7.62% gc time, 98.77% compilation time: 8% of which was recompilation)
```

(note the smaller recompilation numbers)
