### PR TITLE
`get_assignments`: pre-size assignment vector to avoid having to reallocate it as it grows

### DIFF
--- a/src/code.jl
+++ b/src/code.jl
@@ -778,8 +778,9 @@ Base.@deprecate_binding get_symbolify get_rewrites
 
 function get_assignments(d::DestructuredArgs, st)
     name = manual_dispatch_toexpr(d, st)
-    assigns = Assignment[]
-    for i in 1:(length(d.inds)::Int)
+    n = length(d.inds)::Int
+    assigns = Vector{Assignment}(undef, n)
+    for i in 1:n
         idx = d.inds[i]
         if idx isa Symbol
             ex = Expr(:., name, QuoteNode(idx))
@@ -789,7 +790,7 @@ function get_assignments(d::DestructuredArgs, st)
         if d.inbounds && d.create_bindings
             ex = Expr(:macrocall, Symbol("@inbounds"), LineNumberNode(0), ex)
         end
-        push!(assigns, Assignment(d.elems[i], ex))
+        assigns[i] = Assignment(d.elems[i], ex)
     end
     return assigns
 end


### PR DESCRIPTION
Saw some

```
   ╎ 1124  @SymbolicUtils/src/code.jl:865  handle_let_pair!
   ╎  873   @SymbolicUtils/src/code.jl:884  handle_let_pair!
   ╎   815   @SymbolicUtils/src/code.jl:792  get_assignments
   ╎    801   @Base/array.jl:1289  push!
   ╎     801   @Base/array.jl:1292  _push!
   ╎    ╎ 801   @Base/array.jl:1131  _growend!
   ╎    ╎  799   @Base/array.jl:1148  #_growend!##0
   ╎    ╎   799   @Base/array.jl:1067  array_new_memory
   ╎    ╎    799   @Base/boot.jl:588  GenericMemory
   ╎    ╎     797   @juliasrc/genericmemory.c:41  jl_alloc_genericmemory_unchecked
   ╎    ╎    ╎ 797   @juliasrc/gc-stock.c:799  jl_gc_alloc_
```

in a profile trace.