### PR TITLE
feat: allow passing non-symbolic values to `Fill`

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -1787,6 +1787,14 @@ function (f::Fill)(x::BasicSymbolic{T}) where {T}
     return BSImpl.ArrayOp{T}(out_idxs, x, +, term, ranges; type = term.type, shape = term.shape)
 end
 
+function (f::Fill)(x)
+    ux = unwrap(x)
+    if ux !== x
+        return f(ux)
+    end
+    return fill(x, map(length, f.sh)...)
+end
+
 function promote_symtype(f::Fill, T::TypeT)
     return Array{T, length(f.sh)}
 end

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -483,3 +483,8 @@ end
     @test SymbolicUtils.promote_shape(tuple, Unknown(1), ShapeVecT((1:3, 1:3,)), ShapeVecT()) == [1:3]
 end
 
+
+@testset "`Fill` with non-symbolic argument" begin
+    f = Fill(ShapeVecT((1:3, 1:3)))
+    @test f(1) == fill(1, 3, 3)
+end


### PR DESCRIPTION
This allows it to be constant-folded in `combine_fold`. Supersedes #968 