### PR TITLE
improve performance of `handle_let_pair!` by manually doing some type checking of common cases

### DIFF
--- a/src/code.jl
+++ b/src/code.jl
@@ -858,7 +858,20 @@ function search_variables!(buffer, l::Let; kw...)
     union!(buffer, rhsbuf)
 end
 
-function handle_let_pair!(dargs::Vector{Assignment}, @nospecialize(x::Union{DestructuredArgs, Assignment}), st)
+@inline function store_rewrite!(rewrites::Dict{Any, Any}, @nospecialize(key), @nospecialize(val))
+    if key isa BasicSymbolic{SymReal}
+        rewrites[key] = val
+    elseif key isa BasicSymbolic{SafeReal}
+        rewrites[key] = val
+    elseif key isa BasicSymbolic{TreeReal}
+        rewrites[key] = val
+    else
+        rewrites[key] = val
+    end
+    return nothing
+end
+
+function handle_let_pair!(dargs::Vector{Assignment}, x::Union{DestructuredArgs, Assignment}, st)
     if x isa DestructuredArgs
         if x.create_bindings
             for a in get_assignments(x, st)
@@ -866,7 +879,7 @@ function handle_let_pair!(dargs::Vector{Assignment}, @nospecialize(x::Union{Dest
             end
         else
             for a in get_assignments(x, st)
-                st.rewrites[a.lhs] = a.rhs
+                store_rewrite!(st.rewrites, a.lhs, a.rhs)
             end
         end
     elseif x isa Assignment
@@ -880,7 +893,7 @@ function handle_let_pair!(dargs::Vector{Assignment}, @nospecialize(x::Union{Dest
             else
                 handle_let_pair!(dargs, Assignment(lhs.name, x.rhs), st)
                 for a in get_assignments(lhs, st)
-                    st.rewrites[a.lhs] = a.rhs
+                    store_rewrite!(st.rewrites, a.lhs, a.rhs)
                 end
             end
         else


### PR DESCRIPTION
This mirrors what is done in `search_variables!`

This function is quite hot from my profiling of creating `ODEProblem`, typically it looks something like

```
    2175  @ModelingToolkitBase/src/systems/codegen_utils.jl:615  build_function_wrapper(::System, ::Any, ::Any, ::Vararg{Any}; p_start::Int64, p_end::Int64, compress_args::Vector{UnitRange{Int64}}, non_standard_param_layout::Bool, u_arg::Int64, wrap_delays::Bool, histfn::SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymReal}, histfn_symbolic::SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymReal}, wrap_code::typeof(identity), add_observed::Bool, obsidxs_to_use::Nothing, create_bindings::Bool, output_type::Nothing, mkarray::Nothing, wrap_mtkparameters::Bool, extra_assignments::Vector{SymbolicUtils.Code.Assignment}, cse::Bool, optimize::Nothing, kwargs::Base.Pairs{Symbol, Any, Nothing, @NamedTuple{expression::DataType, similarto::DataType, checkbounds::Bool, use_scc::Bool, p_constructor::typeof(identity), warn_cyclic_dependency::Bool, circular_dependency_max_cycle_length::Int64, circular_dependency_max_cycles::Int64, build_initializeprob::Bool, is_initializeprob::Bool}})
   ╎  2175  @Symbolics/src/codegen_fn.jl:40  kwcall(::@NamedTuple{wrap_code::Tuple{ComposedFunction{typeof(identity), ModelingToolkitBase.var"#wrapper#226"{Bool, Vector{SymbolicUtils.Code.Assignment}}}, ComposedFunction{typeof(identity), ModelingToolkitBase.var"#wrapper#226"{Bool, Vector{SymbolicUtils.Code.Assignment}}}}, similarto::DataType, cse::Bool, optimize::Nothing, expression::DataType, checkbounds::Bool, use_scc::Bool, p_constructor::typeof(identity), warn_cyclic_dependency::Bool, circular_dependency_max_cycle_length::Int64, circular_dependency_max_cycles::Int64, build_initializeprob::Bool, is_initializeprob::Bool}, ::typeof(Symbolics.codegen_function), ir::IRStructure{SymReal}, expr::SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymReal}, args::Vector{Any})
   ╎   1030  @Symbolics/src/codegen_fn.jl:57  codegen_function(ir::IRStructure{SymReal}, expr::SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymReal}, args::Vector{Any}; nanmath::Bool, wrap_code::Tuple{ComposedFunction{typeof(identity), ModelingToolkitBase.var"#wrapper#226"{Bool, Vector{SymbolicUtils.Code.Assignment}}}, ComposedFunction{typeof(identity), ModelingToolkitBase.var"#wrapper#226"{Bool, Vector{SymbolicUtils.Code.Assignment}}}}, checkbounds::Bool, iip_config::Tuple{Bool, Bool}, sort_addmul::Bool, optimize::Nothing, kwargs::Base.Pairs{Symbol, Any, Nothing, @NamedTuple{similarto::DataType, cse::Bool, expression::DataType, use_scc::Bool, p_constructor::typeof(identity), warn_cyclic_dependency::Bool, circular_dependency_max_cycle_length::Int64, circular_dependency_max_cycles::Int64, build_initializeprob::Bool, is_initializeprob::Bool}})
   ╎    1030  @SymbolicUtils/src/faster_code.jl:334  fast_toexpr(sym::SymbolicUtils.Code.Func, ir::IRStructure{SymReal}, rewrites::Dict{Any, Any})
   ╎     1030  @SymbolicUtils/src/faster_code.jl:1209  (::SymbolicUtils.Code.CodegenState{SymReal})(fn::SymbolicUtils.Code.Func)
   ╎    ╎ 1019  @SymbolicUtils/src/faster_code.jl:1152  (::SymbolicUtils.Code.CodegenState{SymReal})(l::SymbolicUtils.Code.Let)
   ╎    ╎  1019  /Users/kc/.julia/compiled/v1.12/ModelingToolkitBase/E5fDi_ywUL8.dylib:?  handle_let_pair!(dargs::Vector{SymbolicUtils.Code.Assignment}, x::Union{SymbolicUtils.Code.Assignment, SymbolicUtils.Code.DestructuredArgs}, st::SymbolicUtils.Code.CodegenState{SymReal})
   ╎    ╎   1019  /Users/kc/.julia/compiled/v1.12/ModelingToolkitBase/E5fDi_ywUL8.dylib:?  handle_let_pair!(dargs::Vector{SymbolicUtils.Code.Assignment}, x::Union{SymbolicUtils.Code.Assignment, SymbolicUtils.Code.DestructuredArgs}, st::SymbolicUtils.Code.CodegenState{SymReal})
   ╎    ╎    774   @juliasrc/gf.c:4210  ijl_apply_generic
   ╎    ╎     699   @juliasrc/gf.c:4141  jl_lookup_generic_
   ╎    ╎    ╎ 699   @juliasrc/gf.c:3072  lookup_arg_type_tuple
   ╎    ╎    ╎  675   @juliasrc/jltypes.c:1139  lookup_typevalue
   ╎    ╎    ╎   313   @juliasrc/jltypes.c:0  lookup_type_setvalue
   ╎    ╎    ╎   251   @juliasrc/jltypes.c:1065  lookup_type_setvalue
   ╎    ╎    ╎   104   @juliasrc/jltypes.c:1067  lookup_type_setvalue
```

where we can see there is a bunch of time spent in the runtime in `handle_let_pair` due to the `Dict{Any, Any}` etc. Improving this make an end to end `ODEProblem` construction go from

```
 12.715491 seconds (152.00 M allocations: 5.775 GiB, 11.93% gc time, 0.01% compilation time)
```

to

```
  9.444904 seconds (152.01 M allocations: 5.780 GiB, 18.79% gc time)
```
