### PR TITLE
Make isconst public

### DIFF
--- a/src/SymbolicUtils.jl
+++ b/src/SymbolicUtils.jl
@@ -189,6 +189,7 @@ end
 @public add_worker, mul_worker
 @public BasicSymbolic, unwrap, isadd, ismul
 @public symtype, issym, isterm, isdiv, Sym
+@public isconst
 @public fntype_ret_type
 @public Mapper, Mapreducer
 


### PR DESCRIPTION
`isadd`, `ismul`, `isterm`, `isdiv`, and `issym` are all public, and `unwrap_const` is exported, but the sibling predicate `isconst` isn't, so there's no public way to tell whether a `BasicSymbolic` is a wrapped constant before unwrapping it. 