### PR TITLE
strip trailing whitespace

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -37,7 +37,7 @@ jobs:
           - {user: JuliaSymbolics, repo: Symbolics.jl, group: D3TreesExt}
           - {user: JuliaSymbolics, repo: Symbolics.jl, group: Downstream}
           - {user: SciML, repo: ModelOrderReduction.jl, group: All}
-          
+
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -10,4 +10,4 @@ jobs:
       - name: Checkout Actions Repository
         uses: actions/checkout@v3
       - name: Check spelling
-        uses: crate-ci/typos@v1.16.23 
+        uses: crate-ci/typos@v1.16.23

--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,13 +1,13 @@
-Hash Consing Optimization: SymbolicUtils.jl now uses hash consing to eliminate duplicate 
-symbolic expressions in memory and enable faster equality comparisons. This optimization 
-significantly improves performance for complex symbolic computations by reducing memory 
+Hash Consing Optimization: SymbolicUtils.jl now uses hash consing to eliminate duplicate
+symbolic expressions in memory and enable faster equality comparisons. This optimization
+significantly improves performance for complex symbolic computations by reducing memory
 overhead and computation time. Available starting from v3.28.0.
 @misc{zhu2025efficientsymboliccomputationhash,
-    title={Efficient Symbolic Computation via Hash Consing}, 
+    title={Efficient Symbolic Computation via Hash Consing},
     author={Bowen Zhu and Aayush Sabharwal and Songchen Tan and Yingbo Ma and Alan Edelman and Christopher Rackauckas},
     year={2025},
     eprint={2509.20534},
     archivePrefix={arXiv},
     primaryClass={cs.PL},
-    url={https://arxiv.org/abs/2509.20534}, 
+    url={https://arxiv.org/abs/2509.20534},
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SymbolicUtils.jl 
+# SymbolicUtils.jl
 
 [![Join the chat at https://julialang.zulipchat.com #sciml-bridged](https://img.shields.io/static/v1?label=Zulip&message=chat&color=9558b2&labelColor=389826)](https://julialang.zulipchat.com/#narrow/stream/279055-sciml-bridged)
 [![Global Docs](https://img.shields.io/badge/docs-SciML-blue.svg)](https://docs.sciml.ai/SymbolicUtils/stable/)

--- a/docs/src/manual/interface.md
+++ b/docs/src/manual/interface.md
@@ -4,7 +4,7 @@ This section is for Julia package developers who may want to use the `simplify` 
 
 ## Defining the interface
 
-SymbolicUtils matchers can match any Julia object that implements an interface to traverse it as a tree. The interface in question, is defined in the [TermInterface.jl](https://github.com/JuliaSymbolics/TermInterface.jl) package. Its purpose is to provide a shared interface between various symbolic programming Julia packages. 
+SymbolicUtils matchers can match any Julia object that implements an interface to traverse it as a tree. The interface in question, is defined in the [TermInterface.jl](https://github.com/JuliaSymbolics/TermInterface.jl) package. Its purpose is to provide a shared interface between various symbolic programming Julia packages.
 
 In particular, you should define methods from TermInterface.jl for an expression tree type `T` with symbol types `S` to  work
 with SymbolicUtils.jl

--- a/docs/src/manual/rewrite.md
+++ b/docs/src/manual/rewrite.md
@@ -189,16 +189,16 @@ rewriters.
 - `IfElse(cond, rw1, rw2)` runs the `cond` function on the input, applies `rw1` if cond
    returns true, `rw2` if it returns false
 - `If(cond, rw)` is the same as `IfElse(cond, rw, Empty())`
-- `Prewalk(rw; threaded=false, thread_cutoff=100)` returns a rewriter which does a pre-order 
-   (*from top to bottom and from left to right*) traversal of a given expression and applies 
+- `Prewalk(rw; threaded=false, thread_cutoff=100)` returns a rewriter which does a pre-order
+   (*from top to bottom and from left to right*) traversal of a given expression and applies
    the rewriter `rw`. `threaded=true` will use multi threading for traversal.
    Note that if `rw` returns `nothing` when a match is not found, then `Prewalk(rw)` will
    also return nothing unless a match is found at every level of the walk. If you are
    applying multiple rules, then `Chain` already has the appropriate passthrough behavior.
    If you only want to apply one rule, then consider using `PassThrough`.
-   `thread_cutoff` 
+   `thread_cutoff`
    is the minimum number of nodes in a subtree which should be walked in a threaded spawn.
-- `Postwalk(rw; threaded=false, thread_cutoff=100)` similarly does post-order 
+- `Postwalk(rw; threaded=false, thread_cutoff=100)` similarly does post-order
    (*from left to right and from bottom to top*) traversal.
 - `Fixpoint(rw)` returns a rewriter which applies `rw` repeatedly until there are no changes to be made.
 - `PassThrough(rw)` returns a rewriter which if `rw(x)` returns `nothing` will instead

--- a/docs/src/manual/variants.md
+++ b/docs/src/manual/variants.md
@@ -26,7 +26,7 @@ A given expression must be pure in its `vartype`. In other words, no operation s
 of different `vartype`s.
 
 !!! warning "A short note on (im-)mutability"
-  
+
     While `ismutabletype(BasicSymbolic)` returns `true`, symbolic types are IMMUTABLE.
     Any mutation is undefined behavior and can lead to very confusing and hard-to-debug issues.
     This includes internal mutation, such as mutating `AddMul.dict`. The arrays returned from
@@ -296,7 +296,7 @@ range of indices over which they should iterate, in case such a range is explici
 provided.
 
 !!! note
-  
+
   The common global index variable is printed as `_1`, `_2`, ... in arrayops. It is not
   a valid symbolic variable outside of an `ArrayOp`'s `expr`.
 

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -322,11 +322,11 @@ macro cache(args...)
             end
             continue
         end
-            
+
         # use `eval` to get the type because we need to know if it's a `BasicSymbolic`
         T = Base.eval(__module__, Texpr)
         if T <: BasicSymbolic
-            push!(keytypes, SymbolicKey) 
+            push!(keytypes, SymbolicKey)
             push!(keyexprs, :($get_cache_key($argname)))
             valid_key_condition = :($valid_key_condition && !($(Symbol(:key_, length(keyexprs))) isa $CacheSentinel))
         else
@@ -447,7 +447,7 @@ macro cache(args...)
     return quote
         $(EL.codegen_ast(structdef))
         $(EL.codegen_ast(filterfn))
-        
+
         const $cachename = $cachector
 
         $(EL.codegen_ast(fn))

--- a/src/hashconsing.jl
+++ b/src/hashconsing.jl
@@ -22,7 +22,7 @@ macro __generate_isequal_somescalar()
         push!(cur_expr.args, new_expr)
         cur_expr = new_expr
     end
-    
+
     push!(cur_expr.args, :(isequal(a, b)::Bool))
     return esc(expr)
 end
@@ -237,7 +237,7 @@ macro __generate_hash_somescalar()
         push!(cur_expr.args, new_expr)
         cur_expr = new_expr
     end
-    
+
     push!(cur_expr.args, :(hash(a, h)::UInt))
     return esc(expr)
 end
@@ -474,7 +474,7 @@ function hash_bsimpl(s::BSImpl.Type{T}, h::UInt, full) where {T}
             else
                 _unreachable()
             end
-            
+
             Base.hash(f, Base.hash(args, h))::UInt
         end
         BSImpl.AddMul(; coeff, dict, variant, shape, type, hash, hash2) => begin
@@ -534,20 +534,20 @@ $(TYPEDSIGNATURES)
 
 Implements hash consing (flyweight design pattern) for `BasicSymbolic` objects.
 
-This function checks if an equivalent `BasicSymbolic` object already exists. It uses a 
-custom hash function (`hash2`) incorporating metadata and symtypes to search for existing 
-objects in a `WeakCacheSet` (`wcs`). Due to the possibility of hash collisions (where 
-different objects produce the same hash), a custom equality check (`isequal_with_metadata`) 
-which includes metadata comparison, is used to confirm the equivalence of objects with 
-matching hashes. If an equivalent object is found, the existing object is returned; 
-otherwise, the input `s` is returned. This reduces memory usage, improves compilation time 
-for runtime code generation, and supports built-in common subexpression elimination, 
+This function checks if an equivalent `BasicSymbolic` object already exists. It uses a
+custom hash function (`hash2`) incorporating metadata and symtypes to search for existing
+objects in a `WeakCacheSet` (`wcs`). Due to the possibility of hash collisions (where
+different objects produce the same hash), a custom equality check (`isequal_with_metadata`)
+which includes metadata comparison, is used to confirm the equivalence of objects with
+matching hashes. If an equivalent object is found, the existing object is returned;
+otherwise, the input `s` is returned. This reduces memory usage, improves compilation time
+for runtime code generation, and supports built-in common subexpression elimination,
 particularly when working with symbolic objects with metadata.
 
-Using a `WeakCacheSet` ensures that only weak references to `BasicSymbolic` objects are 
-stored, allowing objects that are no longer strongly referenced to be garbage collected. 
-Custom functions `hash2` and `isequal_with_metadata` are used instead of `Base.hash` and 
-`Base.isequal` to accommodate metadata without disrupting existing tests reliant on the 
+Using a `WeakCacheSet` ensures that only weak references to `BasicSymbolic` objects are
+stored, allowing objects that are no longer strongly referenced to be garbage collected.
+Custom functions `hash2` and `isequal_with_metadata` are used instead of `Base.hash` and
+`Base.isequal` to accommodate metadata without disrupting existing tests reliant on the
 original behavior of those functions.
 """
 

--- a/src/inspect.jl
+++ b/src/inspect.jl
@@ -7,7 +7,7 @@ function AbstractTrees.nodevalue(x::BSImpl.Type)
     str = if !iscall(x)
         string(T, "(", x, ")")
     elseif isadd(x)
-        string(T, 
+        string(T,
             (variant=string(x.variant),))
     elseif ismul(x)
         string(T,

--- a/src/polyform.jl
+++ b/src/polyform.jl
@@ -381,7 +381,7 @@ function quick_mulpow(x::S, y::S)::Tuple{S, S} where {T <: SymVariant, S <: Basi
                 argexp = 1
                 break
             end
-        
+
             if iscall(arg) && operation(arg) === (^) && isequal(arguments(arg)[1], base)
                 idx = i
                 argbase, argexp = arguments(arg)

--- a/src/rewriters.jl
+++ b/src/rewriters.jl
@@ -257,10 +257,10 @@ end
     FixpointNoCycle(rw)
 
 `FixpointNoCycle` behaves like [`Fixpoint`](@ref),
-but returns a rewriter which applies `rw` repeatedly until 
-it produces a result that was already produced before, for example, 
-if the repeated application of `rw` produces results `a, b, c, d, b` in order, 
-`FixpointNoCycle` stops because `b` has been already produced. 
+but returns a rewriter which applies `rw` repeatedly until
+it produces a result that was already produced before, for example,
+if the repeated application of `rw` produces results `a, b, c, d, b` in order,
+`FixpointNoCycle` stops because `b` has been already produced.
 """
 struct FixpointNoCycle{C}
     rw::C

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -112,7 +112,7 @@ function makesegment(s::Expr, keys)
     end
 
     name = s.args[1]
-    
+
     push!(keys, name)
     :(Segment($(QuoteNode(name)), $(esc(s.args[2]))))
 end
@@ -631,7 +631,7 @@ function (acr::ACRule)(term)
     else
         f =  operation(term)
         # Assume that the matcher was formed by closing over a term
-        if f != operation(r.lhs) # Maybe offer a fallback if m.term errors. 
+        if f != operation(r.lhs) # Maybe offer a fallback if m.term errors.
             return nothing
         end
 

--- a/src/simplify_rules.jl
+++ b/src/simplify_rules.jl
@@ -2,7 +2,7 @@ using .Rewriters
 """
   is_operation(f)
 Returns a single argument anonymous function predicate, that returns `true` if and only if
-the argument to the predicate satisfies `iscall` and `operation(x) == f` 
+the argument to the predicate satisfies `iscall` and `operation(x) == f`
 """
 is_operation(f) = @nospecialize(x) -> iscall(x) && (operation(x) === f)
 

--- a/src/symbolic_ops/common.jl
+++ b/src/symbolic_ops/common.jl
@@ -42,7 +42,7 @@ macro __generate_numeric_or_arrrnumeric_type()
     cur_expr = new_expr
 
     i = 0
-    
+
     N = length(SCALARS)
     for t1 in SCALARS
         for T in [t1, Vector{t1}, Matrix{t1}, LinearAlgebra.UniformScaling{t1}]

--- a/src/syms.jl
+++ b/src/syms.jl
@@ -234,7 +234,7 @@ Base.@nospecializeinfer function parse_variable(x; default_type = Number)::Parse
         for i in 2:length(x.args)
             if Meta.isexpr(x.args[i], :...)
                 ndim = :($(ndim) + length($(x.args[i].args[1])))
-            else 
+            else
                 ndim = ndim isa Int ? ndim + 1 : :($(ndim) + 1)
             end
         end

--- a/src/terminterface.jl
+++ b/src/terminterface.jl
@@ -17,7 +17,7 @@ using SymbolicUtils
 expr1 = x + y
 operation(expr1)    # returns +
 
-expr2 = x * y  
+expr2 = x * y
 operation(expr2)    # returns *
 
 # Function calls
@@ -147,7 +147,7 @@ using SymbolicUtils
 expr1 = x + y
 arguments(expr1)    # returns collection containing x and y
 
-expr2 = x * y * z  
+expr2 = x * y * z
 arguments(expr2)    # returns collection containing x, y, and z
 
 # Function calls
@@ -221,11 +221,11 @@ end
 """
     $TYPEDSIGNATURES
 
-Check if a symbolic expression `expr` represents a function call. Returns `true` if the 
+Check if a symbolic expression `expr` represents a function call. Returns `true` if the
 expression is a composite expression with an operation and arguments, `false` otherwise.
 
-This function is fundamental for traversing and analyzing symbolic expressions. In 
-SymbolicUtils.jl, an expression is considered a "call" if it represents a function 
+This function is fundamental for traversing and analyzing symbolic expressions. In
+SymbolicUtils.jl, an expression is considered a "call" if it represents a function
 application (including operators like +, -, *, etc.).
 
 # Examples
@@ -236,7 +236,7 @@ using SymbolicUtils
 # Basic variables are not calls
 iscall(x)           # false
 
-# Function calls are calls  
+# Function calls are calls
 expr = sin(x + y)
 iscall(expr)        # true
 

--- a/test/adjoints.jl
+++ b/test/adjoints.jl
@@ -25,4 +25,4 @@ using Zygote
       @test gs[1][i] == one(eltype(ŷ))
     end
   end
-end 
+end

--- a/test/cache_macro.jl
+++ b/test/cache_macro.jl
@@ -54,7 +54,7 @@ end
     @test stats.misses == misses + 1
     @test f1(x) === val
     @test stats.hits == hits + 1
-    
+
     clear_cache!(f1)
     @test length(cache) == 0
     stats = SymbolicUtils.get_stats(f1)

--- a/test/code.jl
+++ b/test/code.jl
@@ -197,7 +197,7 @@ nanmath_st.rewrites[:nanmath] = true
                           MakeArray([a b; a+b a/b], arr))))
     @test trackedarr isa ReverseDiff.TrackedArray
     @test trackedarr == [1 2; 3 1/2]
-    
+
 
     R1 = eval(toexpr(Let([a ← 1, b ← 2, arr ← @MVector([1,2])],MakeArray([a,b,a+b,a/b], arr))))
     @test R1 == (@MVector [1, 2, 3, 1/2]) && R1 isa MVector

--- a/test/cse.jl
+++ b/test/cse.jl
@@ -46,7 +46,7 @@ end
     @test length(let_expr.pairs) == 1
     node = let_expr.pairs[end].rhs
     @test operation(node) === (+) && issetequal(arguments(node), [a, b])
-    
+
     expr = a
     sorted_nodes = topological_sort(expr)
     @test isempty(sorted_nodes)

--- a/test/irstructure.jl
+++ b/test/irstructure.jl
@@ -95,7 +95,7 @@ end
     expr = x + 2y + 3sin(z + fn(w[1] + sum(w) * tanh(w'w)))
     ir = IRStructure{SymReal}()
     populate_ir!(ir, expr)
-    
+
     buffer = Set{BasicSymbolic{SymReal}}()
     SU.search_variables!(buffer, ir, expr)
     buffer2 = empty(buffer)

--- a/test/recursive_utils.jl
+++ b/test/recursive_utils.jl
@@ -138,7 +138,7 @@ end
         det_expr = LinearAlgebra.det(M)
 
         det_scal = SymbolicUtils.scalarize(det_expr)
-        
+
         vals = reshape(1:(N*N), N, N)
         @test det(vals) ≈ unwrap_const(substitute(det_scal, Dict(M => vals); fold = Val(true))) atol = 1e-16
     end

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -1,6 +1,6 @@
 using SymbolicUtils
 using SymbolicUtils: unwrap_const
-using Test 
+using Test
 include("utils.jl")
 
 @syms a b c d x
@@ -102,7 +102,7 @@ end
     @test r_mult3(a*(c+2)) === a
     @test r_mult3(2*(c+2)) === 2
     @test r_mult3(c+2) === 1
-    
+
     r_pow = @rule (~x)^(~!m) => ~m
     @test isequal(r_pow(a^(b+1)), b+1)
     @test r_pow(a) === 1
@@ -208,7 +208,7 @@ using SymbolicUtils: @capture
 
     #note that @test inserts a soft local scope (try-catch) that would gobble
     #the matches from assignment statements in @capture macro, so we call it
-    #outside the test macro 
+    #outside the test macro
     ret = @capture ex (~x)^(~x)
     @test ret
     @test @isdefined x


### PR DESCRIPTION
My editor keeps making diffs in random places due to all the trailing whitespace. We can add a git blame ignore revs file (like https://github.com/JuliaLang/julia/blob/master/.git-blame-ignore-revs) to avoid it messing up git blame.