### PR TITLE
hack around runtime subtyping by tweaking the construction of `DefaultSubstituter` in `substitute`

### DIFF
--- a/src/substitute.jl
+++ b/src/substitute.jl
@@ -258,14 +258,24 @@ julia> substitute(1+sqrt(y), Dict(y => 2), fold=Val(false))
 1 + sqrt(2)
 ```
 """
-@inline function substitute(expr, dict; fold::Val{Fold}=Val{false}(), filterer=default_substitute_filter) where {Fold}
-    isempty(dict) && !Fold && return expr
-    return DefaultSubstituter{Fold}(dict, filterer)(expr)
+function substitute(expr, dict; fold::Val{Fold}=Val{false}(), filterer=default_substitute_filter) where {Fold}
+    # This is kind of ugly (inlines some of the constructor logic of `DefaultSubstituter` but is needed to avoid runtime subtyping in
+    # when calling this function. It makes a very big difference in runtime.
+    d = dict isa AbstractDict ? dict : Dict(dict)
+    isempty(d) && !Fold && return expr
+    VT = infer_vartype(d)
+    if VT === Nothing
+        sub = DefaultSubstituter{Fold, typeof(d), typeof(filterer), Nothing}(d, filterer, nothing)
+    else
+        cache = IdDict{BasicSymbolic{VT}, BasicSymbolic{VT}}()
+        sub = DefaultSubstituter{Fold, typeof(d), typeof(filterer), typeof(cache)}(d, filterer, cache)
+    end
+    return sub(expr)
 end
 
 const EMPTY_DICT = Dict{Int, Int}()
 
-@inline function evaluate(expr; filterer = default_substitute_filter)
+function evaluate(expr; filterer = default_substitute_filter)
     return substitute(expr, EMPTY_DICT; fold = Val{true}(), filterer)
 end
 
@@ -438,7 +448,7 @@ function _reduce_eliminated_idxs(expr::BasicSymbolic{T}, output_idx::OutIdxT{T},
         for (idx, ii) in zip(iidxs, collapsed)
             subrules[ii] = idx
         end
-        return substitute(new_expr, subrules; fold = Val{false}())::BasicSymbolic{T}
+        return substitute(new_expr, subrules)::BasicSymbolic{T}
     end::BasicSymbolic{T}
 end
 @cache function reduce_eliminated_idxs_1(expr::BasicSymbolic{SymReal}, output_idx::OutIdxT{SymReal}, ranges::RangesT{SymReal}, reduce)::BasicSymbolic{SymReal}
@@ -793,7 +803,7 @@ function _getindex_scal(::typeof(getindex), x::BasicSymbolic{T}, ::Val{toplevel}
     if idx !== nothing
         return getindex(scalarize(args[1]), idx)
     end
-    
+
     idxs = Iterators.map((-), Iterators.map(unwrap_const, Iterators.drop(args, 1)), Iterators.map(Base.Fix2((-), 1) ∘ first, shape(args[1])))
     return getindex(scalarize(args[1]), idxs...)
 end

--- a/src/symbolic_ops/getindex.jl
+++ b/src/symbolic_ops/getindex.jl
@@ -303,7 +303,7 @@ function __stable_getindex(arr::BasicSymbolic{T}, sidxs::StableIndex{I}) where {
                 end
             end
             new_expr = reduce_eliminated_idxs(expr, output_idx, ranges, reduce)
-            result = substitute(new_expr, subrules; fold = Val{false}(), filterer = !isarrayop)
+            result = substitute(new_expr, subrules; filterer = !isarrayop)
             return result
         end
         _ => begin
@@ -414,10 +414,10 @@ Base.@propagate_inbounds function _getindex(::Type{T}, arr::BasicSymbolic{T}, id
             end
             if isempty(new_output_idx)
                 new_expr = reduce_eliminated_idxs(expr, output_idx, ranges, reduce)
-                result = substitute(new_expr, subrules; fold = Val{false}(), filterer = !isarrayop)
+                result = substitute(new_expr, subrules; filterer = !isarrayop)
                 return result
             else
-                new_expr = substitute(expr, subrules; fold = Val{false}(), filterer = !isarrayop)
+                new_expr = substitute(expr, subrules; filterer = !isarrayop)
                 if term !== nothing
                     term = getindex(term, idxs...)
                 end


### PR DESCRIPTION
I noticed a buch of subtyping during runtime which was bad for runtime performance:

```
╎ 936   @SymbolicUtils/src/substitute.jl:263  substitute(expr::SymbolicUtils.BasicSymbolicImpl.var
  ╎  914   @juliasrc/builtins.c:2095  jl_f__compute_sparams
  ╎   894   @juliasrc/subtype.c:4580  jl_type_intersection_env_s
  ╎    61    @juliasrc/subtype.c:2267  ijl_subtype_env
  ╎     61    @juliasrc/subtype.c:2239  ijl_obvious_subtype
  ╎    ╎ 56    @juliasrc/subtype.c:2132  obvious_subtype
  ╎    ╎  23    @juliasrc/subtype.c:2076  obvious_subtype
  ╎    ╎   21    @juliasrc/subtype.c:1942  obvious_subtype
```

This change makes a model I am looking at go from

```
julia> @time "multibody model" ssys = multibody(model)
multibody model: 7.757320 seconds (86.02 M allocations: 3.771 GiB, 8.26% gc time)
```

to

```
julia> @time "multibody model" ssys = multibody(model)
multibody model: 6.033411 seconds (72.17 M allocations: 2.815 GiB, 3.89% gc time)
```

