### PR TITLE
fix: make expression ordering less dependent on hash

### DIFF
--- a/src/ordering.jl
+++ b/src/ordering.jl
@@ -54,7 +54,22 @@ end
 end
 
 function __default_degrees!(degrees::DegreesT, expr::BasicSymbolic{T}) where {T}
-    push!(degrees, SmallV{Symbol}((Symbol(:zzzzzzz, hash(expr)),)) => 1.0)
+    @match expr begin
+        BSImpl.Term(; f) => begin
+            if f isa BasicSymbolic{T}
+                if hasname(f)
+                    push!(degrees, SmallV{Symbol}((getname(f),)) => 1.0)
+                else
+                    __default_degrees!(degrees, f)
+                end
+            elseif applicable(nameof, f)
+                push!(degrees, SmallV{Symbol}((nameof(f),)) => 1.0)
+            else
+                push!(degrees, SmallV{Symbol}((:zzz_ZZZ_unknown,)) => 1.0)
+            end
+        end
+        _ => push!(degrees, SmallV{Symbol}((:zzz__ZZZ_unknown,)) => 1.0)
+    end
 end
 
 function __get_degrees(expr::BasicSymbolic{T})::RODegreesT where {T}
@@ -257,7 +272,7 @@ function <ₑ(a::BasicSymbolic, b::BasicSymbolic)
     bw = monomial_lt(db, da)
     if fw === bw && !isequal(a, b)
         if _arglen(a) == _arglen(b) != 0
-            return (operation(a), arguments(a)...,) <ₑ (operation(b), arguments(b)...,)
+            return (operation(a), sorted_arguments(a)...,) <ₑ (operation(b), sorted_arguments(b)...,)
         else
             return _arglen(a) < _arglen(b)
         end

--- a/src/ordering.jl
+++ b/src/ordering.jl
@@ -263,7 +263,7 @@ function <ₑ(a::DegreesT, b::DegreesT)
     end
 end
 
-function <ₑ(a::BasicSymbolic, b::BasicSymbolic)
+function <ₑ(a::BasicSymbolic{T}, b::BasicSymbolic{T}) where {T}
     if isconst(a) || isconst(b)
         return <ₑ(unwrap_const(a), unwrap_const(b))
     end
@@ -271,12 +271,22 @@ function <ₑ(a::BasicSymbolic, b::BasicSymbolic)
     fw = monomial_lt(da, db)
     bw = monomial_lt(db, da)
     if fw === bw && !isequal(a, b)
-        if _arglen(a) == _arglen(b) != 0
-            return (operation(a), sorted_arguments(a)...,) <ₑ (operation(b), sorted_arguments(b)...,)
-        else
-            return _arglen(a) < _arglen(b)
+        nargsa = _arglen(a)
+        nargsb = _arglen(b)
+        nargsa == nargsb || return nargsa < nargsb
+        nargsa == 0 && return false
+
+        opa = operation(a)
+        opb = operation(b)
+        if opa isa BasicSymbolic{T} && opb isa BasicSymbolic{T} && opa !== opb
+            return <ₑ(opa, opb)
         end
-    else
-        return fw
+        sargsa = sorted_arguments(a)
+        sargsb = sorted_arguments(b)
+        for i in eachindex(sargsa)
+            isequal(sargsa[i], sargsb[i]) && continue
+            return <ₑ(sargsa[i], sargsb[i])
+        end
     end
+    return fw
 end

