### PR TITLE
Avoid float in symbolic integer powers when not necessary

### DIFF
--- a/src/symbolic_ops/pow.jl
+++ b/src/symbolic_ops/pow.jl
@@ -96,10 +96,12 @@ function ^(a::BasicSymbolic{T}, b::Union{AbstractArray{<:Number}, Number, BasicS
             end
             BSImpl.Term(; f, args) && if f === sqrt && (safe_isinteger(b) && Int(b) % 2 == 0 || b isa Rational && numerator(b)%2 == 0) end => begin
                 exp = safe_isinteger(b) ? (Int(b) // 2) : (b::Rational // 2)
+                exp = safe_isinteger(exp) ? Int(exp) : exp
                 return Const{T}(args[1] ^ exp)
             end
             BSImpl.Term(; f, args) && if f === cbrt && (safe_isinteger(b) && Int(b) % 3 == 0 || b isa Rational && numerator(b)%3 == 0) end => begin
                 exp = safe_isinteger(b) ? (Int(b) // 3) : (b::Rational // 3)
+                exp = safe_isinteger(exp) ? Int(exp) : exp
                 return Const{T}(args[1] ^ exp)
             end
             _ => nothing

--- a/src/symbolic_ops/pow.jl
+++ b/src/symbolic_ops/pow.jl
@@ -54,7 +54,10 @@ function ^(a::BasicSymbolic{T}, b::Union{AbstractArray{<:Number}, Number, BasicS
     if !_numeric_or_arrnumeric_symtype(a) || !_numeric_or_arrnumeric_symtype(b)
         throw(MethodError(^, (a, b)))
     end
-    isconst(a) && return Const{T}(^(unwrap_const(a), b))
+    if isconst(a)
+       c = unwrap_const(^(unwrap_const(a), b))
+       safe_isinteger(c) && return Const{T}(Int(c))
+    end
     b = unwrap_const(unwrap(b))
     sha = shape(a)
     shb = shape(b)
@@ -89,7 +92,6 @@ function ^(a::BasicSymbolic{T}, b::Union{AbstractArray{<:Number}, Number, BasicS
     if b isa Number
         @match a begin
             BSImpl.Term(; f, args) && if f === (^) && isconst(args[2]) && symtype(args[2]) <: Number end => begin
-                base, exp = args
                 base, exp = arguments(a)
                 exp = unwrap_const(exp)
                 return Const{T}(base ^ (exp * b))

--- a/src/symbolic_ops/pow.jl
+++ b/src/symbolic_ops/pow.jl
@@ -55,8 +55,13 @@ function ^(a::BasicSymbolic{T}, b::Union{AbstractArray{<:Number}, Number, BasicS
         throw(MethodError(^, (a, b)))
     end
     if isconst(a)
-       c = unwrap_const(^(unwrap_const(a), b))
-       safe_isinteger(c) && return Const{T}(Int(c))
+       ac = unwrap_const(a)
+       c = unwrap_const(^(ac, b))
+       if safe_isinteger(c)
+            return Const{T}(Int(c))
+       elseif c isa Rational || !(ac isa Integer || ac isa Rational) # for c rational and when a was a float to begin with, we can safely simplify to a Const.
+            return Const{T}(c)
+       end
     end
     b = unwrap_const(unwrap(b))
     sha = shape(a)
@@ -122,6 +127,11 @@ function ^(a::BasicSymbolic{T}, b::Union{AbstractArray{<:Number}, Number, BasicS
                         return BSImpl.AddMul{T}(coeff, ACDict{T}(newmul => b), AddMulVariant.MUL; shape, type)
                     end
                     # return mul_worker(T, (coeff, newpow))
+                elseif (coeff isa Integer || coeff isa Rational) && !safe_isinteger(b) #integers and rationals keep the symbolic form to avoid float conversion
+                    coeff = isone(coeff) ? coeff :  Term{T}(^, ArgsT{T}((coeff, b)); shape, type)
+                    dict = copy(dict)
+                    map!(Base.Fix1(*, b), values(dict))
+                    return BSImpl.AddMul{T}(coeff, dict, variant; shape, type)
                 else
                     coeff = coeff ^ b
                     dict = copy(dict)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1171,8 +1171,12 @@ end
         _s = n5^(1//k)
         @test !SymbolicUtils.isconst(_s)
         @test unwrap_const(_s^k) === n
-    end
+        _s2 = (n*a)^(1//k)
+        @test unwrap_const((_s2^k).coeff) === n
 
+        _s3 = (1//n*a)^(1//k)
+        @test unwrap_const((_s3^k).coeff) === 1//n
+    end
 
 end
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1151,6 +1151,31 @@ end
     @test isequal((-5a)^0.5, sqrt(5) * Term{SymReal}(^, [-a, 0.5]; type = Number, shape = ShapeVecT()))
 end
 
+@testset "Avoid float in symbolic integer powers" begin
+    @syms a::Real
+    n::Int = 5
+    n5 = SymbolicUtils.Const{SymReal}(n)
+    s = sqrt(n5)
+    @test unwrap_const(s * s) === n
+    @test unwrap_const(s^2) === n
+    @test unwrap_const(s^4) === n^2 
+
+    # Non-even powers should remain symbolic
+    @test !SymbolicUtils.isconst(s^3)
+
+    c = cbrt(n5)
+    @test unwrap_const(c^3) === n
+
+
+    for k in 2:5
+        _s = n5^(1//k)
+        @test !SymbolicUtils.isconst(_s)
+        @test unwrap_const(_s^k) === n
+    end
+
+
+end
+
 @testset "Equivalent expressions across tasks are equal" begin
     @syms a
     task = Threads.@spawn @syms a


### PR DESCRIPTION
This fixes https://github.com/JuliaSymbolics/Symbolics.jl/issues/1875, which is nice for exact simplifications of larger expressions.