### PR TITLE
A few micro optimizations when profiling a `mtkcompile` call on a large model

### DIFF
--- a/src/substitute.jl
+++ b/src/substitute.jl
@@ -345,33 +345,48 @@ Wrappers for [`BasicSymbolic`](@ref) should implement this function by unwrappin
 
 See also: [`default_is_atomic`](@ref).
 """
-function search_variables!(buffer, expr::BasicSymbolic; is_atomic::F = default_is_atomic, recurse::G = iscall) where {F, G}
+function search_variables!(buffer, expr::BasicSymbolic{T}; is_atomic::F = default_is_atomic, recurse::G = iscall, _seen::Union{Base.IdSet{BasicSymbolic{T}}, Nothing} = nothing) where {T, F, G}
     if is_atomic(expr)
         push!(buffer, expr)
-        return
+        return nothing
     end
-    recurse(expr) || return
+    recurse(expr) || return nothing
+    seen = _seen === nothing ? Base.IdSet{BasicSymbolic{T}}() : _seen
+    _search_variables_impl!(buffer, expr, is_atomic, recurse, seen)
+    return nothing
+end
+
+function _search_variables_impl!(buffer, expr::BasicSymbolic{T}, is_atomic::F, recurse::G, seen::Base.IdSet{BasicSymbolic{T}}) where {T, F, G}
+    expr in seen && return nothing
+    push!(seen, expr)
+    if is_atomic(expr)
+        push!(buffer, expr)
+        return nothing
+    end
+    recurse(expr) || return nothing
     @match expr begin
         BSImpl.Term(; f, args) => begin
-            search_variables!(buffer, f; is_atomic, recurse)
+            if f isa BasicSymbolic{T}
+                _search_variables_impl!(buffer, f, is_atomic, recurse, seen)
+            end
             for arg in args
-                search_variables!(buffer, arg; is_atomic, recurse)
+                _search_variables_impl!(buffer, arg, is_atomic, recurse, seen)
             end
         end
         BSImpl.AddMul(; dict) => begin
             for k in keys(dict)
-                search_variables!(buffer, k; is_atomic, recurse)
+                _search_variables_impl!(buffer, k, is_atomic, recurse, seen)
             end
         end
         BSImpl.Div(; num, den) => begin
-            search_variables!(buffer, num; is_atomic, recurse)
-            search_variables!(buffer, den; is_atomic, recurse)
+            _search_variables_impl!(buffer, num, is_atomic, recurse, seen)
+            _search_variables_impl!(buffer, den, is_atomic, recurse, seen)
         end
         BSImpl.ArrayOp(; expr = inner_expr, term) => begin
-            search_variables!(buffer, @something(term, inner_expr); is_atomic, recurse)
+            _search_variables_impl!(buffer, @something(term, inner_expr), is_atomic, recurse, seen)
         end
         BSImpl.ArrayMaker(; values) => @union_split_smallvec values for val in values
-            search_variables!(buffer, val; is_atomic, recurse)
+            _search_variables_impl!(buffer, val, is_atomic, recurse, seen)
         end
     end
     return nothing

--- a/src/substitute.jl
+++ b/src/substitute.jl
@@ -441,13 +441,22 @@ function _reduce_eliminated_idxs(expr::BasicSymbolic{T}, output_idx::OutIdxT{T},
         return substitute(new_expr, subrules; fold = Val{false}())::BasicSymbolic{T}
     end::BasicSymbolic{T}
 end
-@cache function reduce_eliminated_idxs_1(expr::BasicSymbolic{SymReal}, output_idx::OutIdxT{SymReal}, ranges::RangesT{SymReal}, reduce)::BasicSymbolic{SymReal}
-    @nospecialize reduce
-    _reduce_eliminated_idxs(expr, output_idx, ranges, reduce)::BasicSymbolic{SymReal}
+
+struct IdHashWrapper{T}
+    val::T
+    h::UInt
 end
-@cache function reduce_eliminated_idxs_2(expr::BasicSymbolic{SafeReal}, output_idx::OutIdxT{SafeReal}, ranges::RangesT{SafeReal}, reduce)::BasicSymbolic{SafeReal}
+IdHashWrapper(x) = IdHashWrapper(x, objectid(x))
+Base.hash(x::IdHashWrapper, h::UInt) = hash(x.h, h)
+Base.isequal(a::IdHashWrapper, b::IdHashWrapper) = a.val === b.val
+
+@cache function reduce_eliminated_idxs_1(expr::BasicSymbolic{SymReal}, output_idx::OutIdxT{SymReal}, ranges_wrapped::IdHashWrapper{RangesT{SymReal}}, reduce)::BasicSymbolic{SymReal}
     @nospecialize reduce
-    _reduce_eliminated_idxs(expr, output_idx, ranges, reduce)::BasicSymbolic{SafeReal}
+    _reduce_eliminated_idxs(expr, output_idx, ranges_wrapped.val, reduce)::BasicSymbolic{SymReal}
+end
+@cache function reduce_eliminated_idxs_2(expr::BasicSymbolic{SafeReal}, output_idx::OutIdxT{SafeReal}, ranges_wrapped::IdHashWrapper{RangesT{SafeReal}}, reduce)::BasicSymbolic{SafeReal}
+    @nospecialize reduce
+    _reduce_eliminated_idxs(expr, output_idx, ranges_wrapped.val, reduce)::BasicSymbolic{SafeReal}
 end
 
 """
