### PR TITLE
fast path `symbolic_type` for non-`isconst` where the array shape can be used to determine the type

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -410,7 +410,12 @@ end
 shape(::Colon) = ShapeVecT((1:0,))
 
 function SymbolicIndexingInterface.symbolic_type(x::BasicSymbolic)
-    symtype(x) <: AbstractArray ? ArraySymbolic() : ScalarSymbolic()
+    if isconst(x)
+        # 0-dim arrays wrapped in `Const` are not `is_array_shape(shape(x))` but should presumably still be
+        # considered `ArraySymbolic`
+        return symtype(x) <: AbstractArray ? ArraySymbolic() : ScalarSymbolic()
+    end
+    return is_array_shape(shape(x)) ? ArraySymbolic() : ScalarSymbolic()
 end
 SymbolicIndexingInterface.symbolic_type(::Type{BasicSymbolic}) = ScalarSymbolic()
 SymbolicIndexingInterface.symbolic_type(::Type{BasicSymbolic{T}}) where {T} = ScalarSymbolic()


### PR DESCRIPTION
The `<:` is quite slow to do at runtime so this tries to avoid it. 

```julia
julia> @variables v[1:3]

julia> vu = unwrap(v);

julia> using BenchmarkTools

julia> @btime SU.symtype(vu) <: AbstractArray 
  111.792 ns (0 allocations: 0 bytes)
true
```

There is however a bit of a weird case with 0-dim arrays as:

```julia
julia> x = convert(BasicSymbolic{SymReal}, fill(7.0));

julia> SU.symtype(x) <: AbstractArray
true

julia> SU.is_array_shape(SU.shape(x))
false
```

in other words, `x` here is not `is_array_shape` but it has a `symbolic_type` of `ArraySymbolic()`. For now, I just let the `isconst` pass fall through to the old behavior to not change it.
However, I am not sure this is handled "correctly" in other places, there are many direct calls to `is_array_shape` and they don't seem to care about this 0-dim case. Maybe we shouldn't either...

--------


For a benchmark like:

```julia
using Symbolics
using BenchmarkTools
import SymbolicUtils as SU
import SymbolicUtils: BasicSymbolic, SymReal
using Symbolics: unwrap

sym_old(x) = SU.symtype(x) <: AbstractArray ? SU.ArraySymbolic() : SU.ScalarSymbolic()

function sym_new(x::SU.BasicSymbolic)
    if SU.isconst(x)
        return SU.symtype(x) <: AbstractArray ? SU.ArraySymbolic() : SU.ScalarSymbolic()
    end
    return SU.is_array_shape(SU.shape(x)) ? SU.ArraySymbolic() : SU.ScalarSymbolic()
end

# ---- test inputs covering the variants ----
@variables a b v[1:3] M[1:2, 1:3]
cases = [
    ("scalar Sym a",        unwrap(a)),
    ("scalar Term sin(a)",  unwrap(sin(a))),
    ("scalar Term a+b",     unwrap(a + b)),
    ("scalar Term a*b",     unwrap(a * b)),
    ("vector Sym v[1:3]",   unwrap(v)),
    ("matrix Sym M[2,3]",   unwrap(M)),
    ("getindex v[1]",       unwrap(v[1])),
    ("Const scalar 3.0",    convert(BasicSymbolic{SymReal}, 3.0)),
    ("Const vector [1,2,3]",convert(BasicSymbolic{SymReal}, [1.0, 2.0, 3.0])),
    ("Const matrix 2x2",    convert(BasicSymbolic{SymReal}, [1.0 2.0; 3.0 4.0])),
    ("Const 0-dim array",   convert(BasicSymbolic{SymReal}, fill(7.0))),
]

for (name, x) in cases
    o = sym_old(x); n = sym_new(x)
   @assert o === n
end

println("\n=== SPEED: old vs new ===")
for (name, x) in cases
    println("--- $name ---")
    print("  old: "); @btime sym_old($x)
    print("  new: "); @btime sym_new($x)
end
```

This gives:

```
=== SPEED: old vs new ===
--- scalar Sym a ---
  old:   8.875 ns (0 allocations: 0 bytes)
  new:   2.458 ns (0 allocations: 0 bytes)
--- scalar Term sin(a) ---
  old:   8.842 ns (0 allocations: 0 bytes)
  new:   2.375 ns (0 allocations: 0 bytes)
--- scalar Term a+b ---
  old:   8.833 ns (0 allocations: 0 bytes)
  new:   2.375 ns (0 allocations: 0 bytes)
--- scalar Term a*b ---
  old:   8.875 ns (0 allocations: 0 bytes)
  new:   2.416 ns (0 allocations: 0 bytes)
--- vector Sym v[1:3] ---
  old:   106.811 ns (0 allocations: 0 bytes)
  new:   2.458 ns (0 allocations: 0 bytes)
--- matrix Sym M[2,3] ---
  old:   103.712 ns (0 allocations: 0 bytes)
  new:   2.416 ns (0 allocations: 0 bytes)
--- getindex v[1] ---
  old:   8.916 ns (0 allocations: 0 bytes)
  new:   2.417 ns (0 allocations: 0 bytes)
--- Const scalar 3.0 ---
  old:   10.083 ns (0 allocations: 0 bytes)
  new:   9.250 ns (0 allocations: 0 bytes)
--- Const vector [1,2,3] ---
  old:   104.849 ns (0 allocations: 0 bytes)
  new:   105.412 ns (0 allocations: 0 bytes)
--- Const matrix 2x2 ---
  old:   105.086 ns (0 allocations: 0 bytes)
  new:   105.379 ns (0 allocations: 0 bytes)
--- Const 0-dim array ---
  old:   104.435 ns (0 allocations: 0 bytes)
  new:   104.211 ns (0 allocations: 0 bytes)
```