### PR TITLE
Avoid force inlining of `getindex` which is a big function

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -1650,6 +1650,9 @@ function promote_shape(::typeof(LinearAlgebra.cross), shx::ShapeT, shy::ShapeT)
     return ShapeVecT((1:3,))
 end
 
+function _cross_product(::Type{T}, x, y) where {T}
+    BSImpl.Const{T}(ArgsT{T}((x[2] * y[3] - x[3] * y[2], -x[1] * y[3] + x[3] * y[1], x[1] * y[2] - x[2] * y[1])))
+end
 function LinearAlgebra.cross(x::BasicSymbolic{T}, y::Union{BasicSymbolic{T}, AbstractVector{<:Number}, AbstractVector{BasicSymbolic{T}}}) where {T}
     if y isa Vector{BasicSymbolic{T}}
         st_y = symtype(BSImpl.Const{T}(y))
@@ -1658,7 +1661,7 @@ function LinearAlgebra.cross(x::BasicSymbolic{T}, y::Union{BasicSymbolic{T}, Abs
     end
     promote_symtype(LinearAlgebra.cross, symtype(x), st_y)
     promote_shape(LinearAlgebra.cross, shape(x), shape(y))
-    BSImpl.Const{T}(ArgsT{T}((x[2] * y[3] - x[3] * y[2], -x[1] * y[3] + x[3] * y[1], x[1] * y[2] - x[2] * y[1])))
+    _cross_product(T, x, y)
 end
 function LinearAlgebra.cross(x::Union{AbstractVector{<:Number}, AbstractVector{BasicSymbolic{T}}}, y::BasicSymbolic{T}) where {T}
     if x isa Vector{BasicSymbolic{T}}
@@ -1668,7 +1671,7 @@ function LinearAlgebra.cross(x::Union{AbstractVector{<:Number}, AbstractVector{B
     end
     promote_symtype(LinearAlgebra.cross, symtype(x), symtype(y))
     promote_shape(LinearAlgebra.cross, shape(x), shape(y))
-    BSImpl.Const{T}(ArgsT{T}((x[2] * y[3] - x[3] * y[2], -x[1] * y[3] + x[3] * y[1], x[1] * y[2] - x[2] * y[1])))
+    _cross_product(T, x, y)
 end
 
 struct Fill

--- a/src/symbolic_ops/getindex.jl
+++ b/src/symbolic_ops/getindex.jl
@@ -63,7 +63,7 @@ function promote_shape(::typeof(getindex), sharr::ShapeT, shidxs::ShapeT...)
     throw(ArgumentError("Cannot use arrays of unknown size for indexing."))
 end
 
-Base.@propagate_inbounds function Base.getindex(arr::BasicSymbolic{T}, idxs::Union{BasicSymbolic{T}, Int, AbstractRange{Int}, Colon}...) where {T}
+function Base.getindex(arr::BasicSymbolic{T}, idxs::Union{BasicSymbolic{T}, Int, AbstractRange{Int}, Colon}...) where {T}
     # Fast path: scalar integer indexing into ArrayOp bypasses @cache (each index is unique).
     # Guarded on VERSION because calling _getindex directly from this Vararg Union method
     # triggers a segfault in Julia 1.10's codegen (general_use_analysis).
@@ -324,7 +324,7 @@ function __stable_getindex(arr::BasicSymbolic{T}, sidxs::StableIndex{I}) where {
     end
 end
 
-Base.@propagate_inbounds function _getindex(::Type{T}, arr::BasicSymbolic{T}, idxs::Union{BasicSymbolic{T}, Int, AbstractRange{Int}, Colon}...) where {T}
+function _getindex(::Type{T}, arr::BasicSymbolic{T}, idxs::Union{BasicSymbolic{T}, Int, AbstractRange{Int}, Colon}...) where {T}
     @match arr begin
         BSImpl.Const(; val) && if all(x -> !(x isa BasicSymbolic{T}) || isconst(x), idxs) end => return Const{T}(val[unwrap_const.(idxs)...])
         BSImpl.Term(; f) && if f === array_literal && all(x -> !(x isa BasicSymbolic{T}) || isconst(x), idxs) end => begin


### PR DESCRIPTION
This makes functions that call `getindex` (especially multiple times) become very bloated. 
A prime example of this is `cross` which calls it 12 times. The change in compile time can be seen in:

```julia-repl
julia> @time precompile(Tuple{typeof(LinearAlgebra.cross), Symbolics.Arr{Symbolics.Num, 1}, SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymbolicUtils.SymReal}})
  0.676814 seconds (4.16 M allocations: 188.066 MiB, 15.94% gc time, 100.00% compilation time)
true

julia> @time precompile(Tuple{typeof(LinearAlgebra.cross), Symbolics.Arr{Symbolics.Num, 1}, SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymbolicUtils.SymReal}})
  0.134154 seconds (398.82 k allocations: 20.483 MiB, 99.99% compilation time)
true
```

There is really no point in thinking about bounds checking for these operations because they won't SIMD and the overhead is negligible. 