### PR TITLE
Route array-shaped factors out of Mul{T} to keep MUL dicts scalar-only

### DIFF
--- a/src/safe_ctors.jl
+++ b/src/safe_ctors.jl
@@ -85,6 +85,13 @@ High-level constructor for multiplication expressions.
 This constructor maintains invariants required by the `AddMul` variant. This should be
 preferred over the `BSImpl.AddMul{T}` constructor.
 """
+function _has_array_key(dict)
+    for k in keys(dict)
+        is_array_shape(shape(k)) && return true
+    end
+    return false
+end
+
 @inline function Mul{T}(coeff, dict; kw...) where {T}
     @nospecialize coeff kw
     coeff = unwrap(coeff)
@@ -93,7 +100,18 @@ preferred over the `BSImpl.AddMul{T}` constructor.
         return Const{T}(coeff)
     elseif _iszero(coeff)
         return zero_of_vartype(T)
-    elseif _isone(coeff) && length(dict) == 1
+    end
+    if _has_array_key(dict)
+        factors = ArgsT{T}()
+        sizehint!(factors, length(dict) + 1)
+        push!(factors, Const{T}(coeff))
+        for (k, v) in dict
+            # `k ^ 1` is just `k`; avoid `^` so an array base isn't rejected.
+            push!(factors, _isone(v) ? k : k ^ v)
+        end
+        return mul_worker(T, factors)::BasicSymbolic{T}
+    end
+    if _isone(coeff) && length(dict) == 1
         k, v = first(dict)
         if _isone(v)
             return k

--- a/test/arrayop.jl
+++ b/test/arrayop.jl
@@ -301,3 +301,19 @@ end
 
     @test isequal(scalarize(outer), [2A[1]+1, 2A[2]+1, 2A[3]+1])
 end
+
+@testset "Array summand reconstruction (no `vector ^ 1`)" begin
+    using SymbolicUtils: ismul, ACDict, Mul
+
+    @syms y[1:3]
+
+    # Reconstructing a `coeff * vector` summand must not raise the vector base to a
+    # power (`y ^ 1`), which `^` rejects for non-matrix arrays.
+    ex = y - y + y + y
+    @test all(s -> operation(s) === (*) && length(arguments(s)) == 2, arguments(ex))
+
+    # `Mul` keeps the invariant directly: an array base never becomes a MUL key.
+    m = Mul{SymReal}(3, ACDict{SymReal}(y => 1))
+    @test operation(m) === (*) && !ismul(m)
+    @test isequal(Mul{SymReal}(1, ACDict{SymReal}(y => 1)), y)  # coeff 1, power 1 -> bare vector
+end


### PR DESCRIPTION
Otherwise, we had situations like:

```
julia> y - y + y + y
Error showing value of type SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymReal}:

SYSTEM (REPL): showing an error caused an error
ERROR: 1-element ExceptionStack:
ArgumentError: Matrices are the only arrays that can be raised to a power. Found array of shape UnitRange{Int64}[1:3].
Stacktrace:
  [1] throw_nonmatbase(x::SymbolicUtils.SmallVec{UnitRange{Int64}, Vector{UnitRange{Int64}}})
    @ SymbolicUtils ~/JuliaTests/SymbolicUtilPerf/SymbolicUtils2.jl/src/symbolic_ops/pow.jl:9
  [2] promote_shape
    @ ~/JuliaTests/SymbolicUtilPerf/SymbolicUtils2.jl/src/symbolic_ops/pow.jl:44 [inlined]
  [3] ^(a::SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymReal}, b::Int64)
    @ SymbolicUtils ~/JuliaTests/SymbolicUtilPerf/SymbolicUtils2.jl/src/symbolic_ops/pow.jl:61
  [4] arguments(x::SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymReal})
    @ SymbolicUtils ~/JuliaTests/SymbolicUtilPerf/SymbolicUtils2.jl/src/terminterface.jl:192
  [5] __get_degrees(expr::SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymReal})
    @ SymbolicUtils ~/JuliaTests/SymbolicUtilPerf/SymbolicUtils2.jl/src/ordering.jl:146
  [6] ##_get_degrees_1#1134
    @ ~/JuliaTests/SymbolicUtilPerf/SymbolicUtils2.jl/src/ordering.jl:47 [inlined]
  [7] _get_degrees_1(expr::SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymReal})
    @ SymbolicUtils ~/JuliaTests/SymbolicUtilPerf/SymbolicUtils2.jl/src/cache.jl:432
  [8] get_degrees
    @ ~/JuliaTests/SymbolicUtilPerf/SymbolicUtils2.jl/src/ordering.jl:34 [inlined]
  [9] macro expansion
    @ ~/JuliaTests/SymbolicUtilPerf/SymbolicUtils2.jl/src/terminterface.jl:116 [inlined]
 [10] macro expansion
    @ ~/JuliaTests/SymbolicUtilPerf/SymbolicUtils2.jl/src/small_array.jl:354 [inlined]
 [11] __sorted_args(x::SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymReal})
    @ SymbolicUtils ~/JuliaTests/SymbolicUtilPerf/SymbolicUtils2.jl/src/terminterface.jl:114
 [12] ##_sorted_args1#470
    @ ~/JuliaTests/SymbolicUtilPerf/SymbolicUtils2.jl/src/terminterface.jl:100 [inlined]
 [13] _sorted_args1(x::SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymReal})
    @ SymbolicUtils ~/JuliaTests/SymbolicUtilPerf/SymbolicUtils2.jl/src/cache.jl:432
 [14] sorted_arguments
    @ ~/JuliaTests/SymbolicUtilPerf/SymbolicUtils2.jl/src/terminterface.jl:90 [inlined]
 [15] show_add(io::IOContext{REPL.LimitIO{…}}, x::SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymReal})
    @ SymbolicUtils ~/JuliaTests/SymbolicUtilPerf/SymbolicUtils2.jl/src/printing.jl:270
 [16] show_plain(io::IOContext{REPL.LimitIO{…}}, x::SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymReal})
    @ SymbolicUtils ~/JuliaTests/SymbolicUtilPerf/SymbolicUtils2.jl/src/printing.jl:52
 [17] show
    @ ~/JuliaTests/SymbolicUtilPerf/SymbolicUtils2.jl/src/printing.jl:67 [inlined]
 [18] show(io::IOContext{…}, ::MIME{…}, x::SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{…})
    @ Base.Multimedia ./multimedia.jl:47
```