### PR TITLE
add a fast path for scalarizing `Fill`

### DIFF
--- a/src/substitute.jl
+++ b/src/substitute.jl
@@ -672,6 +672,22 @@ function _default_scalarize(f, x::BasicSymbolic{T}, ::Val{toplevel}) where {T, t
     end
 end
 
+scalarization_function(::Fill) = _scalarize_fill
+# Fast path for scalarizing a constant `Fill` array
+function _scalarize_fill(f, x::BasicSymbolic{T}, v::Val{toplevel}) where {T, toplevel}
+    @nospecialize f
+    sh = shape(x)
+    is_array_shape(sh) || return _default_scalarize(f, x, v)
+    val = @match x begin
+        BSImpl.ArrayOp(; expr) => expr
+        _ => nothing
+    end
+    if val isa BasicSymbolic{T} && !is_array_shape(shape(val))
+        return fill(val, prod(length, sh))
+    end
+    return _default_scalarize(f, x, v)
+end
+
 scalarization_function(::Type{ArrayOp{T}}) where {T} = _scalarize_arrayop
 
 function _scalarize_arrayop(_, x::BasicSymbolic{T}, ::Val{toplevel}) where {T, toplevel}

--- a/src/substitute.jl
+++ b/src/substitute.jl
@@ -683,7 +683,7 @@ function _scalarize_fill(f, x::BasicSymbolic{T}, v::Val{toplevel}) where {T, top
         _ => nothing
     end
     if val isa BasicSymbolic{T} && !is_array_shape(shape(val))
-        return fill(val, prod(length, sh))
+        return fill(val, map(length, sh)...)
     end
     return _default_scalarize(f, x, v)
 end


### PR DESCRIPTION
This pattern is not so uncommon, it happens for example in `collect(A)` in `unhack_system` in some cases

For a benchmark like:

```julia
using SymbolicUtils
using SymbolicUtils: Fill, ShapeVecT, scalarize, _default_scalarize
using BenchmarkTools

@syms x::Real

N = 2000
f = Fill(ShapeVecT((1:N,)))
A = f(x)                       # ArrayOp whose value is `x` everywhere

print("scalarize (fast _scalarize_fill): "); @btime scalarize($A);
print("_default_scalarize (per-element): "); @btime _default_scalarize($f, $A, Val{false}());
```

this gives

```julia
scalarize (fast _scalarize_fill):   766.490 ns (3 allocations: 16.06 KiB)
_default_scalarize (per-element):   657.042 μs (23500 allocations: 1.81 MiB)
```

