### PR TITLE
Render IRStructure in the API reference

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -26,6 +26,11 @@ SymbolicUtils.Mapper
 SymbolicUtils.Mapreducer
 ```
 
+### Intermediate Representation
+```@docs
+SymbolicUtils.IRStructure
+```
+
 ## Rewriting System
 
 ### Rule Creation


### PR DESCRIPTION
> This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- render the existing public `SymbolicUtils.IRStructure` docstring in the API reference
- make the owner documentation complete before downstream Symbolics documentation points users to this type

## Motivation

`IRStructure` is exported and already has a detailed owner-package docstring, but that docstring was not included in the rendered SymbolicUtils manual. JuliaSymbolics/Symbolics.jl#1928 documents its new low-level code-generation API in terms of the owner-qualified `SymbolicUtils.IRStructure`; the owner API should be rendered at the same time.

## Validation

- `GROUP=Core julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` — passed: 17,830 passed, 8 pre-existing broken
- Julia 1.12 docs build — exited 0 and rendered the new `IRStructure` entry; the repository's existing unrelated docs/link warnings remain
- Runic 1.7.0 was run across the full repository; both this branch and an exact clean upstream `master` checkout hit the same internal reparse assertion in untouched `test/new_code.jl`. A separate clean-main audit is being handled rather than changing this docs-only patch.
- `git diff --check` — passed

## Process

1. Confirmed `IRStructure` is declared and exported by SymbolicUtils and already has an owner docstring.
2. Confirmed no rendered `@docs` entry existed.
3. Added the focused API-reference entry and built the complete documentation locally.
