### PR TITLE
Handle throwing scalar equality in hashconsing

### DIFF
--- a/src/hashconsing.jl
+++ b/src/hashconsing.jl
@@ -16,14 +16,14 @@ macro __generate_isequal_somescalar()
     N = length(SCALARS)
     for (i, (t1, t2)) in enumerate(Iterators.product(SCALARS, SCALARS))
         push!(cur_expr.args, :(a isa $t1 && b isa $t2))
-        push!(cur_expr.args, :(isequal(a, b)))
+        push!(cur_expr.args, :(_safe_isequal_somescalar(a, b)))
         i == N * N && continue
         new_expr = Expr(:elseif)
         push!(cur_expr.args, new_expr)
         cur_expr = new_expr
     end
 
-    push!(cur_expr.args, :(isequal(a, b)::Bool))
+    push!(cur_expr.args, :(_safe_isequal_somescalar(a, b)))
     return esc(expr)
 end
 
@@ -34,7 +34,16 @@ Generated function which manually dispatches on `isequal` for common scalar type
 avoiding dynamic dispatch in common cases.
 """
 function isequal_somescalar(@nospecialize(a), @nospecialize(b))
-    @__generate_isequal_somescalar
+    return @__generate_isequal_somescalar
+end
+
+function _safe_isequal_somescalar(@nospecialize(a), @nospecialize(b))
+    try
+        return isequal(a, b)::Bool
+    catch err
+        err isa InterruptException && rethrow()
+        return false
+    end
 end
 
 """
@@ -215,7 +224,7 @@ function isequal_bsimpl(a::BSImpl.Type{T}, b::BSImpl.Type{T}, full::Bool) where 
 end
 
 function Base.isequal(a::BSImpl.Type, b::BSImpl.Type)
-    isequal_bsimpl(a, b, COMPARE_FULL[])
+    return isequal_bsimpl(a, b, COMPARE_FULL[])
 end
 
 Base.isequal(a::BSImpl.Type, b::WeakRef) = isequal(a, b.value)
@@ -251,7 +260,7 @@ function hash_somescalar(@nospecialize(a), h::UInt)
     # Done this way because the manual dispatch chain is too long to write out
     # by hand, `@eval` causes Revise to error, and `@generated` completely
     # negates the `@nospecialize`.
-    @__generate_hash_somescalar
+    return @__generate_hash_somescalar
 end
 
 const UNITRANGE_SALT = 0x65888b97ed76e7a3 % UInt
