### PR TITLE
add a fastpass for multiplying by one

### DIFF
--- a/src/symbolic_ops/mul.jl
+++ b/src/symbolic_ops/mul.jl
@@ -371,7 +371,7 @@ mul_worker(::Type{SymReal}, terms) = _run_mulbuffer(SYMREAL_MULBUFFER[], terms)
 mul_worker(::Type{SafeReal}, terms) = _run_mulbuffer(SAFEREAL_MULBUFFER[], terms)
 
 function *(x::T, args::Union{Number, T, AbstractArray{<:Number}, AbstractArray{T}}...) where {T <: NonTreeSym}
-    length(args) == 1 && _isone(args[1]) && return x
+    length(args) == 1 && args[1] isa Number && _isone(args[1]) && return x
     mul_worker(vartype(T), (x, args...))
 end
 

--- a/src/symbolic_ops/mul.jl
+++ b/src/symbolic_ops/mul.jl
@@ -377,7 +377,7 @@ end
 
 for T in [:(PolyadicNumericOpFirstArgT{T}), Int, Float64, Bool]
     @eval function *(a::$T, b::T, bs::Union{Number, T, AbstractArray{<:Number}, AbstractArray{T}}...) where {T <: NonTreeSym}
-        isempty(bs) && a isa Number && isone(a) && return b
+        isempty(bs) && _isone(a) && return b
         return mul_worker(vartype(T), (a, b, bs...))
     end
 end

--- a/src/symbolic_ops/mul.jl
+++ b/src/symbolic_ops/mul.jl
@@ -377,7 +377,7 @@ end
 
 for T in [:(PolyadicNumericOpFirstArgT{T}), Int, Float64, Bool]
     @eval function *(a::$T, b::T, bs::Union{Number, T, AbstractArray{<:Number}, AbstractArray{T}}...) where {T <: NonTreeSym}
-        isempty(bs) && _isone(a) && return b
+        isempty(bs) && a isa Number && _isone(a) && return b
         return mul_worker(vartype(T), (a, b, bs...))
     end
 end

--- a/src/symbolic_ops/mul.jl
+++ b/src/symbolic_ops/mul.jl
@@ -371,11 +371,13 @@ mul_worker(::Type{SymReal}, terms) = _run_mulbuffer(SYMREAL_MULBUFFER[], terms)
 mul_worker(::Type{SafeReal}, terms) = _run_mulbuffer(SAFEREAL_MULBUFFER[], terms)
 
 function *(x::T, args::Union{Number, T, AbstractArray{<:Number}, AbstractArray{T}}...) where {T <: NonTreeSym}
+    length(args) == 1 && args[1] isa Number && isone(args[1]) && return x
     mul_worker(vartype(T), (x, args...))
 end
 
 for T in [:(PolyadicNumericOpFirstArgT{T}), Int, Float64, Bool]
     @eval function *(a::$T, b::T, bs::Union{Number, T, AbstractArray{<:Number}, AbstractArray{T}}...) where {T <: NonTreeSym}
+        isempty(bs) && a isa Number && isone(a) && return b
         return mul_worker(vartype(T), (a, b, bs...))
     end
 end

--- a/src/symbolic_ops/mul.jl
+++ b/src/symbolic_ops/mul.jl
@@ -371,7 +371,7 @@ mul_worker(::Type{SymReal}, terms) = _run_mulbuffer(SYMREAL_MULBUFFER[], terms)
 mul_worker(::Type{SafeReal}, terms) = _run_mulbuffer(SAFEREAL_MULBUFFER[], terms)
 
 function *(x::T, args::Union{Number, T, AbstractArray{<:Number}, AbstractArray{T}}...) where {T <: NonTreeSym}
-    length(args) == 1 && args[1] isa Number && isone(args[1]) && return x
+    length(args) == 1 && _isone(args[1]) && return x
     mul_worker(vartype(T), (x, args...))
 end
 


### PR DESCRIPTION
This is not very uncommon, and it bypasses the whole `Mul` machinery:

```julia
using Symbolics
using BenchmarkTools

N = 2000
@variables x y[1:N] z[1:N]
yy = collect(y); zz = collect(z)

# expr = x + y1*z1 + y2*z2 + ... + yN*zN   (every dict coefficient is 1)
expr = x + sum(yy[i] * zz[i] for i in 1:N)

a, b, islin = Symbolics.linear_expansion(expr, x)
@assert islin

t = @btime Symbolics.linear_expansion($expr, $x);

# Before:
#  8.198 ms (131632 allocations: 4.72 MiB)
# After:
#  3.696 ms (47597 allocations: 1.94 MiB)
```