### PR TITLE
Make FnType public

### DIFF
--- a/src/SymbolicUtils.jl
+++ b/src/SymbolicUtils.jl
@@ -190,6 +190,7 @@ end
 @public BasicSymbolic, unwrap, isadd, ismul
 @public symtype, issym, isterm, isdiv, Sym
 @public fntype_ret_type
+@public FnType
 @public Mapper, Mapreducer
 
 PrecompileTools.@setup_workload begin


### PR DESCRIPTION
There's no public way to tell whether a sym's `symtype` is an `FnType` (a callable symbol): `FnType` isn't public, and the internal `is_function_symtype` has narrower semantics. This marks `FnType` public so downstream can dispatch on `symtype(x) <: FnType`. Alternatively, if you'd rather keep the type internal, a small public predicate like `isfunction(x)` would cover the same need, happy to switch to that.