@@ -264,10 +273,10 @@ Specialized `hash` for range types used in `BasicSymbolic`, since the one in `Ba
 iterates over the full range and is thus `O(n)` in the length.
 """
 function hash_range(a::UnitRange{Int}, h::UInt)
-    hash(first(a), hash(last(a), h)) ⊻ UNITRANGE_SALT
+    return hash(first(a), hash(last(a), h)) ⊻ UNITRANGE_SALT
 end
 function hash_range(a::StepRange{Int, Int}, h::UInt)
-    hash(first(a), hash(last(a), h)) ⊻ STEPRANGE_SALT
+    return hash(first(a), hash(last(a), h)) ⊻ STEPRANGE_SALT
 end
 
 """
@@ -387,7 +396,7 @@ stable across machines or processes.
 """
 function hash_maybe_fntype(T::TypeT, h::UInt)
     @nospecialize T
-    if T === Number
+    return if T === Number
         hash(Number, h)
     elseif T === Real
         hash(Real, h)
@@ -466,7 +475,7 @@ function hash_metadata(m::MetadataT, h::UInt)
         hv = Base.hasha_seed
         return hash(hash_metadict(m, hv), h)
     end
-    _unreachable()
+    return _unreachable()
 end
 
 """
@@ -551,7 +560,7 @@ end
 function Base.hash(s::BSImpl.Type, h::UInt)
     # Always use the metadata-free hash to avoids a task-local lookup on every hash.
     # This is coarser than `full = true` but is still ok as a hash function in both modes.
-    hash_bsimpl(s, h, false)
+    return hash_bsimpl(s, h, false)
 end
 
 const ENABLE_HASHCONSING = Ref(true)
@@ -565,7 +574,7 @@ const WCS_TREEREAL = WeakCacheSet{BasicSymbolic{TreeReal}}()
 @inline wcs_for_vartype(::Type{TreeReal}) = WCS_TREEREAL
 
 function generate_id()
-    IDType()
+    return IDType()
 end
 
 """
@@ -622,7 +631,7 @@ Get the default zero constant for a given `BasicSymbolic` variant type.
 # Returns
 - A `Const` variant representing zero with the appropriate variant type
 """
-@inline defaultval(::Type{BasicSymbolic{SymReal}}) =  CONST_ZERO_SYMREAL
+@inline defaultval(::Type{BasicSymbolic{SymReal}}) = CONST_ZERO_SYMREAL
 @inline defaultval(::Type{BasicSymbolic{SafeReal}}) = CONST_ZERO_SAFEREAL
 @inline defaultval(::Type{BasicSymbolic{TreeReal}}) = CONST_ZERO_TREEREAL
 

--- a/test/hash_consing.jl
+++ b/test/hash_consing.jl
@@ -6,8 +6,21 @@ import TermInterface
 
 isequal2(a, b) = SymbolicUtils.@manually_scope SymbolicUtils.COMPARE_FULL => true isequal(a, b)
 
+const BSImpl = SymbolicUtils.BasicSymbolicImpl
+
 struct Ctx1 end
 struct Ctx2 end
+
+struct ThrowingEqualityScalar
+    tag::Symbol
+    value::Int
+end
+
+Base.hash(x::ThrowingEqualityScalar, h::UInt) = hash(x.value, h)
+function Base.isequal(a::ThrowingEqualityScalar, b::ThrowingEqualityScalar)
+    a.tag === b.tag && return isequal(a.value, b.value)
+    throw(ArgumentError("incomparable scalar tags"))
+end
 
 @testset "Sym" begin
     x1 = only(@syms x)
@@ -37,10 +50,10 @@ end
     t1 = sin(a)
     t2 = sin(a)
     @test t1.id === t2.id
-    t3 = Term{SymReal}(identity,[a])
-    t4 = Term{SymReal}(identity,[a])
+    t3 = Term{SymReal}(identity, [a])
+    t4 = Term{SymReal}(identity, [a])
     @test t3.id === t4.id
-    t5 = Term{SymReal}(identity,[a]; type = Int)
+    t5 = Term{SymReal}(identity, [a]; type = Int)
     @test t3.id !== t5.id
     tm1 = setmetadata(t1, Ctx1, "meta_1")
     @test t1.id !== tm1.id
@@ -51,21 +64,21 @@ end
     d2 = b + a
     @test d1.id === d2.id
     d3 = b - 2 + a
-    d4 = a + b  - 2
+    d4 = a + b - 2
     @test d3.id === d4.id
     d5 = Add{SymReal}(0, ACDict{SymReal}(a => 1, b => 1); type = Int)
     @test d5.id !== d1.id
 
-    dm1 = setmetadata(d1,Ctx1,"meta_1")
+    dm1 = setmetadata(d1, Ctx1, "meta_1")
     @test d1.id !== dm1.id
 end
 
 @testset "Mul" begin
-    m1 = a*b
-    m2 = b*a
+    m1 = a * b
+    m2 = b * a
     @test m1.id === m2.id
-    m3 = 6*a*b
-    m4 = 3*a*2*b
+    m3 = 6 * a * b
+    m4 = 3 * a * 2 * b
     @test m3.id === m4.id
     m5 = Mul{SymReal}(1, ACDict{SymReal}(a => 1, b => 1); type = Int)
     @test m5.id !== m1.id
@@ -75,19 +88,19 @@ end
 end
 
 @testset "Div" begin
-    v1 = a/b
-    v2 = a/b
+    v1 = a / b
+    v2 = a / b
     @test v1.id === v2.id
-    v3 = -1/a
-    v4 = -1/a
+    v3 = -1 / a
+    v4 = -1 / a
     @test v3.id === v4.id
-    v5 = 3a/6
-    v6 = 2a/4
+    v5 = 3a / 6
+    v6 = 2a / 4
     @test v5.id === v6.id
-    v7 = Div{SymReal}(-1,a, false; type = Float64)
+    v7 = Div{SymReal}(-1, a, false; type = Float64)
     @test v7.id !== v3.id
 
-    vm1 = setmetadata(v1,Ctx1, "meta_1")
+    vm1 = setmetadata(v1, Ctx1, "meta_1")
     @test vm1.id !== v1.id
 end
 
@@ -99,7 +112,7 @@ end
     p4 = a^(2^-b)
     @test p3.id === p4.id
 
-    pm1 = setmetadata(p1,Ctx1, "meta_1")
+    pm1 = setmetadata(p1, Ctx1, "meta_1")
     @test pm1.id !== p1.id
 end
 
@@ -154,6 +167,20 @@ end
     x2 = setmetadata(x, Int, [1])
     @test x1 === x2
     @test hash(x1) == hash(x2)
+end
+
+@testset "Throwing scalar equality is not a hashconsing match" begin
+    @test_throws ArgumentError isequal(
+        ThrowingEqualityScalar(:tag1, 1), ThrowingEqualityScalar(:tag2, 1)
+    )
+
+    x1 = BSImpl.Const{SymReal}(ThrowingEqualityScalar(:tag1, 1))
+    x2 = BSImpl.Const{SymReal}(ThrowingEqualityScalar(:tag2, 1))
+    x3 = BSImpl.Const{SymReal}(ThrowingEqualityScalar(:tag1, 1))
+
+    @test x1 !== x2
+    @test x1 === x3
+    @test !isequal2(x1, x2)
 end
 
 @testset "Operations hash by content" begin


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Make hashcons scalar equality treat an exception from scalar `isequal` as a non-match rather than aborting lookup.
- Preserve interrupts by rethrowing `InterruptException`.
- Add a regression test with a scalar type whose `isequal` throws for incomparable tags, mirroring the ForwardDiff dual-tag failure mode.

## Verification
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.12 --startup-file=no --project=/home/crackauc/sandbox/tmp_20260708_165240_11300/.runic-env -m Runic --inplace src/hashconsing.jl test/hash_consing.jl && timeout 3600 /home/crackauc/.juliaup/bin/julia +1.12 --startup-file=no --project=/home/crackauc/sandbox/tmp_20260708_165240_11300/.runic-env -m Runic --check src/hashconsing.jl test/hash_consing.jl`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.instantiate(); include("test/hash_consing.jl")'`\n  - `Throwing scalar equality is not a hashconsing match | 4 pass / 4 total`\n- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test(coverage=false)'`\n  - `Core | 17828 pass, 8 broken, 17836 total`\n- ForwardDiff smoke test in a temporary environment using this checkout:\n  - `ForwardDiff dual hashcons smoke passed`\n