### PR TITLE
Declare public API (unlock downstream ExplicitImports allow-lists)

### DIFF
--- a/src/SymbolicUtils.jl
+++ b/src/SymbolicUtils.jl
@@ -187,6 +187,7 @@ PrecompileTools.@recompile_invalidations begin
 end
 
 @public add_worker, mul_worker
+@public BasicSymbolic, unwrap, isadd, ismul
 
 PrecompileTools.@setup_workload begin
     fold1 = Val{false}()


### PR DESCRIPTION
## Summary

Marks a focused set of documented, user-facing names that this package **owns** as `public` (via the existing `SciMLPublic.@public` convention, alongside the current `@public add_worker, mul_worker`). The goal is to unlock downstream cleanup: we have enabled ExplicitImports QA fleet-wide, and ~92 downstream repos currently carry `ei_kwargs` allow-lists ignoring NON-PUBLIC names from SymbolicUtils (for `check_all_qualified_accesses_are_public` / `check_all_explicit_imports_are_public`). Declaring the legitimately-public ones here lets those downstreams drop the matching ignores.

### Made public
- **`BasicSymbolic`** — `const BasicSymbolic = BSImpl.Type` (`src/types.jl`), docstringed; the core symbolic-expression type downstreams dispatch on.
- **`unwrap`** — `src/types.jl`, docstringed; returns the inner `Symbolic` wrapped in a non-symbolic subtype.
- **`isadd`** — `src/types.jl`, docstringed predicate (`AddMul`/ADD).
- **`ismul`** — `src/types.jl`, docstringed predicate (`AddMul`/MUL).

All four are defined and owned by `SymbolicUtils`, were neither exported nor public before, and have docstrings / are used as API downstream.

### Skipped (recorded reasons)
- **`_iszero`** — underscore-prefixed internal/impl-detail naming convention; not declared public even though it carries a docstring and is referenced in rule conditions. False-publicizing an internal is worse than a leftover downstream ignore.

## Verification (run locally)
- **Julia 1.12**: package precompiles/loads; `Base.ispublic(SymbolicUtils, n)` is `true` and `Base.isexported` is `false` for each of `BasicSymbolic`, `unwrap`, `isadd`, `ismul`. `_iszero` remains non-public.
- **Julia 1.10** (compat floor, no `public` keyword): package precompiles/loads cleanly; predicates and `unwrap` work. The `@public` macro version-gates correctly.
- Runic: the added line is not flagged (pre-existing formatting in the precompile-workload block was left untouched to keep this PR focused).

## Overlap with #836
PR #836 (`as/public-api`, "build: mark API as public") also touches public declarations and includes these names among a much larger batch, but it predates the Moshi struct refactor and is stale (last updated 2026-01-12). This PR is intentionally a **separate, small, focused** change off the current `master`, covering only the four names above so it is easy to review and merge independently. If #836 lands first and already marks these, this PR can be closed; otherwise this unblocks the downstream EI allow-list removals now.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)