### PR TITLE
Declare `ispow` public

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymbolicUtils"
 uuid = "d1185830-fcd6-423d-90d6-eec64667417b"
-version = "4.43.0"
+version = "4.44.0"
 authors = ["Shashi Gowda"]
 
 [deps]

--- a/src/SymbolicUtils.jl
+++ b/src/SymbolicUtils.jl
@@ -190,6 +190,7 @@ end
 @public BasicSymbolic, unwrap, isadd, ismul
 @public symtype, issym, isterm, isdiv, Sym
 @public isconst
+@public ispow
 @public fntype_ret_type
 @public FnType
 @public Mapper, Mapreducer


### PR DESCRIPTION
## What this declares

**`ispow`** — the expression-shape predicate that answers "is this symbolic
expression a power?". Defined in this package, in `src/types.jl`:

```julia
ispow(x::BSImpl.Type) = isterm(x) && operation(x) === (^)
```

plus the `ispow(x) = false` fallback generated by the shared predicate loop a
few lines below. Two methods, both owned here; nothing is re-exported from a
dependency.

## Why it is interface, not an implementation detail

It is one of the `BasicSymbolic` shape predicates, and its siblings are already
public in `src/SymbolicUtils.jl`:

```julia
@public BasicSymbolic, unwrap, isadd, ismul
@public symtype, issym, isterm, isdiv, Sym
@public isconst
```

`isconst`, `issym`, `isterm`, `isadd`, `ismul`, `isdiv` — all public. `ispow`
is the odd one out, and there is no reason for it: it lives in the same list in
`src/types.jl`, is documented in the same `@docs` block in
`docs/src/manual/variants.md` (already rendered — no docs change needed here),
and `docs/src/upgrade.md` explicitly tells users to call it:

> Since `BasicSymbolic` is a concrete type, checking `x isa Sym` or `x isa Pow`
> no longer works. Instead, one should use `issym(x)` or `ispow(x)` to check the
> "type" of the expression.

That is the migration path this package published for everyone who used to
dispatch on `Pow`. It is interface by construction — the whole point of the
predicate is to let code outside this package inspect expression shape without
depending on the internal variant layout.

## Which downstream PR is blocked

SciML/MomentClosure.jl#107 ("Adopt strict SciMLTesting 2.4 QA"). Strict QA
errors on importing a binding its owning package has not declared public, so
that PR dropped `ispow` from its import list and reimplemented it locally:

```julia
is_power(expr) = isterm(expr) && operation(expr) === (^)
```

That is a verbatim copy of this package's definition, sitting in a package that
otherwise has no reason to know how a power expression is represented. It works
today and silently diverges the moment the representation changes here — which
is precisely the coupling the predicate exists to prevent. The fix belongs
upstream: make the binding public so consumers can call the owner's version.

## Verification

- `julia --project=. -e 'using SymbolicUtils'` succeeds.
- `length(names(SymbolicUtils))`: 61 before, 62 after.
- `:ispow in names(SymbolicUtils; all = false)`: `false` before, `true` after.
- Confirmed it was not already reachable: no `export ispow`, no prior
  `@public`/`public` declaration.
- Behaviour spot-check: `ispow(unwrap(x^2)) == true`, `ispow(unwrap(x+1)) == false`.

Minor version bump, matching the convention used for the previous public-API
declarations (e.g. 2a6eccd9). No behaviour change — this only adds `ispow` to
`names(SymbolicUtils)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
