### PR TITLE
make the global caches for add and mul reentrancy safe

### DIFF
--- a/src/symbolic_ops/addsub.jl
+++ b/src/symbolic_ops/addsub.jl
@@ -47,14 +47,27 @@ end
 
 mutable struct AddWorkerBuffer{T}
     dict::ACDict{T}
+    busy::Bool
 end
 
-AddWorkerBuffer{T}() where {T} = AddWorkerBuffer{T}(ACDict{T}())
+AddWorkerBuffer{T}() where {T} = AddWorkerBuffer{T}(ACDict{T}(), false)
 
 Base.empty!(awb::AddWorkerBuffer) = empty!(awb.dict)
 
 const SYMREAL_ADDBUFFER = TaskLocalValue{AddWorkerBuffer{SymReal}}(AddWorkerBuffer{SymReal})
 const SAFEREAL_ADDBUFFER = TaskLocalValue{AddWorkerBuffer{SafeReal}}(AddWorkerBuffer{SafeReal})
+
+@inline function _run_addbuffer(buf::AddWorkerBuffer{T}, terms) where {T}
+    if buf.busy
+        buf = AddWorkerBuffer{T}()
+    end
+    buf.busy = true
+    try
+        return buf(terms)
+    finally
+        buf.busy = false
+    end
+end
 
 """
     $METHODLIST
@@ -62,8 +75,8 @@ const SAFEREAL_ADDBUFFER = TaskLocalValue{AddWorkerBuffer{SafeReal}}(AddWorkerBu
 Add an indexable list or tuple of terms `terms` with the given vartype. Applicable only for
 symbolic expressions with numeric or array of numeric symtype.
 """
-add_worker(::Type{SymReal}, terms) = SYMREAL_ADDBUFFER[](terms)
-add_worker(::Type{SafeReal}, terms) = SAFEREAL_ADDBUFFER[](terms)
+add_worker(::Type{SymReal}, terms) = _run_addbuffer(SYMREAL_ADDBUFFER[], terms)
+add_worker(::Type{SafeReal}, terms) = _run_addbuffer(SAFEREAL_ADDBUFFER[], terms)
 
 function _added_shape(terms::Tuple)
     promote_shape(+, ntuple(shape ∘ Base.Fix1(getindex, terms), Val(length(terms)))...)

--- a/src/symbolic_ops/mul.jl
+++ b/src/symbolic_ops/mul.jl
@@ -178,10 +178,11 @@ mutable struct MulWorkerBuffer{T}
     den_dict::ACDict{T}
     const num_coeff::RefValue{PolyCoeffT}
     const den_coeff::RefValue{PolyCoeffT}
+    busy::Bool
 end
 
 function MulWorkerBuffer{T}() where {T}
-    MulWorkerBuffer{T}(ACDict{T}(), ACDict{T}(), Ref{PolyCoeffT}(1), Ref{PolyCoeffT}(1))
+    MulWorkerBuffer{T}(ACDict{T}(), ACDict{T}(), Ref{PolyCoeffT}(1), Ref{PolyCoeffT}(1), false)
 end
 
 function Base.empty!(mwb::MulWorkerBuffer)
@@ -348,14 +349,26 @@ function (mwb::MulWorkerBuffer{T})(terms) where {T}
     return Term{T}(*, new_arrterms; type, shape = newshape)
 end
 
+@inline function _run_mulbuffer(buf::MulWorkerBuffer{T}, terms) where {T}
+    if buf.busy
+        buf = MulWorkerBuffer{T}()
+    end
+    buf.busy = true
+    try
+        return buf(terms)
+    finally
+        buf.busy = false
+    end
+end
+
 """
     $METHODLIST
 
 Multiply an indexable list or tuple of terms `terms` with the given vartype. Applicable
 only for symbolic expressions with numeric or array of numeric symtype.
 """
-mul_worker(::Type{SymReal}, terms) = SYMREAL_MULBUFFER[](terms)
-mul_worker(::Type{SafeReal}, terms) = SAFEREAL_MULBUFFER[](terms)
+mul_worker(::Type{SymReal}, terms) = _run_mulbuffer(SYMREAL_MULBUFFER[], terms)
+mul_worker(::Type{SafeReal}, terms) = _run_mulbuffer(SAFEREAL_MULBUFFER[], terms)
 
 function *(x::T, args::Union{Number, T, AbstractArray{<:Number}, AbstractArray{T}}...) where {T <: NonTreeSym}
     mul_worker(vartype(T), (x, args...))

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1080,6 +1080,15 @@ end
     @test isequal(x / -1, -x)
 end
 
+@testset "mul worker buffer is reentrancy-safe" begin
+    @syms x y w
+    p = Mul{SymReal}(2, Dict((x / y) => -1); type = Real)
+    @test isequal(p * (1 // 2) * (1 / w), y / (x * w))
+
+    t = Term{SymReal}(^, ArgsT{SymReal}((x / y, Const{SymReal}(-1))); type = Real, shape = ShapeVecT())
+    @test isequal(t * (1 / w), y / (x * w))
+end
+
 @testset "Issue#717: Power with complex exponent" begin
     @syms x
     t = x ^ im


### PR DESCRIPTION
There were cases you could construct where you would have multiple opreations "in flight" that used the same cache, but then one operations would empty the cache while the other one was not done, leading to missing terms.

The tests has an example but an in repl demonstration is:

```julia
julia> @syms x y w
(x, y, w)

julia> p = Mul{SymReal}(2, Dict((x/y) => -1); type = Real)
2(y / x)

julia> p * (1//2) * (1/w)
y / x
```

where the `1/w` term is lost
