### PR TITLE
fix that `combine_fold` can be called with a `op=Fill` with non-symbolic args

### DIFF
--- a/src/substitute.jl
+++ b/src/substitute.jl
@@ -208,7 +208,7 @@ end
 
 function combine_fold(::Type{T}, op, args::Union{ROArgsT{T}, ArgsT{T}}, meta::MetadataT, can_fold::Bool) where {T}
     @nospecialize op args meta
-    if can_fold
+    if can_fold && !(op isa Fill)
         if length(args) == 1
             Const{T}(op(unwrap_const(args[1])))
         elseif length(args) == 2

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -483,3 +483,10 @@ end
     @test SymbolicUtils.promote_shape(tuple, Unknown(1), ShapeVecT((1:3, 1:3,)), ShapeVecT()) == [1:3]
 end
 
+@testset "Fill const" begin
+    @syms x::Real
+    filled = Fill(ShapeVecT((1:3,)))(x)
+    res = substitute(filled, Dict(x => 1))
+    @test operation(res) isa Fill
+    @test unwrap_const(only(arguments(res))) == 1
+end


### PR DESCRIPTION
Trying to evaluate `op` with a non-symbolic used to crash. Now it falls back to `maketerm` instead.

I am not sure we should actually try to execute the `Fill` here though (via the non-symbolic `fill` I guess)...