### PR TITLE
Make Mapper and Mapreducer public API

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -20,6 +20,12 @@ SymbolicUtils.setmetadata
 SymbolicUtils.promote_symtype
 ```
 
+### Array Operation Callables
+```@docs
+SymbolicUtils.Mapper
+SymbolicUtils.Mapreducer
+```
+
 ## Rewriting System
 
 ### Rule Creation

--- a/src/SymbolicUtils.jl
+++ b/src/SymbolicUtils.jl
@@ -190,6 +190,7 @@ end
 @public BasicSymbolic, unwrap, isadd, ismul
 @public symtype, issym, isterm, isdiv, Sym
 @public fntype_ret_type
+@public Mapper, Mapreducer
 
 PrecompileTools.@setup_workload begin
     fold1 = Val{false}()

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -1328,6 +1328,16 @@ function Base.vec(x::BasicSymbolic{T}) where {T}
     return BSImpl.Term{T}(vec, ArgsT{T}((x,)); type, shape = sh)
 end
 
+"""
+    Mapper(f)
+
+Callable used as the `operation` of symbolic `map` terms: tracing
+`map(f, xs...)` over symbolic arrays produces a term whose operation is
+`Mapper(f)` and whose arguments are the mapped collections. Calling a `Mapper`
+applies `map(f, xs...)`. Downstream analyses that walk symbolic expressions can
+dispatch on this type (and on [`Mapreducer`](@ref)) to recognize mapped array
+operations.
+"""
 struct Mapper{F}
     f::F
 end
@@ -1494,6 +1504,19 @@ macro map_methods(T, arg_f, result_f)
     end |> esc
 end
 
+"""
+    Mapreducer(f, reduce, dims, init)
+
+Callable used as the `operation` of symbolic `mapreduce`-family terms: tracing
+`sum`, `prod`, or `mapreduce(f, reduce, xs...; dims, init)` over symbolic
+arrays produces a term whose operation is a `Mapreducer`. For example `sum(x)`
+of a symbolic array `x` traces to a term with operation
+`Mapreducer(identity, Base.add_sum, Colon(), nothing)`. `dims` is `Colon()` or
+an `Int`, and `init === nothing` means no initial value was supplied. Calling a
+`Mapreducer` applies the corresponding `mapreduce`. Downstream analyses that
+walk symbolic expressions can dispatch on this type (and on [`Mapper`](@ref))
+to recognize reductions over symbolic arrays.
+"""
 struct Mapreducer{F, R, D <: Union{Int, Colon}, I}
     f::F
     reduce::R


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

Tracing `map`/`sum`/`prod`/`mapreduce` over symbolic arrays produces terms whose `operation` is a `Mapper`/`Mapreducer` callable. Downstream packages that analyze symbolic expressions need to dispatch on these types to recognize array reductions — the immediate consumer is SymbolicAnalysis.jl, where classifying the curvature of `sum(x)` requires recognizing `Mapreducer(identity, Base.add_sum, ...)` as a plain sum (today such expressions silently analyze as unknown curvature because the operation is never `sum` itself).

This declares both types `@public` with docstrings and adds them to the API reference page, so that dependency is on documented public API rather than internals. No behavior change.

Test suite run locally: 17829 pass, 3 pre-existing broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)