### PR TITLE
Add `ifelse_eager` and `ifelse_branching` conditional operators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicUtils"
 uuid = "d1185830-fcd6-423d-90d6-eec64667417b"
 authors = ["Shashi Gowda"]
-version = "4.34.3"
+version = "4.35.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/SymbolicUtils.jl
+++ b/src/SymbolicUtils.jl
@@ -132,6 +132,7 @@ export @makearray
 include("arraymaker.jl")
 
 # Methods on symbolic objects
+export ifelse_eager, ifelse_branching
 PrecompileTools.@recompile_invalidations begin
 using SpecialFunctions, NaNMath
 include("methods.jl")

--- a/src/code.jl
+++ b/src/code.jl
@@ -19,7 +19,8 @@ import SymbolicUtils: @matchable, BasicSymbolic, Sym, Term, iscall, operation, a
                       search_variables!, _is_index_variable, RangesT, IDXS_SYM, is_array_shape,
                       symtype, vartype, add_worker, search_variables!, @union_split_smallvec,
                       ArrayMaker, TypeT, ShapeT, SymReal, SafeReal, TreeReal, _unreachable, unwrap,
-                      AddMulVariant, _isone, _iszero, Fill, IRStructure, populate_ir!, FnType
+                      AddMulVariant, _isone, _iszero, Fill, IRStructure, populate_ir!, FnType,
+                      ifelse_eager, ifelse_branching
 using Moshi.Match: @match
 import SymbolicIndexingInterface: symbolic_type, NotSymbolic
 import Graphs
@@ -631,6 +632,15 @@ function function_to_expr(op::typeof(^), O::BasicSymbolic{T}, st) where {T}
 end
 
 function function_to_expr(::typeof(ifelse), O, st)
+    args = arguments(O)
+    return Expr(:if, toexpr(args[1], st), toexpr(args[2], st), toexpr(args[3], st))
+end
+
+# `ifelse_branching` lowers to an `if`/`else` (only the taken branch is evaluated). `toexpr`
+# inlines recursively, so this slow path is naturally lazy. `ifelse_eager` needs no special
+# handling: it is a registered function whose definition calls `ifelse`, so the generic
+# `function_to_expr` fallback lowers it to a plain (eager) call.
+function function_to_expr(::typeof(ifelse_branching), O, st)
     args = arguments(O)
     return Expr(:if, toexpr(args[1], st), toexpr(args[2], st), toexpr(args[3], st))
 end
@@ -1537,6 +1547,10 @@ Return `true` if CSE should descend inside `sym`, which has operation `f`.
 function cse_inside_expr(sym, f)
     return true
 end
