### PR TITLE
feat: [AI] implement symbolic versions of some codegen primitives.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        env:
+          GROUP: ${{ matrix.group }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/src/code.jl
+++ b/src/code.jl
@@ -5,7 +5,7 @@ using StaticArraysCore, SparseArrays, LinearAlgebra, NaNMath, SpecialFunctions,
 
 export toexpr, Assignment, (←), Let, Func, DestructuredArgs, LiteralExpr,
        SetArray, MakeArray, MakeSparseArray, MakeTuple, AtIndex,
-       SpawnFetch, Multithreaded, ForLoop, cse
+       SpawnFetch, Multithreaded, ForLoop, cse, symFunc
 
 export OptimizationRule, substitute_in_ir, apply_optimization_rules
 
@@ -18,7 +18,7 @@ import SymbolicUtils: @matchable, BasicSymbolic, Sym, Term, iscall, operation, a
                       search_variables!, _is_index_variable, RangesT, IDXS_SYM, is_array_shape,
                       symtype, vartype, add_worker, search_variables!, @union_split_smallvec,
                       ArrayMaker, TypeT, ShapeT, SymReal, SafeReal, TreeReal, _unreachable, unwrap,
-                      AddMulVariant, _isone, _iszero, Fill, IRStructure, populate_ir!
+                      AddMulVariant, _isone, _iszero, Fill, IRStructure, populate_ir!, FnType
 using Moshi.Match: @match
 import SymbolicIndexingInterface: symbolic_type, NotSymbolic
 import Graphs
@@ -991,6 +991,8 @@ julia> executable(1, 2.0, [2,3.0], x->string(x); var"z(t)" = sqrt(42))
 ```
 """
 Func
+
+include("symbolic_codegen_primitives.jl")
 
 toexpr_kw(f, st) = Expr(:kw, toexpr(f, st).args...)
 

--- a/src/code.jl
+++ b/src/code.jl
@@ -5,7 +5,8 @@ using StaticArraysCore, SparseArrays, LinearAlgebra, NaNMath, SpecialFunctions,
 
 export toexpr, Assignment, (←), Let, Func, DestructuredArgs, LiteralExpr,
        SetArray, MakeArray, MakeSparseArray, MakeTuple, AtIndex,
-       SpawnFetch, Multithreaded, ForLoop, cse, symFunc
+       SpawnFetch, Multithreaded, ForLoop, cse,
+       symFunc, symAssignment, symLet, symDestructuredArgs
 
 export OptimizationRule, substitute_in_ir, apply_optimization_rules
 

--- a/src/faster_code.jl
+++ b/src/faster_code.jl
@@ -1346,46 +1346,71 @@ function codegen_function!(::Type{Func}, cs::CodegenState{T}, expr::BasicSymboli
     args_term_idx = nbors[1]
     body_idx = nbors[2]
 
-    # Extract individual arg syms from the tuple term
     args_nbors = Graphs.outneighbors(cs.ir.dependency_graph, args_term_idx)
-    args = map(i -> cs.ir[i], args_nbors)
+    n_args = length(args_nbors)
     body = cs.ir[body_idx]
 
-    # Save pre-existing rewrite entries so they can be restored after codegen
-    old_rewrites = map(args) do arg
-        arg isa BasicSymbolic{T} ? get(cs.rewrites, arg, nothing) : nothing
-    end
+    # Walk the args once to: register rewrites and collect DestructuredArgs info.
+    # Each entry is (sym_registered_in_rewrites, old_value) for later restoration.
+    rewrites_to_restore = Pair{BasicSymbolic{T}, Any}[]
+    # (name, elems): array param + the element variables to bind inside the body
+    dargs_info = Tuple{BasicSymbolic{T}, Vector{BasicSymbolic{T}}}[]
 
-    # Register each arg as a function parameter (bypasses CSE for args inside the body)
-    for arg in args
-        if arg isa BasicSymbolic{T}
-            add_arg_to_rewrites!(cs.rewrites, arg)
+    for i in 1:n_args
+        arg = cs.ir[args_nbors[i]]
+        @match arg begin
+            BSImpl.Sym(;) => begin
+                push!(rewrites_to_restore, arg => get(cs.rewrites, arg, nothing))
+                add_arg_to_rewrites!(cs.rewrites, arg)
+            end
+            BSImpl.Term(; f) && if f === DestructuredArgs end => begin
+                da_nbors = Graphs.outneighbors(cs.ir.dependency_graph, args_nbors[i])
+                name = cs.ir[da_nbors[1]]
+                elems = BasicSymbolic{T}[cs.ir[da_nbors[j]] for j in 2:length(da_nbors)]
+                push!(rewrites_to_restore, name => get(cs.rewrites, name, nothing))
+                add_arg_to_rewrites!(cs.rewrites, name)
+                push!(dargs_info, (name, elems))
+            end
+            _ => nothing
         end
     end
 
     scs, bm = enter_scope(cs)
+
+    # Emit destructuring bindings — elem_i = array_param[i] — before the body
+    for (name, elems) in dargs_info
+        name_sym = cs.rewrites[name]::Symbol
+        for (i, elem) in enumerate(elems)
+            elem_name = manual_dispatch_toexpr(elem, NameState(scs.rewrites))
+            declare!(scs, elem_name, Expr(:ref, name_sym, i))
+        end
+    end
+
     scs(body)
     fn_body_block = exit_scope!(scs, bm)
 
     fn_args = Expr(:tuple)
-    for arg in args
-        if arg isa BasicSymbolic{T}
-            push!(fn_args.args, cs.rewrites[arg]::Symbol)
-        else
-            push!(fn_args.args, manual_dispatch_toexpr(arg, NameState(cs.rewrites)))
+    for i in 1:n_args
+        arg = cs.ir[args_nbors[i]]
+        @match arg begin
+            BSImpl.Sym(;) => push!(fn_args.args, cs.rewrites[arg]::Symbol)
+            BSImpl.Term(; f) && if f === DestructuredArgs end => begin
+                da_nbors = Graphs.outneighbors(cs.ir.dependency_graph, args_nbors[i])
+                name = cs.ir[da_nbors[1]]
+                push!(fn_args.args, cs.rewrites[name]::Symbol)
+            end
+            _ => push!(fn_args.args, manual_dispatch_toexpr(arg, NameState(cs.rewrites)))
         end
     end
 
     result = codegen!(cs, expr_idx, Expr(:function, fn_args, Expr(:block, fn_body_block)))
 
     # Restore rewrites to their state before this call
-    for (arg, old_val) in zip(args, old_rewrites)
-        if arg isa BasicSymbolic{T}
-            if old_val === nothing
-                delete!(cs.rewrites, arg)
-            else
-                cs.rewrites[arg] = old_val
-            end
+    for (sym, old_val) in rewrites_to_restore
+        if old_val === nothing
+            delete!(cs.rewrites, sym)
+        else
+            cs.rewrites[sym] = old_val
         end
     end
 

--- a/src/faster_code.jl
+++ b/src/faster_code.jl
@@ -1311,6 +1311,19 @@ function (cs::CodegenState)(f::ForLoop)
     return declare!(cs, get_misc_identifier(cs), result)
 end
 
+function codegen_function!(::Type{Let}, cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
+    nbors = Graphs.outneighbors(cs.ir.dependency_graph, expr_idx)
+    n = length(nbors)
+    body_idx = nbors[n]
+
+    # Codegen each symAssignment as a side effect in order
+    for i in 1:n-1
+        cs(cs.ir[nbors[i]])
+    end
+
+    return codegen!(cs, expr_idx, cs(cs.ir[body_idx]))
+end
+
 function codegen_function!(::Type{Assignment}, cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
     nbors = Graphs.outneighbors(cs.ir.dependency_graph, expr_idx)
     lhs_expr = cs.ir[nbors[1]]

--- a/src/faster_code.jl
+++ b/src/faster_code.jl
@@ -1311,6 +1311,23 @@ function (cs::CodegenState)(f::ForLoop)
     return declare!(cs, get_misc_identifier(cs), result)
 end
 
+function codegen_function!(::Type{Assignment}, cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
+    nbors = Graphs.outneighbors(cs.ir.dependency_graph, expr_idx)
+    lhs_expr = cs.ir[nbors[1]]
+    rhs = cs.ir[nbors[2]]
+
+    lhs = manual_dispatch_toexpr(lhs_expr, NameState(cs.rewrites))
+    if Meta.isexpr(lhs, :call)
+        scs, bm = enter_scope(cs)
+        scs(rhs)
+        rhs_result = exit_scope!(scs, bm)
+    else
+        rhs_result = cs(rhs)
+    end
+    declare!(cs, lhs, rhs_result)
+    return codegen!(cs, expr_idx, lhs)
+end
+
 function codegen_function!(::Type{Func}, cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
     nbors = Graphs.outneighbors(cs.ir.dependency_graph, expr_idx)
     args_term_idx = nbors[1]

--- a/src/faster_code.jl
+++ b/src/faster_code.jl
@@ -1310,3 +1310,54 @@ function (cs::CodegenState)(f::ForLoop)
     push!(result.args, body)
     return declare!(cs, get_misc_identifier(cs), result)
 end
+
+function codegen_function!(::Type{Func}, cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
+    nbors = Graphs.outneighbors(cs.ir.dependency_graph, expr_idx)
+    args_term_idx = nbors[1]
+    body_idx = nbors[2]
+
+    # Extract individual arg syms from the tuple term
+    args_nbors = Graphs.outneighbors(cs.ir.dependency_graph, args_term_idx)
+    args = map(i -> cs.ir[i], args_nbors)
+    body = cs.ir[body_idx]
+
+    # Save pre-existing rewrite entries so they can be restored after codegen
+    old_rewrites = map(args) do arg
+        arg isa BasicSymbolic{T} ? get(cs.rewrites, arg, nothing) : nothing
+    end
+
+    # Register each arg as a function parameter (bypasses CSE for args inside the body)
+    for arg in args
+        if arg isa BasicSymbolic{T}
+            add_arg_to_rewrites!(cs.rewrites, arg)
+        end
+    end
+
+    scs, bm = enter_scope(cs)
+    scs(body)
+    fn_body_block = exit_scope!(scs, bm)
+
+    fn_args = Expr(:tuple)
+    for arg in args
+        if arg isa BasicSymbolic{T}
+            push!(fn_args.args, cs.rewrites[arg]::Symbol)
+        else
+            push!(fn_args.args, manual_dispatch_toexpr(arg, NameState(cs.rewrites)))
+        end
+    end
+
+    result = codegen!(cs, expr_idx, Expr(:function, fn_args, Expr(:block, fn_body_block)))
+
+    # Restore rewrites to their state before this call
+    for (arg, old_val) in zip(args, old_rewrites)
+        if arg isa BasicSymbolic{T}
+            if old_val === nothing
+                delete!(cs.rewrites, arg)
+            else
+                cs.rewrites[arg] = old_val
+            end
+        end
+    end
+
+    return result
+end

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -266,6 +266,13 @@ function _sequential_promote(T::TypeT, Ts::TypeT...)
 end
 
 
+function promote_symtype(::typeof(tuple), Ts::TypeT...)
+    return Tuple{Ts...}::TypeT
+end
+function promote_shape(::typeof(tuple), @nospecialize(shs::ShapeT...))
+    return ShapeVecT((1:length(shs),))
+end
+
 function promote_symtype(::typeof(array_literal), Tp::TypeT, Ts::TypeT...)
     @assert Tp <: Tuple
     return Array{_sequential_promote(Ts...), length(Tp.parameters)}

--- a/src/symbolic_codegen_primitives.jl
+++ b/src/symbolic_codegen_primitives.jl
@@ -1,3 +1,36 @@
+function SymbolicUtils.promote_symtype(::Type{DestructuredArgs}, name_type::TypeT, elem_types::TypeT...)
+    return name_type
+end
+
+function SymbolicUtils.promote_shape(::Type{DestructuredArgs}, name_shape::ShapeT, @nospecialize(elem_shapes::ShapeT...))
+    @nospecialize name_shape
+    return name_shape
+end
+
+"""
+    symDestructuredArgs(name, elems)
+
+Construct a symbolic expression representing an array argument that is destructured into
+its elements. `name` is a symbolic variable representing the array argument; `elems` is an
+iterable of symbolic variables that will be bound to successive elements of the array.
+
+The result is a `Term{T}(Code.DestructuredArgs, [name, elem1, ...])` with `symtype` and
+`shape` equal to those of `name`. It may only be used as an argument in [`symFunc`](@ref).
+
+!!! note
+    `symDestructuredArgs` cannot be nested: the element variables (`elems`) must be plain
+    symbolic variables, not themselves `symDestructuredArgs` terms.
+"""
+function symDestructuredArgs(name::BasicSymbolic{T}, elems) where {T}
+    args = ArgsT{T}()
+    sizehint!(args, 1 + length(elems))
+    push!(args, name)
+    for elem in elems
+        push!(args, elem isa BasicSymbolic{T} ? elem : BSImpl.Const{T}(elem))
+    end
+    return BSImpl.Term{T}(DestructuredArgs, args; type = symtype(name), shape = shape(name))
+end
+
 function SymbolicUtils.promote_symtype(::Type{Let}, Ts::TypeT...)
     return last(Ts)
 end

--- a/src/symbolic_codegen_primitives.jl
+++ b/src/symbolic_codegen_primitives.jl
@@ -1,3 +1,32 @@
+function SymbolicUtils.promote_symtype(::Type{Assignment}, lhs_type::TypeT, rhs_type::TypeT)
+    return rhs_type
+end
+
+function SymbolicUtils.promote_shape(::Type{Assignment}, @nospecialize(_lhs_shape::ShapeT), rhs_shape::ShapeT)
+    @nospecialize rhs_shape
+    return rhs_shape
+end
+
+"""
+    symAssignment(lhs, rhs)
+
+Construct a symbolic expression representing `lhs = rhs`. Returns a
+`Term{T}(Code.Assignment, [lhs, rhs])` with `symtype` and `shape` equal to those of `rhs`.
+"""
+function symAssignment(lhs::BasicSymbolic{T}, rhs::BasicSymbolic{T}) where {T}
+    return BSImpl.Term{T}(
+        Assignment, ArgsT{T}((lhs, rhs));
+        type = symtype(rhs),
+        shape = shape(rhs)
+    )
+end
+function symAssignment(lhs::BasicSymbolic{T}, rhs) where {T}
+    return symAssignment(lhs, BSImpl.Const{T}(rhs))
+end
+function symAssignment(lhs, rhs::BasicSymbolic{T}) where {T}
+    return symAssignment(BSImpl.Const{T}(lhs), rhs)
+end
+
 function SymbolicUtils.promote_symtype(::Type{Func}, args_type::TypeT, body_type::TypeT)
     @assert args_type <: Tuple
     return FnType{args_type, body_type, Nothing}::TypeT

--- a/src/symbolic_codegen_primitives.jl
+++ b/src/symbolic_codegen_primitives.jl
@@ -1,0 +1,38 @@
+function SymbolicUtils.promote_symtype(::Type{Func}, args_type::TypeT, body_type::TypeT)
+    @assert args_type <: Tuple
+    return FnType{args_type, body_type, Nothing}::TypeT
+end
+
+function SymbolicUtils.promote_shape(::Type{Func}, @nospecialize(_args_shape::ShapeT), body_shape::ShapeT)
+    @nospecialize body_shape
+    return body_shape
+end
+
+"""
+    symFunc(args, body)
+
+Construct a symbolic expression representing an anonymous function with argument list `args`
+and body `body`. `args` must be an iterable of symbolic variables. Returns a
+`Term{T}(Code.Func, [args_term, body])` where `args_term = term(tuple, args...)`, with
+`symtype` `FnType{symtype(args_term), symtype(body), Nothing}` and `shape` equal to
+`shape(body)`.
+"""
+function symFunc(args::BasicSymbolic{T}, body::BasicSymbolic{T}) where {T}
+    return BSImpl.Term{T}(
+        Func, ArgsT{T}((args, body));
+        type = SymbolicUtils.promote_symtype(Func, symtype(args), symtype(body)),
+        shape = SymbolicUtils.promote_shape(Func, shape(args), shape(body))
+    )
+end
+function symFunc(args::Union{AbstractArray, Tuple}, body::BasicSymbolic{T}) where {T}
+    return symFunc(
+        BSImpl.Term{T}(
+            tuple, args;
+            type = SymbolicUtils.promote_symtype(tuple, symtype.(args)...),
+            shape = ShapeVecT((1:length(args),))
+        ), body
+    )
+end
+function symFunc(args::BasicSymbolic{T}, body) where {T}
+    return symFunc(args, BSImpl.Const{T}(body))
+end

--- a/src/symbolic_codegen_primitives.jl
+++ b/src/symbolic_codegen_primitives.jl
@@ -1,3 +1,24 @@
+function SymbolicUtils.promote_symtype(::Type{Let}, Ts::TypeT...)
+    return last(Ts)
+end
+
+function SymbolicUtils.promote_shape(::Type{Let}, @nospecialize(shs::ShapeT...))
+    return last(shs)
+end
+
+"""
+    symLet(assignments, body)
+
+Construct a symbolic expression representing a `let` block. `assignments` must be an
+iterable of `symAssignment` terms. Returns a `Term{T}(Code.Let, [asgn..., body])` with
+`symtype` and `shape` equal to those of `body`.
+"""
+function symLet(assignments::AbstractArray{BasicSymbolic{T}}, body::BasicSymbolic{T}) where {T}
+    args = ArgsT{T}(assignments)
+    push!(args, body)
+    return BSImpl.Term{T}(Let, args; type = symtype(body), shape = shape(body))
+end
+
 function SymbolicUtils.promote_symtype(::Type{Assignment}, lhs_type::TypeT, rhs_type::TypeT)
     return rhs_type
 end

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -474,3 +474,12 @@ end
     @test_throws ErrorException ifelse(cond, x, z)
     @test SymbolicUtils.shape(ifelse(cond, x, y)) == [1:3]
 end
+
+@testset "`promote_symtype`, `promote_shape` for `tuple`" begin
+    @test SymbolicUtils.promote_symtype(tuple) == Tuple{}
+    @test SymbolicUtils.promote_symtype(tuple, Real) == Tuple{Real}
+    @test SymbolicUtils.promote_symtype(tuple, Real, Int) == Tuple{Real, Int}
+    @test SymbolicUtils.promote_symtype(tuple, Float64, Float64, Int) == Tuple{Float64, Float64, Int}
+    @test SymbolicUtils.promote_shape(tuple, Unknown(1), ShapeVecT((1:3, 1:3,)), ShapeVecT()) == [1:3]
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,7 @@ if GROUP == "Core"
             @safetestset "Inference" begin include("inference.jl") end
             @safetestset "Code" begin include("code.jl") end
             @safetestset "New codegen" begin include("new_code.jl") end
+            @safetestset "Symbolic codegen primitives" begin include("symbolic_codegen_primitives.jl") end
             @safetestset "CSE" begin include("cse.jl") end
             @safetestset "Interface" begin include("interface.jl") end
             # Disabled until https://github.com/JuliaMath/SpecialFunctions.jl/issues/446 is fixed

--- a/test/symbolic_codegen_primitives.jl
+++ b/test/symbolic_codegen_primitives.jl
@@ -226,3 +226,64 @@ end
     @test fn(2.0, 3.0) ≈ 25.0
     @test fn(1.0, 0.0) ≈ 1.0
 end
+
+@testset "`promote_symtype` for `DestructuredArgs`" begin
+    @test SymbolicUtils.promote_symtype(Code.DestructuredArgs, Vector{Real}) == Vector{Real}
+    @test SymbolicUtils.promote_symtype(Code.DestructuredArgs, Vector{Real}, Real, Real) == Vector{Real}
+end
+
+@testset "`symDestructuredArgs` construction" begin
+    @syms arr[1:2]::Real x::Real y::Real
+    da = Code.symDestructuredArgs(arr, [x, y])
+    @test SymbolicUtils.iscall(da)
+    @test SymbolicUtils.operation(da) === Code.DestructuredArgs
+    args = SymbolicUtils.arguments(da)
+    @test length(args) == 3
+    @test isequal(args[1], arr)
+    @test isequal(args[2], x)
+    @test isequal(args[3], y)
+    @test SymbolicUtils.symtype(da) == SymbolicUtils.symtype(arr)
+    @test SymbolicUtils.shape(da) == SymbolicUtils.shape(arr)
+end
+
+@testset "`symDestructuredArgs` in `symFunc` — basic destructuring" begin
+    @syms arr[1:2]::Real x::Real y::Real
+    da = Code.symDestructuredArgs(arr, [x, y])
+    f = Code.symFunc([da], x + y)
+    @test SymbolicUtils.symtype(f) == FnType{Tuple{Vector{Real}}, Real, Nothing}
+    ir = IRStructure{SymReal}()
+    expr = Code.fast_toexpr(f, ir, Dict{Any,Any}())
+    fn = eval(expr)
+    @test fn([3.0, 4.0]) ≈ 7.0
+    @test fn([1.0, -1.0]) ≈ 0.0
+end
+
+@testset "`symDestructuredArgs` in `symFunc` — mixed with plain args" begin
+    # f(x, arr) = x + arr[1] + arr[2]
+    @syms arr[1:2]::Real x::Real a::Real b::Real
+    da = Code.symDestructuredArgs(arr, [a, b])
+    f = Code.symFunc([x, da], x + a + b)
+    @test SymbolicUtils.symtype(f) == FnType{Tuple{Real, Vector{Real}}, Real, Nothing}
+    ir = IRStructure{SymReal}()
+    expr = Code.fast_toexpr(f, ir, Dict{Any,Any}())
+    fn = eval(expr)
+    @test fn(1.0, [2.0, 3.0]) ≈ 6.0
+    @test fn(10.0, [0.0, -5.0]) ≈ 5.0
+end
+
+@testset "`symDestructuredArgs` rewrites restored after `symFunc`" begin
+    @syms arr[1:2]::Real x::Real y::Real
+    da = Code.symDestructuredArgs(arr, [x, y])
+    f = Code.symFunc([da], x + y)
+    rewrites = Dict{Any,Any}()
+    ir1 = IRStructure{SymReal}()
+    Code.fast_toexpr(f, ir1, rewrites)   # must not leave arr, x, y in rewrites
+    ir2 = IRStructure{SymReal}()
+    expr_xy = Code.fast_toexpr(x + y, ir2, rewrites)
+    result = eval(quote
+        let x = 3.0, y = 4.0
+            $expr_xy
+        end
+    end)
+    @test result ≈ 7.0
+end

--- a/test/symbolic_codegen_primitives.jl
+++ b/test/symbolic_codegen_primitives.jl
@@ -79,3 +79,70 @@ end
     end)
     @test result ≈ 7.0
 end
+
+@testset "`promote_symtype` for `Assignment`" begin
+    @test SymbolicUtils.promote_symtype(Code.Assignment, Real, Real) == Real
+    @test SymbolicUtils.promote_symtype(Code.Assignment, Any, Float64) == Float64
+    @test SymbolicUtils.promote_symtype(Code.Assignment, Any, Vector{Real}) == Vector{Real}
+end
+
+@testset "`symAssignment` construction" begin
+    @syms x::Real y::Real
+    asgn = Code.symAssignment(x, x + y)
+    @test SymbolicUtils.iscall(asgn)
+    @test SymbolicUtils.operation(asgn) === Code.Assignment
+    lhs_t, rhs_t = SymbolicUtils.arguments(asgn)
+    @test isequal(lhs_t, x)
+    @test isequal(rhs_t, x + y)
+    @test SymbolicUtils.symtype(asgn) == Real
+    @test SymbolicUtils.shape(asgn) == ShapeVecT()
+
+    # Array rhs: shape propagates from rhs
+    @syms A::AbstractMatrix{Real}
+    body_arr = A * [x, y]
+    asgn_arr = Code.symAssignment(x, body_arr)
+    @test SymbolicUtils.symtype(asgn_arr) == Vector{Real}
+    @test SymbolicUtils.shape(asgn_arr) == SymbolicUtils.shape(body_arr)
+end
+
+@testset "`symAssignment` codegen — scalar rhs" begin
+    @syms x::Real y::Real
+    asgn = Code.symAssignment(x, x + y)
+    ir = IRStructure{SymReal}()
+    expr = Code.fast_toexpr(asgn, ir, Dict{Any,Any}())
+    result = eval(quote
+        let x = 3.0, y = 4.0
+            $expr
+        end
+    end)
+    @test result ≈ 7.0
+end
+
+@testset "`symAssignment` codegen — array rhs" begin
+    @syms x::Real y::Real A::AbstractMatrix{Real}
+    @syms out[1:2]::Real
+    body = A * [x, y]
+    asgn = Code.symAssignment(out, body)
+    ir = IRStructure{SymReal}()
+    Av = [1.0 2.0; 3.0 4.0]
+    expr = Code.fast_toexpr(asgn, ir, Dict{Any,Any}())
+    result = eval(quote
+        let A = $Av, x = 1.0, y = 2.0, out = zeros(2)
+            $expr
+        end
+    end)
+    @test result ≈ [5.0, 11.0]
+end
+
+@testset "`symAssignment` inside `symFunc`" begin
+    # A symAssignment inside a symFunc body: f(x,y) evaluates (x = x+y; x)
+    @syms x::Real y::Real
+    asgn = Code.symAssignment(x, x + y)
+    f = Code.symFunc([x, y], asgn)
+    @test SymbolicUtils.symtype(f) == FnType{Tuple{Real, Real}, Real, Nothing}
+    ir = IRStructure{SymReal}()
+    expr = Code.fast_toexpr(f, ir, Dict{Any,Any}())
+    fn = eval(expr)
+    @test fn(3.0, 4.0) ≈ 7.0
+end
+

--- a/test/symbolic_codegen_primitives.jl
+++ b/test/symbolic_codegen_primitives.jl
@@ -1,0 +1,81 @@
+using SymbolicUtils, SymbolicUtils.Code
+using SymbolicUtils: IRStructure, SymReal, ShapeVecT, FnType
+using Test
+
+@testset "`symFunc` construction" begin
+    @syms x::Real y::Real
+
+    # Scalar body: type and shape
+    f = Code.symFunc([x, y], x + y)
+    @test SymbolicUtils.iscall(f)
+    @test SymbolicUtils.operation(f) === Code.Func
+    args_t, body_t = SymbolicUtils.arguments(f)
+    @test SymbolicUtils.operation(args_t) === tuple
+    @test SymbolicUtils.symtype(f) == FnType{Tuple{Real, Real}, Real, Nothing}
+    @test SymbolicUtils.shape(f) == ShapeVecT()
+
+    # Array body: shape propagates from body
+    @syms A::AbstractMatrix{Real}
+    body_arr = A * [x, y]
+    f_arr = Code.symFunc([x, y], body_arr)
+    @test SymbolicUtils.symtype(f_arr) == FnType{Tuple{Real, Real}, Vector{Real}, Nothing}
+    @test SymbolicUtils.shape(f_arr) == SymbolicUtils.shape(body_arr)
+end
+
+@testset "`symFunc` codegen — scalar body" begin
+    @syms x::Real y::Real
+    f = Code.symFunc([x, y], x + y)
+    ir = IRStructure{SymReal}()
+    expr = Code.fast_toexpr(f, ir, Dict{Any,Any}())
+    fn = eval(expr)
+    @test fn(3.0, 4.0) ≈ 7.0
+    @test fn(-1.0, 1.0) ≈ 0.0
+end
+
+@testset "`symFunc` codegen — array body" begin
+    @syms x::Real y::Real A::AbstractMatrix{Real}
+    body = A * [x, y]
+    f = Code.symFunc([x, y], body)
+    ir = IRStructure{SymReal}()
+    Av = [1.0 2.0; 3.0 4.0]
+    expr = Code.fast_toexpr(f, ir, Dict{Any,Any}())
+    fn = eval(quote
+        let A = $Av
+            $expr
+        end
+    end)
+    @test fn(1.0, 2.0) ≈ [5.0, 11.0]
+    @test fn(0.0, 1.0) ≈ [2.0, 4.0]
+end
+
+@testset "`symFunc` CSE — body shared with outer expression" begin
+    @syms x::Real y::Real
+    shared = x + y
+    f = Code.symFunc([x, y], shared * shared)
+    ir = IRStructure{SymReal}()
+    expr = Code.fast_toexpr(f, ir, Dict{Any,Any}())
+    fn = eval(expr)
+    @test fn(2.0, 3.0) ≈ 25.0
+end
+
+@testset "`symFunc` rewrites restored — args usable after symFunc in shared rewrites" begin
+    @syms x::Real y::Real
+    f = Code.symFunc([x, y], x + y)
+    # Share one rewrites dict across two fast_toexpr calls.
+    # Without the fix, codegenning `f` permanently adds `x` and `y` to `rewrites`
+    # as function-parameter names (only valid inside the function body). The
+    # second fast_toexpr would then emit `__cse = __argₛᵧₘXXX` for `x`, so the
+    # generated `x + y` expression would reference undefined names.
+    rewrites = Dict{Any,Any}()
+    ir1 = IRStructure{SymReal}()
+    Code.fast_toexpr(f, ir1, rewrites)   # populates rewrites; must not pollute x/y entries
+
+    ir2 = IRStructure{SymReal}()
+    expr_xy = Code.fast_toexpr(x + y, ir2, rewrites)
+    result = eval(quote
+        let x = 3.0, y = 4.0
+            $expr_xy
+        end
+    end)
+    @test result ≈ 7.0
+end

--- a/test/symbolic_codegen_primitives.jl
+++ b/test/symbolic_codegen_primitives.jl
@@ -146,3 +146,83 @@ end
     @test fn(3.0, 4.0) ≈ 7.0
 end
 
+@testset "`promote_symtype` for `Let`" begin
+    @test SymbolicUtils.promote_symtype(Code.Let, Real) == Real
+    @test SymbolicUtils.promote_symtype(Code.Let, Real, Float64) == Float64
+    @test SymbolicUtils.promote_symtype(Code.Let, Real, Real, Vector{Real}) == Vector{Real}
+end
+
+@testset "`symLet` construction" begin
+    @syms x::Real y::Real z::Real
+    asgn = Code.symAssignment(x, y + 1)
+    l = Code.symLet([asgn], x * z)
+    @test SymbolicUtils.iscall(l)
+    @test SymbolicUtils.operation(l) === Code.Let
+    args = SymbolicUtils.arguments(l)
+    @test length(args) == 2
+    @test isequal(args[1], asgn)
+    @test isequal(args[2], x * z)
+    @test SymbolicUtils.symtype(l) == Real
+    @test SymbolicUtils.shape(l) == ShapeVecT()
+
+    # Empty assignments — body type propagates
+    l_empty = Code.symLet(typeof(x)[], x + y)
+    @test SymbolicUtils.symtype(l_empty) == Real
+    @test length(SymbolicUtils.arguments(l_empty)) == 1
+end
+
+@testset "`symLet` codegen — single assignment" begin
+    @syms x::Real y::Real
+    # let x = y + 1; x * 2 end  →  (y+1)*2
+    l = Code.symLet([Code.symAssignment(x, y + 1)], x * 2)
+    ir = IRStructure{SymReal}()
+    expr = Code.fast_toexpr(l, ir, Dict{Any,Any}())
+    result = eval(quote
+        let x = 0.0, y = 3.0
+            $expr
+        end
+    end)
+    @test result ≈ 8.0   # (3+1)*2
+end
+
+@testset "`symLet` codegen — sequential assignments" begin
+    @syms x::Real y::Real z::Real
+    # let x = y + 1; z = x * 2; z + x end  →  ((y+1)*2) + (y+1)
+    asgn1 = Code.symAssignment(x, y + 1)
+    asgn2 = Code.symAssignment(z, x * 2)
+    l = Code.symLet([asgn1, asgn2], z + x)
+    ir = IRStructure{SymReal}()
+    expr = Code.fast_toexpr(l, ir, Dict{Any,Any}())
+    result = eval(quote
+        let x = 0.0, y = 3.0, z = 0.0
+            $expr
+        end
+    end)
+    @test result ≈ 12.0  # (3+1)*2 + (3+1) = 8 + 4
+end
+
+@testset "`symLet` codegen — empty assignments" begin
+    @syms x::Real y::Real
+    l = Code.symLet(typeof(x)[], x + y)
+    ir = IRStructure{SymReal}()
+    expr = Code.fast_toexpr(l, ir, Dict{Any,Any}())
+    result = eval(quote
+        let x = 3.0, y = 4.0
+            $expr
+        end
+    end)
+    @test result ≈ 7.0
+end
+
+@testset "`symLet` inside `symFunc`" begin
+    @syms x::Real y::Real tmp::Real
+    # f(x,y) = let tmp = x+y; tmp*tmp end  →  (x+y)^2
+    l = Code.symLet([Code.symAssignment(tmp, x + y)], tmp * tmp)
+    f = Code.symFunc([x, y], l)
+    @test SymbolicUtils.symtype(f) == FnType{Tuple{Real,Real}, Real, Nothing}
+    ir = IRStructure{SymReal}()
+    expr = Code.fast_toexpr(f, ir, Dict{Any,Any}())
+    fn = eval(expr)
+    @test fn(2.0, 3.0) ≈ 25.0
+    @test fn(1.0, 0.0) ≈ 1.0
+end


### PR DESCRIPTION
This adds symbolic expressions for limited versions of some codegen primitives (such as `Func`). This allows type-stable representations of those primitives, as well as their use in `IRStructure`.