### PR TITLE
Avoid ambiguous interpolated tuple syntax in codegen test

### DIFF
--- a/test/new_code.jl
+++ b/test/new_code.jl
@@ -344,8 +344,10 @@ test_repr(a, b) = @test repr(Base.remove_linenums!(a)) == repr(Base.remove_linen
 
     test_repr(
         Code.fast_toexpr(Func([DestructuredArgs([a, b], c, inds = [:a, :b])], [], a + b), ir, Dict()),
-        :(
-            function ($c,)
+        Expr(
+            :function,
+            Expr(:tuple, c),
+            quote
                 begin
                     __miscₛᵧₘ0 = c.a
                     a = __miscₛᵧₘ0


### PR DESCRIPTION
> [!IMPORTANT]
> Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## Summary

Replace one interpolated singleton-tuple function signature in the code-generation test's expected AST with the equivalent explicit `Expr` construction.

The test still compares the complete generated function representation. This only avoids source syntax that Runic 1.6 and newer rewrites into an unparsable function signature.

## Root cause and investigation

- Clean `master` at `1d59a93ede44a7f54e92997b3ea53563cfeb957d` reproduced `Runic.AssertionError: re-parsing the formatted output failed` in `test/new_code.jl` with Julia 1.12.6 and Runic 1.7.0.
- A five-line reproducer is a quoted `function ($c,) ... end` expression. The trailing comma is required for Julia to parse the interpolated value as a one-argument anonymous function signature, but Runic removes it and then cannot reparse its output.
- A SymbolicUtils history bisect found `6f61bfd305a48bfacef97fbd9757483ebe19b64b` (`test: test new codegen`) as the first source commit containing the trigger.
- Runic 1.5.1 formats the reproducer, while 1.6.0, 1.6.1, and 1.7.0 fail. A Runic source bisect found `c89356cc36aa52798eeef6f2a484171add95751d` (`Upgrade to JuliaSyntax version 1 (#186)`) as the first bad formatter commit.
- Constructing the signature as `Expr(:tuple, c)` is structurally equal to the original parsed signature and avoids relying on that ambiguous surface syntax.

No Runic issue or PR was opened because that repository is outside the authorized scope for this task.

## Validation

- Direct Julia 1.12.6 comparison after `Base.remove_linenums!`: original quote AST and explicit `Expr` AST are equal and have identical `repr` output.
- `GROUP=Core julia +1.12 --project=. -e 'using Pkg; Pkg.test()'`: 17,830 passed, 8 pre-existing broken, 17,838 total in 14m19.9s.
- Runic 1.7.0 on the exact changed range (`--lines=347:350 --inplace`): exit 0 and the file's Git blob hash remained unchanged (`de4bc35cc21e4c46f8e7fca9204fc924392dc8c1`).
- Whole-repository Runic 1.7.0 now reaches all 75 Julia files without an assertion. It still exits 1 for the independent pre-existing formatting backlog: 6 formatted and 69 unformatted files.
- `git diff --check`: clean.

The separate mechanical formatting backlog is tracked in #1008. This PR intentionally does not reformat the other files.
