### PR TITLE
perf: make SmallVec iteration type-stable

### DIFF
--- a/src/small_array.jl
+++ b/src/small_array.jl
@@ -305,8 +305,7 @@ function Base.sizehint!(x::SmallVec{T, V}, n::Int; kwargs...) where {T, V}
     x
 end
 
-Base.iterate(x::SmallVec) = iterate(x.data)
-Base.iterate(x::SmallVec, st::Int) = iterate(x.data, st)
+Base.iterate(x::SmallVec, i::Int = 1) = i > length(x) ? nothing : (@inbounds x[i], i + 1)
 Base.any(f::F, x::SmallVec) where {F <: Function} = any(f, x.data)
 Base.all(f::F, x::SmallVec) where {F <: Function} = all(f, x.data)
 function Base.map(f::F, x::SmallVec{T, Vector{T}}) where {F, T}


### PR DESCRIPTION
In a Tracy profile of compiling MTK, I noticed a huge spike in invalidations mentioning `getindex(AbstractArrav{T, N}, BlockArravs.Block{N, T} where T) where {T, N}`, this seemed suspicious to me, so I asked Claude Opus 4.8 to investigate, and this is what it figured out: 

`SmallVec.data` is a `Union{Backing{T}, V}` and `Backing` defines no `iterate`, so `iterate(x::SmallVec) = iterate(x.data)` produced a union-typed iteration state: `iterate(::Vector)` yields an `Int`, but the `Backing` branch fell back to Base's generic `iterate(::AbstractArray)` whose state is a `Tuple{OneTo,Int}`. That non-`Int` state missed the `iterate(x::SmallVec, ::Int)` method and dropped into Base's generic `iterate(::AbstractArray, state)`, which indexes with `A[y[1]]` where `y[1]::Any` -- compiling a `getindex(::SmallVec, ::Any)` specialization of Base's fallback. That MethodInstance holds a backedge to `Base.getindex`, so it is invalidated whenever any package adds a `getindex` method on `AbstractVector` (e.g. block indexing pulled in via ModelingToolkit), discarding a large caller subtree.

Iterate by an explicit `Int` index instead. The state is always `Int`, so element access goes through the concrete `getindex(::SmallVec, ::Int)` and the `::Any` fallback is never compiled -- nothing to invalidate.

Measured (Julia 1.12.6):
- iterate(::SmallVec) state type: Union{Nothing, Tuple{Int,Int}, Tuple{Int, Tuple{OneTo,Int}}} -> Union{Nothing, Tuple{Int,Int}}
- one downstream getindex(::AbstractVector, ...) insertion invalidates 935 -> 161 MethodInstances (503 -> 21 involving SmallVec)
- `using ModelingToolkit`: total invalidations 5576 -> 4223
- clean-depot ModelingToolkit precompile: 236s -> 221s (-6.6%)
- SmallVec iteration runtime ~1.1-2x faster; no TTFX/load regression