### PR TITLE
Declare public API round 3 (term-interface names)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymbolicUtils"
 uuid = "d1185830-fcd6-423d-90d6-eec64667417b"
-version = "4.37.0"
+version = "4.37.1"
 authors = ["Shashi Gowda"]
 
 [deps]

--- a/src/SymbolicUtils.jl
+++ b/src/SymbolicUtils.jl
@@ -188,6 +188,7 @@ end
 
 @public add_worker, mul_worker
 @public BasicSymbolic, unwrap, isadd, ismul
+@public symtype, issym, isterm, isdiv, Sym
 
 PrecompileTools.@setup_workload begin
     fold1 = Val{false}()


### PR DESCRIPTION
## Summary

Declares more of SymbolicUtils' documented term-interface API as `public` (via `SciMLPublic.@public`), so that downstream packages using ExplicitImports' `check_all_qualified_accesses_are_public` no longer need to carry these names in their ignore-lists.

This follows up #988 (merged), which made `BasicSymbolic`, `unwrap`, `isadd`, `ismul`, `add_worker`, and `mul_worker` public. This round adds the remaining documented term-interface names that **SymbolicUtils itself owns**.

## Names publicized

Each is defined in this package's `src/` and is documented public API (docstring + listed in the docs autodocs blocks):

- `symtype` — `function symtype` (`src/types.jl`); documented at `docs/src/manual/variants.md` (`@docs SymbolicUtils.symtype`) and `docs/src/index.md`.
- `issym` — `src/types.jl`; `@docs SymbolicUtils.issym`.
- `isterm` — `src/types.jl`; `@docs SymbolicUtils.isterm`.
- `isdiv` — `src/types.jl`; `@docs SymbolicUtils.isdiv` (parallel to the already-public `isadd`/`ismul`).
- `Sym` — `struct Sym{T} end` + constructor (`src/safe_ctors.jl`); `@docs SymbolicUtils.Sym`.

```julia
@public symtype, issym, isterm, isdiv, Sym
```

## Names skipped (and why)

- `operation`, `arguments`, `iscall`, `sorted_arguments` — **owned by TermInterface.jl**, not SymbolicUtils. They are brought in via `import TermInterface: iscall, operation, arguments, metadata, maketerm, sorted_arguments` (`src/SymbolicUtils.jl`); SymbolicUtils only adds methods (`TermInterface.operation(...)`, etc.). Declaring them `public` here would be incorrect ownership-wise — they should be declared public by TermInterface. (The docs even attribute them as `TermInterface.arguments`/`TermInterface.sorted_arguments`.)
- `maketerm`, `metadata` — also owned by TermInterface.jl (same import line), not this package. Skipped.
- `arity` — no `function`/`struct`/`const` definition exists in `src/`; the only occurrence is a local variable inside `src/rule.jl`. Not API owned by this package.
- `similarterm` — not defined anywhere in `src/` (or `docs/`). Not present in this package.

## Rationale

Downstream SciML packages run ExplicitImports' `check_all_qualified_accesses_are_public`. Qualified accesses to non-`public` SymbolicUtils names get flagged, forcing per-name ignore-lists in each downstream package. Marking the genuinely-public, documented, SymbolicUtils-owned term-interface names as `public` lets those ignore entries be dropped.

Patch version bumped `4.37.0` -> `4.37.1` (additive, non-breaking: `@public` only annotates visibility).

---

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)