### PR TITLE
fold conj, real, imag on the symbolic imaginary unit

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -479,6 +479,8 @@ function Base.real(s::BasicSymbolic{T}) where {T}
     @match s begin
         BSImpl.Const(; val) => Const{T}(real(val))
         BSImpl.Term(; f, args) && if f === complex && length(args) == 2 end => args[1]
+        # Match `Symbolics.IM = Sym(:im; type = Number)` structurally.
+        BSImpl.Sym(; name) && if name === :im && symtype(s) === Number end => zero_of_vartype(T)
         _ => Term{T}(real, ArgsT{T}((s,)); type = Real)
     end
 end
@@ -490,6 +492,7 @@ function Base.conj(s::BasicSymbolic{T}) where {T}
         BSImpl.Term(; f, args, type, shape) && if f === complex && length(args) == 2 end => begin
             BSImpl.Term{T}(f, ArgsT{T}(args[1], -args[2]); type, shape)
         end
+        BSImpl.Sym(; name) && if name === :im && symtype(s) === Number end => -s
         _ => Term{T}(conj, ArgsT{T}((s,)); type = symtype(s), shape = shape(s))
     end
 end
@@ -498,6 +501,7 @@ function Base.imag(s::BasicSymbolic{T}) where {T}
     @match s begin
         BSImpl.Const(; val) => Const{T}(imag(val))
         BSImpl.Term(; f, args) && if f === complex && length(args) == 2 end => args[2]
+        BSImpl.Sym(; name) && if name === :im && symtype(s) === Number end => one_of_vartype(T)
         _ => Term{T}(imag, ArgsT{T}((s,)); type = Real)
     end
 end

--- a/test/rulesets.jl
+++ b/test/rulesets.jl
@@ -59,6 +59,16 @@ end
     @test unwrap_const(simplify(Term{SymReal}(zero, [a]))) == 0
     @test unwrap_const(simplify(Term{SymReal}(zero, [b + 1]))) == 0
     @test unwrap_const(simplify(Term{SymReal}(zero, [x + 2]))) == 0
+
+    # Fold for the symbolic imaginary unit (matches `Symbolics.IM`).
+    let IM = SymbolicUtils.Sym{SymReal}(:im; type = Number)
+        @eqtest conj(IM) == -IM
+        @test unwrap_const(real(IM)) == 0
+        @test unwrap_const(imag(IM)) == 1
+        # Same name, non-Number symtype: untouched.
+        not_im = SymbolicUtils.Sym{SymReal}(:im; type = Real)
+        @eqtest conj(not_im) == not_im
+    end
 end
 
 @testset "LiteralReal" begin


### PR DESCRIPTION
Three new `@match` arms in `Base.real`, `Base.conj`, `Base.imag` for `BasicSymbolic` that match `Sym(:im; type = Number)` structurally and fold to `0`, `-im`, `1`.

`Symbolics.IM` is `Sym{VartypeT}(:im; type = Number)`, used as a stand-in for `1im` so expressions stay inside `BasicSymbolic{<:Real}` algebra. Without these arms, `conj(IM)` / `real(IM)` / `imag(IM)` were opaque wrappers that `simplify` could not reduce, and downstream code (e.g. SQA's `qadjoint` / `inner_adjoint`) had to special-case `IM` themselves to avoid `conj(im)` leftovers.

Matching is purely structural (name + symtype), so SymbolicUtils picks up no Symbolics-side dependency. A same-named sym with a non-`Number` symtype is unaffected; the test covers that case.
