### PR TITLE
Declare the rewriter combinators public in SymbolicUtils

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymbolicUtils"
 uuid = "d1185830-fcd6-423d-90d6-eec64667417b"
-version = "4.42.0"
+version = "4.43.0"
 authors = ["Shashi Gowda"]
 
 [deps]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -40,6 +40,11 @@ SymbolicUtils.IRStructure
 ```
 
 ### Rewriters
+
+Every combinator below except `FixpointNoCycle` is also public as `SymbolicUtils.X`, so
+`using SymbolicUtils: Chain, Prewalk` and `using SymbolicUtils.Rewriters: Chain, Prewalk`
+are both supported.
+
 ```@docs
 SymbolicUtils.Rewriters
 SymbolicUtils.Rewriters.Empty

--- a/src/SymbolicUtils.jl
+++ b/src/SymbolicUtils.jl
@@ -194,6 +194,11 @@ end
 @public FnType
 @public Mapper, Mapreducer
 
+# `simplify_rules.jl` does `using .Rewriters`, so these already resolve as
+# `SymbolicUtils.X` and callers depend on that spelling. Declare them public here so
+# reaching them through this module is API rather than a side effect of that import.
+@public Empty, IfElse, If, Chain, RestartedChain, Fixpoint, Postwalk, Prewalk, PassThrough
+
 PrecompileTools.@setup_workload begin
     fold1 = Val{false}()
     fold2 = Val{true}()


### PR DESCRIPTION
## Summary

Declares `Empty`, `IfElse`, `If`, `Chain`, `RestartedChain`, `Fixpoint`, `Postwalk`, `Prewalk` and `PassThrough` public in the top-level `SymbolicUtils` module.

They are already *reachable* there: `src/simplify_rules.jl:1` does `using .Rewriters` for internal use, which creates the bindings as a side effect. Nothing marks them public in this module, so `SymbolicUtils.Chain` registers as a non-public access even though it resolves and is widely used.

Callers do depend on that spelling. Symbolics itself uses it:

```julia
# Symbolics/src/solver/attract.jl:127
condition_x = expand(simplify(lhs, rewriter = SymbolicUtils.Postwalk(SymbolicUtils.Chain(r_conditionx))))
```

The practical consequence is that downstream packages running strict ExplicitImports QA have to carry an exception for these names. PDEBase carried exactly that (`:Chain, :Prewalk,  # SymbolicUtils non-public`), and removing it led to a rewrite of working code that introduced a regression — SciML/PDEBase.jl#100. This makes the existing, already-depended-upon spelling API rather than a side effect of an internal import.

`SymbolicUtils.Rewriters.X` is unchanged and remains the owner path; both spellings now work.

`FixpointNoCycle` is deliberately excluded — it is not exported from `Rewriters`, so it never resolved in this module and marking it public here would be new surface rather than a correction:

```
FixpointNoCycle  reachable in SymbolicUtils = false
```

## Docs

All nine already have docstrings and already appear under `### Rewriters` in `docs/src/api.md`, so public and documented stay together. Added a line there noting both spellings are supported.

## Validation

Julia 1.12.6.

```
all 9 combinators ispublic in SymbolicUtils = true
FixpointNoCycle still not reachable in parent = true
Rewriters path unchanged = true
```

`Pkg.test()` passes on this branch.

Version bumped 4.42.0 → 4.43.0 (additive public API).

Note: `Runic --check src/SymbolicUtils.jl` reports pre-existing drift in the `@setup_workload` block on master. It does not touch the lines added here and this repo has no format-check workflow, so I left it alone rather than mixing an unrelated reformat into this PR.

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117aJvytDT3y2jMi5Ng6Q5m