### PR TITLE
improve performance of `setproperties` on `BSImpl.Type`

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -486,15 +486,36 @@ function ConstructionBase.getproperties(obj::BSImpl.Type)
 end
 
 function ConstructionBase.setproperties(obj::BSImpl.Type{T}, patch::NamedTuple) where {T}
-    props = getproperties(obj)
-    overrides = override_properties(obj)
-    # We only want to invalidate `args` if we're updating `coeff` or `dict`.
-    if isaddmul(obj) || isarrayop(obj) || isarraymaker(obj)
-        extras = (; args = ArgsT{T}())
-    else
-        extras = (;)
+    Z = zero(UInt)
+    p = patch
+    newobj = @match obj begin
+        BSImpl.Const(; val) =>
+            BSImpl.Const{T}(get(p, :val, val), Z, nothing)
+        BSImpl.Sym(; name, metadata, shape, type) =>
+            BSImpl.Sym{T}(get(p, :name, name), get(p, :metadata, metadata),
+                          get(p, :shape, shape), get(p, :type, type), Z, Z, nothing)
+        BSImpl.Term(; f, args, metadata, shape, type) =>
+            BSImpl.Term{T}(get(p, :f, f), get(p, :args, args), get(p, :metadata, metadata),
+                           get(p, :shape, shape), get(p, :type, type), Z, Z, nothing)
+        BSImpl.AddMul(; coeff, dict, variant, metadata, shape, type) =>
+            BSImpl.AddMul{T}(get(p, :coeff, coeff), get(p, :dict, dict), get(p, :variant, variant),
+                             get(p, :metadata, metadata), get(p, :shape, shape), get(p, :type, type),
+                             ArgsT{T}(), Z, Z, nothing)
+        BSImpl.Div(; num, den, simplified, metadata, shape, type) =>
+            BSImpl.Div{T}(get(p, :num, num), get(p, :den, den), get(p, :simplified, simplified),
+                          get(p, :metadata, metadata), get(p, :shape, shape), get(p, :type, type),
+                          Z, Z, nothing)
+        BSImpl.ArrayOp(; output_idx, expr, reduce, term, ranges, metadata, shape, type) =>
+            BSImpl.ArrayOp{T}(get(p, :output_idx, output_idx), get(p, :expr, expr),
+                              get(p, :reduce, reduce), get(p, :term, term), get(p, :ranges, ranges),
+                              get(p, :metadata, metadata), get(p, :shape, shape), get(p, :type, type),
+                              ArgsT{T}(), Z, Z, nothing)
+        BSImpl.ArrayMaker(; regions, values, metadata, shape, type) =>
+            BSImpl.ArrayMaker{T}(get(p, :regions, regions), get(p, :values, values),
+                                 get(p, :metadata, metadata), get(p, :shape, shape),
+                                 get(p, :type, type), ArgsT{T}(), Z, Z, nothing)
     end
-    hashcons(MData.variant_type(obj)(; props..., patch..., overrides..., extras...)::BasicSymbolic{T})
+    hashcons(newobj::BasicSymbolic{T})
 end
 
 """


### PR DESCRIPTION
I was seeing many profile traces of the type 

```
 633   @ModelingToolkitBase/src/systems/abstractsystem.jl:553  (::Initial)(x::SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymReal})
  631   /Users/kc/.julia/compiled/v1.12/ModelingToolkitBase/E5fDi_ywUL8.dylib:?  jfptr_toparam_83119
   630   @ModelingToolkitBase/src/parameters.jl:72  toparam(s::SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymReal})
  ╎ 629   @SymbolicUtils/src/types.jl:0  setmetadata
  ╎  629   @Setfield/src/sugar.jl:198  macro expansion
  ╎   629   @Setfield/src/lens.jl:122  set
  ╎    143   @SymbolicUtils/src/types.jl:494  setproperties(obj::SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymReal}, patch::@NamedTuple{metadata::Base.ImmutableDict{DataType, Any}})
  ╎     141   @SymbolicUtils/src/types.jl:485  getproperties(obj::SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymReal})
  ╎    ╎ 83    @Base/boot.jl:792  NamedTuple
  ╎    ╎  28    @juliasrc/jltypes.c:1409  inst_datatype_env
...
```

in other words from `setmetadata` which ends up calling `setproperties` + `getproperties`. These have to go through quite a bit of complicated named tuple handling that allocates and is slow. This instead just "writes out" the different cases and takes either the old value or the "patched" value.

For a benchmark like:

```julia
using SymbolicUtils
using BenchmarkTools
const SU = SymbolicUtils
const CB = SymbolicUtils.ConstructionBase

@syms x::Real y::Real
const md = Base.ImmutableDict{DataType, Any}(Float64, "meta")

variants = [
    ("Sym",  x),
    ("Term", sin(x)),
    ("Add",  x + y),
    ("Mul",  2x * y),
    ("Div",  x / y),
]

fmt(t) = string(lpad(round(Int, t.time), 5), " ns  ", lpad(t.memory, 4), " B  ", t.allocs, " allocs")

println("setproperties(obj, (; metadata)):")
for (name, obj) in variants
    t = minimum(@benchmark CB.setproperties($obj, (; metadata = $md)))
    println("  ", rpad(name, 5), fmt(t))
end

println("\nsetmetadata(obj, Float64, val)  [real entry point]:")
for (name, obj) in variants
    t = minimum(@benchmark SU.setmetadata($obj, Float64, "v"))
    println("  ", rpad(name, 5), fmt(t))
end
```

This gives:

```
# Before
setproperties(obj, (; metadata)):
  Sym   1542 ns   464 B  14 allocs
  Term  1612 ns   480 B  14 allocs
  Add   2194 ns   736 B  18 allocs
  Mul   2199 ns   736 B  18 allocs
  Div   1583 ns   512 B  12 allocs

setmetadata(obj, Float64, val)  [real entry point]:
  Sym   1475 ns   528 B  16 allocs
  Term  1638 ns   544 B  16 allocs
  Add   2255 ns   800 B  20 allocs
  Mul   2245 ns   800 B  20 allocs
  Div   1608 ns   576 B  14 allocs

-------

# After

setproperties(obj, (; metadata)):
  Sym    429 ns   128 B  5 allocs
  Term   476 ns   176 B  7 allocs
  Add    753 ns   224 B  7 allocs
  Mul    754 ns   224 B  7 allocs
  Div    457 ns   144 B  5 allocs

setmetadata(obj, Float64, val)  [real entry point]:
  Sym    442 ns   192 B  7 allocs
  Term   489 ns   240 B  9 allocs
  Add    769 ns   288 B  9 allocs
  Mul    773 ns   288 B  9 allocs
  Div    471 ns   208 B  7 allocs
```