+
+# Keep the branches of `ifelse_branching` out of CSE so they are not hoisted ahead of the
+# conditional; the codegen for `ifelse_branching` emits them inside their `if`/`else` arms.
+cse_inside_expr(sym, ::typeof(ifelse_branching)) = false
 
 """
     $(TYPEDEF)

--- a/src/faster_code.jl
+++ b/src/faster_code.jl
@@ -872,6 +872,28 @@ function codegen_function!(::typeof(ifelse), cs::CodegenState{T}, expr::BasicSym
     return codegen!(cs, expr_idx, Expr(:if, cs(cs.ir[cond_idx]), cs(cs.ir[true_idx]), cs(cs.ir[false_idx])))
 end
 
+# `ifelse_branching` emits each branch body into its own codegen scope so it lands inside the
+# corresponding `if`/`else` arm rather than being hoisted ahead of the conditional. Together
+# with `cse_inside_expr(_, ::typeof(ifelse_branching)) = false`, this guarantees the untaken
+# branch is never evaluated, even when CSE is enabled. (`ifelse_eager` needs no method here:
+# it lowers via the generic `codegen_function!` fallback to an eager call.)
+function codegen_function!(::typeof(ifelse_branching), cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
+    cond_idx, true_idx, false_idx = Graphs.outneighbors(cs.ir.dependency_graph, expr_idx)
+    cond = cs(cs.ir[cond_idx])
+
+    true_cs, true_bm = enter_scope(cs)
+    true_val = true_cs(cs.ir[true_idx])
+    true_block = exit_scope!(true_cs, true_bm)
+    push!(true_block.args, true_val)
+
+    false_cs, false_bm = enter_scope(cs)
+    false_val = false_cs(cs.ir[false_idx])
+    false_block = exit_scope!(false_cs, false_bm)
+    push!(false_block.args, false_val)
+
+    return codegen!(cs, expr_idx, Expr(:if, cond, true_block, false_block))
+end
+
 function codegen_function_no_nanmath!(@nospecialize(op), cs::CodegenState{T}, expr::BasicSymbolic{T}, expr_idx::Integer) where {T}
     result = Expr(:call)
     if !(op isa BasicSymbolic{T})

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -685,6 +685,58 @@ function promote_shape(::typeof(ifelse), shc::ShapeT, sht::ShapeT, shf::ShapeT)
     return sht
 end
 
+"""
+    ifelse_eager(cond, x, y)
+
+Conditional that builds the same kind of symbolic expression as `ifelse`, but **always lowers
+to an eager `ifelse` call** during code generation: both branches `x` and `y` are evaluated
+unconditionally and `cond` selects between the computed values.
+
+Use it when both branches are always valid to evaluate and branch-free code is desirable (e.g.
+to keep generated code vectorizable/SIMD-friendly or GPU-divergence-free). Contrast with
+[`ifelse_branching`](@ref), which never evaluates the untaken branch.
+
+`ifelse`, `ifelse_eager` and `ifelse_branching` differ only in how code generation lowers them;
+`ifelse` is the default and is intended to eventually pick a strategy via a cost heuristic.
+"""
+ifelse_eager(cond, x, y) = ifelse(cond, x, y)
+
+"""
+    ifelse_branching(cond, x, y)
+
+Conditional that builds the same kind of symbolic expression as `ifelse`, but **always lowers
+to an `if`/`else` branch** during code generation, so that only the taken branch is evaluated.
+The untaken branch's code is emitted inside the branch and is never executed when `cond`
+selects the other branch — even under common-subexpression elimination (`ifelse_branching`
+opts out of CSE for the conditional via [`cse_inside_expr`](@ref)).
+
+Use it when a branch is only valid to evaluate when its condition holds (it divides by a
+quantity that is zero otherwise, indexes into something that does not exist, errors, or
+produces `NaN`/`Inf`). Contrast with [`ifelse_eager`](@ref), which evaluates both branches.
+
+`ifelse`, `ifelse_eager` and `ifelse_branching` differ only in how code generation lowers them;
+`ifelse` is the default and is intended to eventually pick a strategy via a cost heuristic.
+"""
+ifelse_branching(cond, x, y) = cond ? x : y
+
+# Symbolic nodes and type/shape promotion for the two variants mirror `ifelse`.
+for op in (:ifelse_eager, :ifelse_branching)
+    @eval begin
+        function $op(_if::BasicSymbolic{T}, _then, _else) where {T}
+            type = promote_symtype($op, symtype(_if), symtype(_then), symtype(_else))
+            sh = promote_shape($op, shape(_if), shape(_then), shape(_else))
+            Term{T}($op, ArgsT{T}((_if, _then, _else)); type, shape = sh)
+        end
+        function promote_symtype(::typeof($op), C::TypeT, T::TypeT, S::TypeT)
+            return promote_symtype(ifelse, C, T, S)
+        end
+        function promote_shape(::typeof($op), shc::ShapeT, sht::ShapeT, shf::ShapeT)
+            @nospecialize shc sht shf
+            return promote_shape(ifelse, shc, sht, shf)
+        end
+    end
+end
+
 # Array-like operations
 Base.IndexStyle(::Type{<:BasicSymbolic}) = Base.IndexCartesian()
 function _size_from_shape(shape::ShapeT)

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -716,6 +716,12 @@ produces `NaN`/`Inf`). Contrast with [`ifelse_eager`](@ref), which evaluates bot
 
 `ifelse`, `ifelse_eager` and `ifelse_branching` differ only in how code generation lowers them;
 `ifelse` is the default and is intended to eventually pick a strategy via a cost heuristic.
+
+!!! note
+    Opting the conditional out of CSE also means the `ifelse_branching` node itself is not
+    bound to a shared temporary, so when its result is referenced at multiple sites the
+    generated `if`/`else` is duplicated at each use (the branches stay lazy and the computed
+    values are unchanged).
 """
 ifelse_branching(cond, x, y) = cond ? x : y
 

