### PR TITLE
Combine like terms for array symbols in Add

### DIFF
--- a/src/safe_ctors.jl
+++ b/src/safe_ctors.jl
@@ -85,6 +85,13 @@ High-level constructor for multiplication expressions.
 This constructor maintains invariants required by the `AddMul` variant. This should be
 preferred over the `BSImpl.AddMul{T}` constructor.
 """
+function _has_array_key(dict)
+    for k in keys(dict)
+        is_array_shape(shape(k)) && return true
+    end
+    return false
+end
+
 @inline function Mul{T}(coeff, dict; kw...) where {T}
     @nospecialize coeff kw
     coeff = unwrap(coeff)
@@ -93,7 +100,18 @@ preferred over the `BSImpl.AddMul{T}` constructor.
         return Const{T}(coeff)
     elseif _iszero(coeff)
         return zero_of_vartype(T)
-    elseif _isone(coeff) && length(dict) == 1
+    end
+    if _has_array_key(dict)
+        factors = ArgsT{T}()
+        sizehint!(factors, length(dict) + 1)
+        push!(factors, Const{T}(coeff))
+        for (k, v) in dict
+            # `k ^ 1` is just `k`; avoid `^` so an array base isn't rejected.
+            push!(factors, _isone(v) ? k : k ^ v)
+        end
+        return mul_worker(T, factors)::BasicSymbolic{T}
+    end
+    if _isone(coeff) && length(dict) == 1
         k, v = first(dict)
         if _isone(v)
             return k

--- a/src/symbolic_ops/addsub.jl
+++ b/src/symbolic_ops/addsub.jl
@@ -131,7 +131,16 @@ function (awb::AddWorkerBuffer{T})(terms) where {T}
                     end
                 end
                 _ => begin
-                    _accumulate!(result, term, 1)
+                    if is_array_shape(SymbolicUtils.shape(term))
+                        coeff, arrterm = _split_arrterm_scalar_coeff(T, term)
+                        if isconst(coeff)
+                            _accumulate!(result, arrterm, unwrap_const(coeff))
+                        else
+                            _accumulate!(result, term, 1)
+                        end
+                    else
+                        _accumulate!(result, term, 1)
+                    end
                 end
             end
         elseif term isa BasicSymbolic{SymReal} || term isa BasicSymbolic{SafeReal} || term isa BasicSymbolic{TreeReal}
@@ -143,8 +152,25 @@ function (awb::AddWorkerBuffer{T})(terms) where {T}
             newcoeff = newcoeff .+ term
         end
     end
+    # If every term cancels we still need to preserve the array shape (a scalar `0` cannot
+    # stand in for a zero vector). Grab a surviving array-shaped key before filtering so the
+    # all-cancel case can be rebuilt as `coeff * arr` (e.g. `y - y` => `0y`).
+    arr_witness = nothing
+    if is_array_shape(shape)
+        for k in keys(result)
+            if is_array_shape(SymbolicUtils.shape(k))
+                arr_witness = k
+                break
+            end
+        end
+    end
     filter!(!(iszero ∘ last), result)
-    isempty(result) && return Const{T}(newcoeff)
+    if isempty(result)
+        if arr_witness !== nothing && !(newcoeff isa AbstractArray)
+            return (newcoeff * arr_witness)::BasicSymbolic{T}
+        end
+        return Const{T}(newcoeff)
+    end
     var = Add{T}(newcoeff, result; type, shape)::BasicSymbolic{T}
     @match var begin
         BSImpl.AddMul(; dict) && if dict === result end => (awb.dict = ACDict{T}())

--- a/test/arrayop.jl
+++ b/test/arrayop.jl
@@ -305,11 +305,15 @@ end
 @testset "Array summand reconstruction (no `vector ^ 1`)" begin
     using SymbolicUtils: ismul, ACDict, Mul
 
-    @syms y[1:3]
+    @syms y[1:3] w[1:3]
+
+    @test isequal(y - y + y + y, 2y)
+    @test isequal(y - y, 0y)
+    @test isequal(y + w - y, w)
 
     # Reconstructing a `coeff * vector` summand must not raise the vector base to a
     # power (`y ^ 1`), which `^` rejects for non-matrix arrays.
-    ex = y - y + y + y
+    ex = 2y + 3w
     @test all(s -> operation(s) === (*) && length(arguments(s)) == 2, arguments(ex))
 
     # `Mul` keeps the invariant directly: an array base never becomes a MUL key.

--- a/test/arrayop.jl
+++ b/test/arrayop.jl
@@ -301,3 +301,19 @@ end
 
     @test isequal(scalarize(outer), [2A[1]+1, 2A[2]+1, 2A[3]+1])
 end
+
+@testset "Array summand reconstruction (no `vector ^ 1`)" begin
+    using SymbolicUtils: ismul, ACDict, Mul
+
+    @syms y[1:3]
+
+    # Reconstructing a `coeff * vector` summand must not raise the vector base to a
+    # power (`y ^ 1`), which `^` rejects for non-matrix arrays.
+    ex = y - y + y + y
+    @test all(s -> operation(s) === (*) && length(arguments(s)) == 2, arguments(ex))
+
+    # `Mul` keeps the invariant directly: an array base never becomes a MUL key.
+    m = Mul{SymReal}(3, ACDict{SymReal}(y => 1))
+    @test operation(m) === (*) && !ismul(m)
+    @test isequal(Mul{SymReal}(1, ACDict{SymReal}(y => 1)), y)  # coeff 1, power 1 -> bare vector
+end


### PR DESCRIPTION
Before we had stuff like:

```
julia> @syms y[1:3]
(y, )

julia> y-y
y + -y

julia> y-y+y
-y + 2y
```

Now:

```
julia> @syms y[1:3]
(y, )

julia> y-y
0y

julia> y-y+y
y
```

On top of #969 because they are kind of similar 