@@ -469,10 +478,11 @@ using the provided reduction function.
   reduction function.
 """
 function reduce_eliminated_idxs(expr::BasicSymbolic{T}, output_idx::OutIdxT{T}, ranges::RangesT{T}, @nospecialize(reduce)) where {T}
+    wrapped = IdHashWrapper(ranges)
     if T === SymReal
-        return reduce_eliminated_idxs_1(expr, output_idx, ranges, reduce)::BasicSymbolic{T}
+        return reduce_eliminated_idxs_1(expr, output_idx, wrapped, reduce)::BasicSymbolic{T}
     elseif T === SafeReal
-        return reduce_eliminated_idxs_2(expr, output_idx, ranges, reduce)::BasicSymbolic{T}
+        return reduce_eliminated_idxs_2(expr, output_idx, wrapped, reduce)::BasicSymbolic{T}
     end
     _unreachable()
 end

--- a/src/symbolic_ops/getindex.jl
+++ b/src/symbolic_ops/getindex.jl
@@ -64,6 +64,10 @@ function promote_shape(::typeof(getindex), sharr::ShapeT, shidxs::ShapeT...)
 end
 
 Base.@propagate_inbounds function Base.getindex(arr::BasicSymbolic{T}, idxs::Union{BasicSymbolic{T}, Int, AbstractRange{Int}, Colon}...) where {T}
+    # Fast path: scalar integer indexing into ArrayOp bypasses @cache (each index is unique)
+    if isarrayop(arr) && all(x -> x isa Int, idxs)
+        return _getindex(T, arr, idxs...)
+    end
     if T === SymReal
         return _getindex_1(arr, idxs...)
     elseif T === SafeReal
@@ -353,6 +357,28 @@ Base.@propagate_inbounds function _getindex(::Type{T}, arr::BasicSymbolic{T}, id
             end
             @assert idxs_i == length(idxs) + 1
             return BSImpl.Term{T}(f, newargs; type, shape = newshape)
+        end
+        _ => nothing
+    end
+
+    # Fast path: scalar integer indexing into ArrayOp (dominant path during scalarize).
+    @match arr begin
+        BSImpl.ArrayOp(; output_idx, expr, ranges, reduce, term) && if all(x -> x isa Int, idxs) end => begin
+            subrules = Dict{BasicSymbolic{T}, Union{BasicSymbolic{T}, Int}}()
+            for i in 1:length(idxs)
+                outidx = output_idx[i]
+                newidx = idxs[i]::Int
+                if outidx isa BasicSymbolic{T}
+                    if haskey(ranges, outidx)
+                        subrules[outidx] = ranges[outidx][newidx]
+                    else
+                        subrules[outidx] = newidx
+                    end
+                end
+            end
+            new_expr = reduce_eliminated_idxs(expr, output_idx, ranges, reduce)
+            result = substitute(new_expr, subrules; filterer = !isarrayop)
+            return result
         end
         _ => nothing
     end

--- a/src/symbolic_ops/getindex.jl
+++ b/src/symbolic_ops/getindex.jl
@@ -64,9 +64,13 @@ function promote_shape(::typeof(getindex), sharr::ShapeT, shidxs::ShapeT...)
 end
 
 Base.@propagate_inbounds function Base.getindex(arr::BasicSymbolic{T}, idxs::Union{BasicSymbolic{T}, Int, AbstractRange{Int}, Colon}...) where {T}
-    # Fast path: scalar integer indexing into ArrayOp bypasses @cache (each index is unique)
-    if isarrayop(arr) && all(x -> x isa Int, idxs)
-        return _getindex(T, arr, idxs...)
+    # Fast path: scalar integer indexing into ArrayOp bypasses @cache (each index is unique).
+    # Guarded on VERSION because calling _getindex directly from this Vararg Union method
+    # triggers a segfault in Julia 1.10's codegen (general_use_analysis).
+    @static if VERSION >= v"1.11"
+        if isarrayop(arr) && all(x -> x isa Int, idxs)
+            return _getindex(T, arr, idxs...)
+        end
     end
     if T === SymReal
         return _getindex_1(arr, idxs...)


### PR DESCRIPTION
Measurements on top of https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/927 (as well as https://github.com/JuliaSymbolics/Symbolics.jl/pull/1871) for my workload gives:

Before

```
multibody model: 6.033411 seconds (72.17 M allocations: 2.815 GiB, 3.89% gc time)
```

After

```
 multibody model:  3.566201 seconds (38.08 M allocations: 1.989 GiB, 4.22% gc time)
```