### PR TITLE
cache checks in `query` to avoid exponential blowup when traversing large expressions

### DIFF
--- a/src/substitute.jl
+++ b/src/substitute.jl
@@ -298,42 +298,53 @@ returns `true` for any node in the tree.
 # Returns
 - `Bool`: `true` if any subexpression satisfies the predicate, `false` otherwise.
 """
-function query(predicate::F, expr::BasicSymbolic; recurse::G = iscall, default::Bool = false) where {F, G}
-    return _query(predicate, expr, recurse, default)
+function query(predicate::F, expr::BasicSymbolic{T}; recurse::G = iscall, default::Bool = false) where {F, G, T}
+    return _query(predicate, expr, recurse, default, nothing)
 end
 query(predicate::F, expr; kw...) where {F} = predicate(expr)
 
-function _query(predicate::F, expr::BasicSymbolic, recurse::G, default::Bool) where {F, G}
+function _query(predicate::F, expr::BasicSymbolic{T}, recurse::G, default::Bool,
+        _seen::Union{Base.IdSet{BasicSymbolic{T}}, Nothing}) where {F, G, T}
     predicate(expr) && return true
     iscall(expr) || return default
     recurse(expr) || return default
 
+    # A node in `seen` was already explored
+    # without ending the query, so revisiting cannot change the result.
+    if _seen === nothing
+        seen = Base.IdSet{BasicSymbolic{T}}()
+    else
+        seen = _seen
+        expr in seen && return false
+    end
+    push!(seen, expr)
+
     return @match expr begin
         BSImpl.Term(; f, args) => begin
             for arg in args
-                _query(predicate, arg, recurse, default) && return true
+                _query(predicate, arg, recurse, default, seen) && return true
             end
             false
         end
         BSImpl.AddMul(; dict) => begin
             for arg in keys(dict)
-                _query(predicate, arg, recurse, default) && return true
+                _query(predicate, arg, recurse, default, seen) && return true
             end
             false
         end
-        BSImpl.Div(; num, den) => _query(predicate, num, recurse, default) || _query(predicate, den, recurse, default)
+        BSImpl.Div(; num, den) => _query(predicate, num, recurse, default, seen) || _query(predicate, den, recurse, default, seen)
         BSImpl.ArrayOp(; expr = inner_expr, term) => begin
-            _query(predicate, @something(term, inner_expr), recurse, default)
+            _query(predicate, @something(term, inner_expr), recurse, default, seen)
         end
         BSImpl.ArrayMaker(; values) => begin
             for arg in values
-                _query(predicate, arg, recurse, default) && return true
+                _query(predicate, arg, recurse, default, seen) && return true
             end
             false
         end
     end
 end
-_query(predicate::F, expr, recurse, default::Bool) where {F} = predicate(expr)
+_query(predicate::F, expr, recurse, default::Bool, _seen) where {F} = predicate(expr)
 
 
 search_variables!(buffer, expr; kw...) = nothing


### PR DESCRIPTION
For the benchmark

```julia
using SymbolicUtils
using SymbolicUtils: query
using BenchmarkTools

@syms x::Real y::Real g(a::Real, b::Real)::Real

function build_dag(depth)
    e = x
    for _ in 1:depth
        e = g(e, e)
    end
    return e
end

pred = isequal(y)

for depth in [4, 8, 16, 20, 24]
    e = build_dag(depth)
    @assert query(pred, e) == false
    t = @btime query($pred, $e)
end
```

this gives:

```
# Before
  411.946 ns (0 allocations: 0 bytes)
  6.833 μs (0 allocations: 0 bytes)
  1.791 ms (0 allocations: 0 bytes)
  30.701 ms (0 allocations: 0 bytes)
  505.504 ms (0 allocations: 0 bytes)

# After
  228.288 ns (3 allocations: 176 bytes)
  471.730 ns (5 allocations: 352 bytes)
  950.000 ns (7 allocations: 656 bytes)
  1.333 μs (8 allocations: 912 bytes)
  1.629 μs (8 allocations: 912 bytes)
```