### PR TITLE
trivial performance tweaks to avoid redundantly computing things etc

### DIFF
--- a/src/code.jl
+++ b/src/code.jl
@@ -659,10 +659,13 @@ end
 function toexpr(O::BasicSymbolic{T}, st) where {T}
     @match O begin
         BSImpl.Const(;) => nothing # Constants should not be rewritten; they are literal values.
-        _ => if haskey(st.rewrites, O)
-            O = st.rewrites[O]
-            if !(O isa BasicSymbolic{T})
-                return manual_dispatch_toexpr(O, st)
+        _ => begin
+            rw = get(st.rewrites, O, nothing)
+            if rw !== nothing
+                O = rw
+                if !(O isa BasicSymbolic{T})
+                    return manual_dispatch_toexpr(O, st)
+                end
             end
         end
     end

--- a/src/inner_ctors.jl
+++ b/src/inner_ctors.jl
@@ -131,6 +131,7 @@ function unwrap_dict(dict)
         dict
     end
 end
+unwrap_dict(dict::OrderedDict{<:BasicSymbolic}) = dict
 
 """
     $TYPEDSIGNATURES

--- a/src/irstructure.jl
+++ b/src/irstructure.jl
@@ -463,10 +463,12 @@ function subset_ir(
     Graphs.add_vertices!(new_ir.dependency_graph, n_new_verts)
     sizehint!(new_ir, n_new_verts)
 
+    old2new = zeros(Int32, length(ir))
     inew = 0
     # `reachables` is in topological order
     for iold in reachables
         inew += 1
+        old2new[iold] = inew
         # Add expression to the IR
         sym = ir.symbols[iold]
         push!(new_ir.symbols, sym)
@@ -479,9 +481,7 @@ function subset_ir(
         # have already been added to `new_ir`.
         oldnbors = Graphs.outneighbors(ir.dependency_graph, iold)
         for nbor in oldnbors
-            nsym = ir.symbols[nbor]
-            nbor_idx = new_ir.definition[nsym]
-            Graphs.add_edge!(new_ir.dependency_graph, inew, nbor_idx)
+            Graphs.add_edge!(new_ir.dependency_graph, inew, old2new[nbor])
         end
     end
 

--- a/src/polyform.jl
+++ b/src/polyform.jl
@@ -290,17 +290,16 @@ quick_cancel(d) = d
 function quick_cancel(d::BasicSymbolic{T})::BasicSymbolic{T} where {T}
     iscall(d) || return d
     op = operation(d)
-    type = symtype(d)
     if op === (^)
         base, exp = arguments(d)
         isconst(base) && return d
         isdiv(base) || return d
         num, den = quick_cancel(base.num, base.den)
-        return Div{T}(num ^ exp, den ^ exp, false; type)
+        return Div{T}(num ^ exp, den ^ exp, false; type = symtype(d))
     elseif op === (/)
         num, den = arguments(d)
         num, den = quick_cancel(num, den)
-        return Div{T}(num, den, false; type)
+        return Div{T}(num, den, false; type = symtype(d))
     else
         return d
     end

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -625,14 +625,15 @@ Base.show(io::IO, acr::ACRule) = print(io, "ACRule(", acr.rule, ")")
 
 function (acr::ACRule)(term)
     r = Rule(acr)
-    if !iscall(term) || operation(term) != operation(r.lhs)
+    if !iscall(term)
         # different operations -> try deflsot
         r(term)
     else
-        f =  operation(term)
+        f = operation(term)
         # Assume that the matcher was formed by closing over a term
-        if f != operation(r.lhs) # Maybe offer a fallback if m.term errors. 
-            return nothing
+        if f != operation(r.lhs)
+            # different operations -> try deflsot
+            return r(term)
         end
 
         T = vartype(term)

--- a/src/safe_ctors.jl
+++ b/src/safe_ctors.jl
@@ -100,7 +100,7 @@ preferred over the `BSImpl.AddMul{T}` constructor.
         else
             return (k ^ v)::BasicSymbolic{T}
         end
-    elseif _isone(-coeff) && length(dict) == 1
+    elseif length(dict) == 1 && _isone(-coeff)
         k, v = first(dict)
         if _isone(v)
             @match k begin

--- a/src/small_array.jl
+++ b/src/small_array.jl
@@ -327,7 +327,7 @@ function Base.resize!(x::SmallVec{T, V}, sz::Integer) where {T, V}
     else
         resize!(tmp, sz)
     end
-    resize!(x.data, sz)
+    return x
 end
 function Base.insert!(x::SmallVec{T, V}, i::Integer, val) where {T, V}
     if x.data isa Backing{T} && isfull(x.data)

--- a/src/symbolic_ops/pow.jl
+++ b/src/symbolic_ops/pow.jl
@@ -90,7 +90,6 @@ function ^(a::BasicSymbolic{T}, b::Union{AbstractArray{<:Number}, Number, BasicS
         @match a begin
             BSImpl.Term(; f, args) && if f === (^) && isconst(args[2]) && symtype(args[2]) <: Number end => begin
                 base, exp = args
-                base, exp = arguments(a)
                 exp = unwrap_const(exp)
                 return Const{T}(base ^ (exp * b))
             end


### PR DESCRIPTION
I don't have benchmarks for this but they are trivially doing less work and removes some "noise" from the code.