### PR TITLE
hashconsing: always use the coarser (but still valid) metadata free hash

### DIFF
--- a/src/hashconsing.jl
+++ b/src/hashconsing.jl
@@ -549,7 +549,9 @@ function hash_bsimpl(s::BSImpl.Type{T}, h::UInt, full) where {T}
 end
 
 function Base.hash(s::BSImpl.Type, h::UInt)
-    hash_bsimpl(s, h, COMPARE_FULL[])
+    # Always use the metadata-free hash to avoids a task-local lookup on every hash.
+    # This is coarser than `full = true` but is still ok as a hash function in both modes.
+    hash_bsimpl(s, h, false)
 end
 
 const ENABLE_HASHCONSING = Ref(true)

--- a/test/hash_consing.jl
+++ b/test/hash_consing.jl
@@ -4,7 +4,6 @@ using SymbolicUtils: Fill, Mapper, Mapreducer, ShapeVecT, SymReal
 import MultivariatePolynomials as MP
 import TermInterface
 
-hash2(a) = SymbolicUtils.@manually_scope SymbolicUtils.COMPARE_FULL => true hash(a)
 isequal2(a, b) = SymbolicUtils.@manually_scope SymbolicUtils.COMPARE_FULL => true isequal(a, b)
 
 struct Ctx1 end
@@ -133,13 +132,14 @@ end
     SymbolicUtils.ENABLE_HASHCONSING[] = true
 end
 
-@testset "`hash2` is cached" begin
+@testset "`hash` is cached" begin
     @syms a b f(..)
     for ex in [a + b, a * b, f(a)]
-        h = hash2(ex)
-        @test h == ex.hash2[]
+        h = hash(ex)
+        @test h == ex.hash[]
         ex2 = setmetadata(ex, Int, 3)
-        @test ex2.hash2[] != h
+        # the hash is metadata-free
+        @test hash(ex2) == h
     end
 end
 
@@ -148,12 +148,12 @@ end
     x1 = setmetadata(x, Int, 1)
     x2 = setmetadata(x, Int, 1.0)
     @test x1 !== x2
-    @test hash2(x1) != hash2(x2)
+    @test !isequal2(x1, x2)
 
     x1 = setmetadata(x, Int, [1])
     x2 = setmetadata(x, Int, [1])
     @test x1 === x2
-    @test hash2(x1) == hash2(x2)
+    @test hash(x1) == hash(x2)
 end
 
 @testset "Operations hash by content" begin


### PR DESCRIPTION
Having to do a local lookup task at every `hash` call is quite unfortunate and it doesn't seem super important to have that fine-level granularity in the hash function. If you really want the metadata one, you can explicitly call `hash_bsimpl`. I see around a ~5% improvement in an end-to-end workload and for a micro benchmark like:

```julia
using SymbolicUtils
using SymbolicUtils: Sym, Term, SymReal
using BenchmarkTools

N = 10_000
p = Sym{SymReal}(:p; type = Vector{Real}, shape = SymbolicUtils.ShapeVecT([1:N]))
syms = [Term{SymReal}(getindex, Any[p, i]; type = Real) for i in 1:N]
foreach(hash, syms)  # populate the cached partial hash, as in real codegen workloads

# Populate task local storage with some stuff to make it more realistic
for i in 1:100
    task_local_storage(Symbol(:mwe_junk_, i), i)
end

function popdict(syms)
    d = Dict{Any, Any}()
    for (i, s) in enumerate(syms)
        d[s] = i
    end
    return d
end

function lookupall(d, syms)
    acc = 0
    for s in syms
        acc += get(d, s, 0)::Int
    end
    return acc
end

println("== pure hash, cached path (10k terms)")
@btime sum(hash, $syms)
println("== Dict{Any,Any} population, 10k symbolic keys (hash + probe + growth rehash)")
@btime popdict($syms)
d = popdict(syms)
println("== Dict{Any,Any} lookup, 10k symbolic keys")
@btime lookupall($d, $syms)
println("== rehash! of a 10k-key dict (what Dict growth does)")
@btime Base.rehash!(dd, 4 * length(dd)) setup = (dd = popdict($syms)) evals = 1
nothing
```

The timings are:

```
Before:
== pure hash, cached path (10k terms)
  87.125 μs (0 allocations: 0 bytes)
== Dict{Any,Any} population, 10k symbolic keys (hash + probe + growth rehash)
  384.542 μs (16668 allocations: 679.52 KiB)
== Dict{Any,Any} lookup, 10k symbolic keys
  182.958 μs (0 allocations: 0 bytes)
== rehash! of a 10k-key dict (what Dict growth does)
  346.083 μs (20006 allocations: 1.52 MiB)

After:
== pure hash, cached path (10k terms)
  36.875 μs (0 allocations: 0 bytes)
== Dict{Any,Any} population, 10k symbolic keys (hash + probe + growth rehash)
  300.291 μs (16668 allocations: 679.52 KiB)
== Dict{Any,Any} lookup, 10k symbolic keys
  103.291 μs (0 allocations: 0 bytes)
== rehash! of a 10k-key dict (what Dict growth does)
  280.291 μs (20006 allocations: 1.52 MiB)
```