### PR TITLE
avoid rehashing BasicSymbolic keys when copying IRStructure

### DIFF
--- a/src/irstructure.jl
+++ b/src/irstructure.jl
@@ -183,12 +183,25 @@ Number of nodes in `ir`.
 """
 Base.length(ir::IRStructure) = length(ir.symbols)
 
+# Copies a dictionary where the values are shallow copied
+# without having to rehash the keys
+function dict_copy_depth_1_no_rehash(d)
+    d2 = copy(d)
+    vals = d2.vals
+    for i in eachindex(vals)
+        if isassigned(vals, i)
+            @inbounds vals[i] = copy(vals[i])
+        end
+    end
+    return d2
+end
+
 function Base.copy(ir::IRStructure{T}) where {T}
     return IRStructure{T}(
         copy(ir.dependency_graph),
         copy(ir.symbols),
         copy(ir.definition),
-        Dict(k => copy(v) for (k, v) in ir.weak_definitions),
+        dict_copy_depth_1_no_rehash(ir.weak_definitions),
         copy(ir.cached_mask),
         copy(ir.cached_idxs),
         copy(ir.non_canonical_idxs),


### PR DESCRIPTION
In the previous `copy` the `Dict(k => copy(v) for ...)` construction has to
rehash every `BasicSymbolic` key on insertion which is very expensive.
This uses some internals of `Dict` together with the knowledge that we only have to copy
"one level deep" to avoid the rehashing.

On a `IRStructure` from some system I get:

```
julia> ir = ModelingToolkitBase.get_irstructure(ssys);

julia> @btime copy(ir);
  21.910 ms (349069 allocations: 23.49 MiB)

julia> @btime copy(ir);
  5.606 ms (349069 allocations: 29.86 MiB)
```

it is a bit unfortunate to have to use internals like this although the "exposure"\
to them is quite limited at least
