### PR TITLE
fix: avoid processing and caching filtered subtrees in `IRSubstituter`

### DIFF
--- a/src/graph_traversal.jl
+++ b/src/graph_traversal.jl
@@ -8,7 +8,8 @@ end
 
 function RecursiveDFS(
         g::G; neighbors_fn::N = Graphs.outneighbors,
-        on_enter::E = Returns(nothing), on_exit::X = Returns(nothing)
+        on_enter::E = Returns(nothing), on_exit::X = Returns(nothing),
+        visited::BitVector = falses(Graphs.nv(g))
     ) where {G <: Graphs.AbstractGraph, N, E, X}
     return RecursiveDFS{G, N, E, X}(g, falses(Graphs.nv(g)), neighbors_fn, on_enter, on_exit)
 end

--- a/src/irstructure.jl
+++ b/src/irstructure.jl
@@ -688,6 +688,7 @@ struct IRSubstituter{Fold, T, D <: AbstractDict{BasicSymbolic{T}, BasicSymbolic{
     filterer::F
     cache::Dict{Int32, Int32}
     reachability::Vector{Int32}
+    dfs_visited::BitVector
 end
 
 """
@@ -698,7 +699,7 @@ Create an `IRSubstituter` using the given `ir` and `rules`.
 function IRSubstituter{Fold}(
         ir::IRStructure{T}, rules::D; filterer::F = default_substitute_filter
     ) where {Fold, T, D <: AbstractDict, F}
-    IRSubstituter{Fold, T, D, F}(ir, rules, filterer, Dict{Int32, Int32}(), Int32[])
+    IRSubstituter{Fold, T, D, F}(ir, rules, filterer, Dict{Int32, Int32}(), Int32[], falses(length(ir)))
 end
 
 get_substitution_dict(sub::IRSubstituter) = sub.rules
@@ -718,7 +719,7 @@ function substitute_ir!(sub::IRSubstituter{Fold, T}, idx::Int32) where {Fold, T}
     # work correctly.
     require_canonical(sub.ir)
 
-    (; rules, filterer, ir) = sub
+    (; rules, filterer, ir, dfs_visited) = sub
 
     # Check the cache, filter, and rules for `idx`
     cached = get(sub.cache, idx, zero(Int32))
@@ -746,7 +747,20 @@ function substitute_ir!(sub::IRSubstituter{Fold, T}, idx::Int32) where {Fold, T}
     empty!(queue)
     reachability = sub.reachability
     empty!(reachability)
-    get_reachability!(reachability, ir, idx)
+    # We don't use `get_reachability!` because that won't respect `filterer`
+    nbors_fn = let filterer = filterer, ir = ir
+        function __nbors_fn(graph, idx)
+            nbors = Graphs.outneighbors(graph, idx)
+            return filterer(ir[idx]) ? nbors : empty(nbors)
+        end
+    end
+    resize!(dfs_visited, length(ir))
+    fill!(dfs_visited, false)
+    rdfs = RecursiveDFS(ir.dependency_graph; neighbors_fn = nbors_fn, on_exit = PushToBuffer(reachability), visited = dfs_visited)
+    rdfs(idx)
+    # Remove `idx` from the end
+    pop!(reachability)
+
     for i in reachability
         # Check the cache, filter, and rules for `i`
         cached = get(sub.cache, i, zero(Int32))

--- a/src/ordereddigraph.jl
+++ b/src/ordereddigraph.jl
@@ -103,6 +103,8 @@ struct AdjView{T <: Integer}
     entry::Union{NTuple{2, T}, Vector{T}, Set{T}}
 end
 
+Base.empty(::AdjView{T}) where {T} = AdjView((zero(T), zero(T)))
+
 Base.eltype(::Type{AdjView{T}}) where {T} = T
 
 # length and membership dispatch through _flen / _fin (defined for all three).

--- a/test/irstructure.jl
+++ b/test/irstructure.jl
@@ -502,3 +502,17 @@ end
     sub = SU.Substituter{false}(rules)
     @test isequal(irsub(expr), sub(expr))
 end
+
+@testset "`IRSubstituter` doesn't process filtered subtrees" begin
+    # It used to still give the correct result, but processed (and thus cached)
+    # subtrees which are filtered out.
+    @syms x y
+    filterer = x -> iscall(x) && operation(x) !== sin
+    expr = sin(x) + cos(y)
+    ir = IRStructure{SymReal}()
+    subber = IRSubstituter{false}(ir, Dict(y => x); filterer)
+    res = subber(expr)
+    @test isequal(res, sin(x) + cos(x))
+    x_idx = ir[x]
+    @test !haskey(subber.cache, x_idx)
+end


### PR DESCRIPTION
Expressions in the subtrees were then processed and potentially either put into the queue or cached as unmodified. Neither of these outcomes is ideal.