### PR TITLE
Harden Const hashconsing against payloads with non-Bool isequal

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymbolicUtils"
 uuid = "d1185830-fcd6-423d-90d6-eec64667417b"
-version = "4.38.1"
+version = "4.38.2"
 authors = ["Shashi Gowda"]
 
 [deps]

--- a/src/hashconsing.jl
+++ b/src/hashconsing.jl
@@ -23,8 +23,27 @@ macro __generate_isequal_somescalar()
         cur_expr = new_expr
     end
 
-    push!(cur_expr.args, :(isequal(a, b)::Bool))
+    push!(cur_expr.args, :(isequal_somescalar_fallback(a, b)))
     return esc(expr)
+end
+
+"""
+    $TYPEDSIGNATURES
+
+Fallback comparison for `Const` payloads that are not among the common scalar types.
+
+Some symbolic-scalar payloads (e.g. `CasADi.MX`) break the `isequal` contract: their
+comparison operators are themselves symbolic and return a non-`Bool`, so a plain
+`isequal(a, b)::Bool` throws `TypeError: non-boolean (...) used in boolean context`.
+Two `Const`s can only hashcons-equal when their payloads share a type, so a type mismatch
+is unambiguously unequal — checking it first both preserves correctness and avoids invoking
+a throwing `isequal`. When the payloads share a type but still return a non-`Bool`, we treat
+them as unequal, which is safe for hashconsing (it just stores them as distinct entries).
+"""
+@inline function isequal_somescalar_fallback(@nospecialize(a), @nospecialize(b))
+    typeof(a) === typeof(b) || return false
+    res = isequal(a, b)
+    return res isa Bool ? res : false
 end
 
 """

--- a/test/hash_consing.jl
+++ b/test/hash_consing.jl
@@ -212,3 +212,33 @@ end
         @test hash(t1) == hash(t2)
     end
 end
+
+# Mimics a symbolic-scalar backend payload (e.g. `CasADi.MX`) whose comparison operators
+# are themselves symbolic and therefore do NOT return `Bool`. Substituting such an object
+# into a symbolic expression with folding wraps it in a `Const`, whose hashconsing used to
+# throw `TypeError: non-boolean (...) used in boolean context`. See issue MTK#4706.
+struct NonBoolScalar <: Number
+    v::Float64
+end
+Base.isequal(::NonBoolScalar, ::Number) = NonBoolScalar(0.0)
+Base.isequal(::Number, ::NonBoolScalar) = NonBoolScalar(0.0)
+Base.isequal(::NonBoolScalar, ::NonBoolScalar) = NonBoolScalar(0.0)
+Base.:*(a::NonBoolScalar, b::Number) = NonBoolScalar(a.v * b)
+Base.:*(a::Number, b::NonBoolScalar) = NonBoolScalar(a * b.v)
+Base.hash(a::NonBoolScalar, h::UInt) = hash(a.v, h)
+
+@testset "Const payloads with non-`Bool` `isequal` (issue MTK#4706)" begin
+    # The exact comparison hashconsing performs; used to throw.
+    @test SymbolicUtils.isequal_somescalar(NonBoolScalar(2.0), 1.0) === false
+    @test SymbolicUtils.isequal_somescalar(1.0, NonBoolScalar(2.0)) === false
+    @test SymbolicUtils.isequal_somescalar(NonBoolScalar(2.0), NonBoolScalar(1.0)) === false
+
+    # End-to-end: substituting a raw backend object with folding (the MTK optimal-control
+    # path) must not throw during `Const` hashconsing.
+    @syms q::Real
+    r = SymbolicUtils.substitute(2q, Dict(q => NonBoolScalar(3.0)); fold = Val(true))
+    @test SymbolicUtils.unwrap_const(r) === NonBoolScalar(6.0)
+
+    # Common cross-type numeric hashconsing is unaffected.
+    @test isequal(SymbolicUtils.Const{SymReal}(1), SymbolicUtils.Const{SymReal}(1.0))
+end


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.**

## Problem

`isequal_somescalar`'s fallback used `isequal(a, b)::Bool`. That throws for `Const` payloads whose comparison operators are *symbolic* and do not return a `Bool` — e.g. `CasADi.MX`, whose `==`/`isequal` return an `MX`.

This surfaces in ModelingToolkit.jl's CasADi dynamic-optimization backend (SciML/ModelingToolkit.jl#4706). When a symbolic parameter/variable is substituted with a raw `CasADi.MX`, `substitute` wraps the value in `Const{T}(value)` (both the leaf case in `substitute.jl` and folded results in `combine_fold`), which goes through hashconsing. When the new `Const(::MX)` lands in the same `WeakCacheSet` bucket as a cached numeric `Const`, hashconsing compares payloads via `isequal_somescalar(::MX, ::Float64)`, and the `::Bool` fallback throws:

```
TypeError: non-boolean (CasADi.MX) used in boolean context
```

Because it depends on a hash-bucket collision, it looks version-/run-dependent.

### Minimal reproduction (with a mock of `MX`'s contract)

```julia
struct MockMX <: Number; v::Float64; end
Base.isequal(::MockMX, ::Number) = MockMX(0.0)   # non-Bool, like CasADi.MX
# before this PR:
SymbolicUtils.isequal_somescalar(MockMX(2.0), 1.0)  # TypeError: non-boolean (MockMX) used in boolean context
```

## Fix

Route the fallback through `isequal_somescalar_fallback`, which:

- returns `false` on a payload **type mismatch** — two `Const`s can only be hashcons-equal if their payload types match, and checking this first avoids invoking a throwing `isequal`; and
- coerces any non-`Bool` result to `false` (safe for hashconsing — such payloads are simply stored as distinct entries).

Common numeric hashconsing is unaffected: those comparisons go through the generated scalar-pair branches (all 13×13 combinations of the listed `SCALARS`), not the fallback. Verified that e.g. `isequal(Const(1), Const(1.0))` still holds.

## Testing

- Added a regression testset in `test/hash_consing.jl` using a mock symbolic-scalar type with non-`Bool` `isequal`, covering both the direct `isequal_somescalar` call and the end-to-end `substitute(...; fold = Val(true))` path that MTK uses.
- Full `GROUP=Core` suite passes locally on Julia 1.12.4: **17834 pass, 0 fail** (3 pre-existing broken), including the fuzz group.

Patch version bump `4.38.1 → 4.38.2` (bugfix, no public API change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)