--- a/src/terminterface.jl
+++ b/src/terminterface.jl
@@ -91,7 +91,7 @@ function TermInterface.sorted_arguments(x::BasicSymbolic{T})::ROArgsT{T} where {
     elseif T === SafeReal
         return _sorted_args2(x)
     elseif T === TreeReal
-        return _sorted_args2(x)
+        return _sorted_args3(x)
     end
     _unreachable()
 end
@@ -109,20 +109,27 @@ function __sorted_args(x::BasicSymbolic{T})::ROArgsT{T} where {T}
     @match x begin
         BSImpl.AddMul(; variant) => begin
             args = copy(parent(arguments(x)))
-            degrees = SmallV{RODegreesT}()
-            sizehint!(degrees, length(args))
-            @union_split_smallvec args begin
-                for arg in args
-                    push!(degrees, get_degrees(arg))
+            @match variant begin
+                AddMulVariant.ADD => begin
+                    @union_split_smallvec args begin
+                        sort!(args; lt = <ₑ)
+                    end
+                    return ROArgsT{T}(ArgsT{T}(args))
+                end
+                AddMulVariant.MUL => begin
+                    degrees = SmallV{RODegreesT}()
+                    sizehint!(degrees, length(args))
+                    @union_split_smallvec args begin
+                        for arg in args
+                            push!(degrees, get_degrees(arg))
+                        end
+                    end
+                    idxs = @union_split_smallvec degrees begin
+                        sortperm(degrees)
+                    end
+                    return ROArgsT{T}(ArgsT{T}(args[idxs]))
                 end
             end
-            idxs = @union_split_smallvec degrees begin
-                @match variant begin
-                    AddMulVariant.ADD => sortperm(degrees; lt = monomial_lt)
-                    AddMulVariant.MUL => sortperm(degrees)
-                end
-            end
-            return ROArgsT{T}(ArgsT{T}(args[idxs]))
         end
         _ => return arguments(x)
     end

--- a/test/code.jl
+++ b/test/code.jl
@@ -397,7 +397,7 @@ end
                 __array_literal_allocator = ones
                 __array_literal_result = __array_literal_allocator((3,))
                 $(setindex!)(__array_literal_result, x, 1)
-                $(setindex!)(__array_literal_result, $(+)($(+)(y, $(sin)(z)), $(*)(2, $(^)(x, 2))), 2)
+                $(setindex!)(__array_literal_result, $(+)($(+)($(sin)(z), y), $(*)(2, $(^)(x, 2))), 2)
                 $(setindex!)(__array_literal_result, $(+)(1, $(*)(2, z)), 3)
                 __array_literal_result
             end

--- a/test/new_code.jl
+++ b/test/new_code.jl
@@ -661,15 +661,15 @@ end
                 var"##cse#0" = ones
                 var"##cse#1" = var"##cse#0"((3,))
                 var"##cse#2" = x
-                var"##cse#3" = y
-                var"##cse#4" = z
-                var"##cse#5" = $(sin)(var"##cse#4")
+                var"##cse#3" = z
+                var"##cse#4" = $(sin)(var"##cse#3")
+                var"##cse#5" = y
                 var"##cse#6" = 2
                 var"##cse#7" = $(^)(var"##cse#2", 2)
                 var"##cse#8" = $(*)(var"##cse#6", var"##cse#7")
-                var"##cse#9" = $(+)(var"##cse#3", var"##cse#5", var"##cse#8")
+                var"##cse#9" = $(+)(var"##cse#4", var"##cse#5", var"##cse#8")
                 var"##cse#10" = 1
-                var"##cse#11" = $(*)(var"##cse#6", var"##cse#4")
+                var"##cse#11" = $(*)(var"##cse#6", var"##cse#3")
                 var"##cse#12" = $(+)(var"##cse#10", var"##cse#11")
                 __miscₛᵧₘ0 = $(Code.fill_arr!)(var"##cse#1", $Val($((3,))), var"##cse#2", var"##cse#9", var"##cse#12")
             end


### PR DESCRIPTION
- Fix `_sorted_args3` (TreeReal) mistakenly calling `_sorted_args2` (SafeReal), which threw a MethodError when `<ₑ` called `sorted_arguments` on TreeReal expressions
- Split ADD and MUL cases in `__sorted_args`: ADD now sorts arguments directly with `<ₑ` (a total order), replacing the previous `sortperm(degrees; lt=monomial_lt)` whose stable-sort tie-breaking was hash-dependent; MUL keeps its existing `sortperm(degrees)` which is already hash-independent
- Replace `hash(expr)`-based placeholder in `__default_degrees!` with a session-stable fallback: callable Sym operations use their name, named functions/types use `nameof`, and unknown callables use a fixed sentinel symbol
- Use `sorted_arguments` instead of `arguments` in the `<ₑ` structural fallback so that equal-degree expressions compare in canonical rather than hash-dependent order