### PR TITLE
avoid hashing keys twice in accumulate operations on dicts

### DIFF
--- a/src/symbolic_ops/addsub.jl
+++ b/src/symbolic_ops/addsub.jl
@@ -108,24 +108,24 @@ function (awb::AddWorkerBuffer{T})(terms) where {T}
                         AddMulVariant.ADD => begin
                             newcoeff = newcoeff .+ coeff
                             for (k, v) in dict
-                                result[k] = get(result, k, 0) + v
+                                _accumulate!(result, k, v)
                             end
                         end
                         AddMulVariant.MUL => begin
                             newterm = Mul{T}(1, dict; shape, type, metadata)
-                            result[newterm] = get(result, newterm, 0) + coeff
+                            _accumulate!(result, newterm, coeff)
                         end
                     end
                 end
                 _ => begin
-                    result[term] = get(result, term, 0) + 1
+                    _accumulate!(result, term, 1)
                 end
             end
         elseif term isa BasicSymbolic{SymReal} || term isa BasicSymbolic{SafeReal} || term isa BasicSymbolic{TreeReal}
             error(LazyString("Cannot operate on symbolics with different vartypes. Found `", T, "` and `", vartype(term), "`."))
         elseif term isa AbstractIrrational
             term = BSImpl.Term{T}(identity, ArgsT{T}((Const{T}(term),)); type = Real, shape = ShapeVecT())
-            result[term] = get(result, term, 0) + 1
+            _accumulate!(result, term, 1)
         else
             newcoeff = newcoeff .+ term
         end

--- a/src/symbolic_ops/mul.jl
+++ b/src/symbolic_ops/mul.jl
@@ -147,26 +147,26 @@ function _mul_worker!(::Type{T}, num_coeff, den_coeff, num_dict, den_dict, term)
             BSImpl.AddMul(; coeff, dict, variant) && if variant == AddMulVariant.MUL end => begin
                 num_coeff[] *= coeff
                 for (k, v) in dict
-                    num_dict[k] = get(num_dict, k, 0) + v
+                    _accumulate!(num_dict, k, v)
                 end
             end
             BSImpl.Term(; f, args) && if f === (^) && !isconst(args[1]) && isconst(args[2]) end => begin
                 base, exp = args
-                num_dict[base] = get(num_dict, base, 0) + unwrap_const(exp)
+                _accumulate!(num_dict, base, unwrap_const(exp))
             end
             BSImpl.Div(; num, den) => begin
                 _mul_worker!(T, num_coeff, den_coeff, num_dict, den_dict, num)
                 _mul_worker!(T, den_coeff, num_coeff, den_dict, num_dict, den)
             end
             x => begin
-                num_dict[x] = get(num_dict, x, 0) + 1
+                _accumulate!(num_dict, x, 1)
             end
         end
     elseif term isa BasicSymbolic{SymReal} || term isa BasicSymbolic{SafeReal}
         error(LazyString("Cannot operate on symbolics with different vartypes. Found `", T, "` and `", vartype(term), "`."))
     elseif term isa AbstractIrrational
         base = BSImpl.Term{T}(identity, ArgsT{T}((Const{T}(term),)); type = Real, shape = ShapeVecT())
-        num_dict[base] = get(num_dict, base, 0) + 1
+        _accumulate!(num_dict, base, 1)
     else
         num_coeff[] *= term
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -142,7 +142,7 @@ end
 
 Core ADT for symbolic expressions.
 """
-@data mutable BasicSymbolicImpl{T <: SymVariant} begin 
+@data mutable BasicSymbolicImpl{T <: SymVariant} begin
     struct Const
         const val::Any
         hash::UInt
@@ -263,6 +263,25 @@ The type of the dictionary stored in [`BSImpl.AddMul`](@ref). Passing this to th
 allocating a new dictionary.
 """
 const ACDict{T} = Dict{BasicSymbolic{T}, Number}
+
+
+# Add `val` to the value stored at `key` in `h`, inserting `val` if `key` is absent.
+function _accumulate!(h::AbstractDict, key, val)
+    h[key] = get(h, key, 0) + val
+    return h
+end
+# Specialized for `Dict` to only do one lookup.
+function _accumulate!(h::Dict{K, V}, key::K, val) where {K, V}
+    index, sh = Base.ht_keyindex2_shorthash!(h, key)
+    if index > 0
+        @inbounds h.vals[index] = h.vals[index] + val
+    else
+        v = val isa V ? val : convert(V, val)::V
+        @inbounds Base._setindex!(h, v, key, -index, sh)
+    end
+    return h
+end
+
 """
 The type of the `output_idxs` field in [`BSImpl.ArrayOp`](@ref).
 """


### PR DESCRIPTION
In a benchmark like:

```julia
using BenchmarkTools, SymbolicUtils
using Random

begin
    @syms a b c d
    Random.seed!(123)
    funs = [*, /]
    atoms = [a, b, c, d, a^2, b^2, a^1.5, (b + c), b^c, 1, 2.0]
    function random_term(len; atoms, funs, fallback_atom=1)
            xs = rand(atoms, len)
            while length(xs) > 1
                xs = map(Iterators.partition(xs, 2)) do xy
                    x = xy[1]; y = get(xy, 2, fallback_atom)
                    rand(funs)(x, y)
                end
            end
            xs[]
        end
    exs = [random_term(5; atoms, funs) for _ in 1:50]
    @btime SymbolicUtils.mul_worker(SymReal, $exs);
end
```

I see

```
# Before
  16.831 μs (236 allocations: 6.22 KiB)
# After
  14.578 μs (222 allocations: 6.00 KiB)
``` 

Want to see what the full benchmark suite looks like. The savings of this of course depends on how expensive hashing the keys are. 