--- a/src/simplify_rules.jl
+++ b/src/simplify_rules.jl
@@ -72,6 +72,10 @@ const ASSORTED_RULES = (
     @rule(imag(~x::_isreal) => zero(symtype(~x))),
     @rule(ifelse(~x::is_literal_number, ~y, ~z) => ~x ? ~y : ~z),
     @rule(ifelse(~x, ~y, ~y) => ~y),
+    @rule(ifelse_eager(~x::is_literal_number, ~y, ~z) => ~x ? ~y : ~z),
+    @rule(ifelse_eager(~x, ~y, ~y) => ~y),
+    @rule(ifelse_branching(~x::is_literal_number, ~y, ~z) => ~x ? ~y : ~z),
+    @rule(ifelse_branching(~x, ~y, ~y) => ~y),
 )
 
 const TRIG_EXP_RULES = (

--- a/test/conditionals.jl
+++ b/test/conditionals.jl
@@ -1,0 +1,55 @@
+using SymbolicUtils
+using SymbolicUtils: ifelse_eager, ifelse_branching, term, symtype
+using SymbolicUtils.Code
+using RuntimeGeneratedFunctions
+using Test
+
+RuntimeGeneratedFunctions.init(@__MODULE__)
+
+# Errors if it is ever actually evaluated; used to detect whether the untaken branch runs.
+boom(v) = error("untaken branch was evaluated: boom($v)")
+boomterm(v) = term(boom, v; type = Real, shape = SymbolicUtils.shape(v))
+
+compile(body, args...) = @RuntimeGeneratedFunction(toexpr(cse(Func(collect(args), [], body))))
+
+@testset "Construction, symtype and shape mirror `ifelse`" begin
+    @syms cond::Bool a b x[1:3] y[1:3] z[1:4]
+    for op in (ifelse_eager, ifelse_branching)
+        e = op(cond, a, b)
+        @test operation(e) === op
+        @test symtype(e) == symtype(ifelse(cond, a, b))
+        @test SymbolicUtils.promote_symtype(op, Bool, Int, Bool) == Int
+        @test_throws ArgumentError SymbolicUtils.promote_symtype(op, Real, Int, Float64)
+        # array-branch rules match `ifelse`
+        @test SymbolicUtils.shape(op(cond, x, y)) == [1:3]
+        @test_throws ErrorException op(cond, x, z)
+    end
+end
+
+@testset "Lowering forms" begin
+    @syms cond::Bool a b
+    @test toexpr(ifelse_branching(cond, a, b)).head === :if
+    # `ifelse_eager` lowers via the generic fallback to a plain (eager) call
+    @test toexpr(ifelse_eager(cond, a, b)).head === :call
+end
+
+@testset "simplify folds like `ifelse`" begin
+    @syms cond::Bool b
+    for op in (ifelse_eager, ifelse_branching)
+        @test isequal(simplify(op(cond, b, b)), b)
+    end
+end
+
+@testset "ifelse_branching does not evaluate the untaken branch" begin
+    @syms x::Real
+    f = compile(ifelse_branching(x > 0, x^2, boomterm(x)), x)
+    @test f(2.0) == 4.0          # takes the valid branch; `boom` never runs
+    g = compile(ifelse_branching(x > 0, boomterm(x), 1 / x), x)
+    @test g(-2.0) == -0.5
+end
+
+@testset "ifelse_eager evaluates both branches" begin
+    @syms x::Real
+    f = compile(ifelse_eager(x > 0, x^2, boomterm(x)), x)
+    @test_throws ErrorException f(2.0)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,6 +33,7 @@ if GROUP == "Core"
             @safetestset "New codegen" begin include("new_code.jl") end
             @safetestset "Symbolic codegen primitives" begin include("symbolic_codegen_primitives.jl") end
             @safetestset "CSE" begin include("cse.jl") end
+            @safetestset "Conditionals" begin include("conditionals.jl") end
             @safetestset "Interface" begin include("interface.jl") end
             # Disabled until https://github.com/JuliaMath/SpecialFunctions.jl/issues/446 is fixed
             @safetestset "Fuzz" begin include("fuzz.jl") end


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Opened as a draft.

## Summary

Adds two conditional operators next to `ifelse`, requested for the 3D-multibody / spherical-joint work in [Symbolics.jl#1887](https://github.com/JuliaSymbolics/Symbolics.jl/pull/1887). They build the *same* kind of symbolic expression as `ifelse` and only differ in **how code generation lowers them**:

- **`ifelse_eager(cond, x, y)`** — always lowers to an eager `ifelse` call: both branches are evaluated and `cond` selects between the computed values. It needs **no custom codegen** — its definition is `ifelse(cond, x, y)`, so the generic lowering already emits a plain eager call.
- **`ifelse_branching(cond, x, y)`** — always lowers to an `if`/`else`, so the **untaken branch is never evaluated, even under CSE**. Useful when a branch is only valid when its condition holds (divides by a quantity that is zero otherwise, indexes into something that doesn't exist, errors, …).

`ifelse` stays the default; the intent is that it eventually picks a lowering strategy via a cost heuristic while these two pin a specific strategy.

## Implementation

- `methods.jl`: the two functions, their `BasicSymbolic` term construction, and `promote_symtype`/`promote_shape` (delegating to `ifelse`'s — condition must be `Bool`, branches share a shape).
- `faster_code.jl` / `code.jl`: a `codegen_function!` (fast path) and `function_to_expr` (slow path) for `ifelse_branching` that emit each branch into its own codegen scope (`enter_scope`/`exit_scope!`) so it lands inside the arm; plus `cse_inside_expr(_, ::typeof(ifelse_branching)) = false` so CSE doesn't hoist the branches out. `ifelse_eager` needs none of this — it lowers via the generic fallback.
- `simplify_rules.jl`: the same literal-condition / equal-branch folds `ifelse` has.
- Exported from `SymbolicUtils`.

## Tests

New `test/conditionals.jl` (wired into `runtests.jl`): construction/symtype/shape parity with `ifelse`, lowering forms (`:if` vs `:call`), `simplify` folding, and behavioral checks that `ifelse_branching` never runs the untaken branch (compiled via `cse` + `RuntimeGeneratedFunction`) while `ifelse_eager` does. All pass locally.

The `Num`/`Arr` wrappers, differentiation and linearity/sparsity integration live in the companion Symbolics.jl PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
