### PR TITLE
Don't error on `x^1` for non-matrix array bases

### DIFF
--- a/src/symbolic_ops/pow.jl
+++ b/src/symbolic_ops/pow.jl
@@ -54,8 +54,14 @@ function ^(a::BasicSymbolic{T}, b::Union{AbstractArray{<:Number}, Number, BasicS
     if !_numeric_or_arrnumeric_symtype(a) || !_numeric_or_arrnumeric_symtype(b)
         throw(MethodError(^, (a, b)))
     end
-    isconst(a) && return Const{T}(^(unwrap_const(a), b))
     b = unwrap_const(unwrap(b))
+    # `x^1 == x` for any shape. The array path below goes through
+    # `promote_shape(^, …)`, which rejects non-matrix array bases even for this
+    # identity exponent — but a non-matrix array can legitimately appear as a
+    # multiplicity-1 factor of a `Mul`, which `arguments` materializes as
+    # `base^1`. Handle it up front so an identity power never errors.
+    b isa Number && isone(b) && return a
+    isconst(a) && return Const{T}(^(unwrap_const(a), b))
     sha = shape(a)
     shb = shape(b)
     newshape = promote_shape(^, sha, shb)

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -91,6 +91,16 @@ end
     @test promote_shape(NaNMath.pow, ShapeVecT(), ShapeVecT()) == ShapeVecT()
 end
 
+@testset "identity power x^1 for non-matrix array bases" begin
+    # `x^1 == x` for any shape. A non-matrix array can appear as a
+    # multiplicity-1 factor of a `Mul`, materialized as `base^1`; this must
+    # not error in the generic array `^` path (promote_shape rejects
+    # non-matrix bases, but exponent 1 is an identity and never raises a power).
+    @syms a[1:3]::Float64
+    @test isequal(a ^ 1, a)
+    @test isequal(a ^ 1.0, a)
+end
+
 @testset "promote_shape for log with matrices" begin
     @test promote_shape(log, Unknown(2)) == Unknown(2)
     @test promote_shape(log, Unknown(-1)) == Unknown(-1)


### PR DESCRIPTION
`^(a::BasicSymbolic, b)` runs the (array) base through `promote_shape(^, …)`, which rejects non-matrix arrays — but it does so even for the **identity exponent `b == 1`**. A non-matrix array can legitimately appear as a multiplicity-1 factor of a `Mul`, which `arguments` materializes as `base^1`; that then errors (e.g. during code generation) with:

```
ArgumentError: Matrices are the only arrays that can be raised to a power. Found array of shape 1:3.
```

Since `x^1 == x` for any shape, this returns the base unchanged up front, before the array-shape check. Surfaced via ModelingToolkit/Symbolics RHS codegen of a multibody model, where a 3-vector factor appeared as `vec^1`.

Adds a regression test (`test/methods.jl`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

cc @AayushSabharwal 
