### PR TITLE
docs: document `istree` and `RuleSet`, stop exporting `get_canonical_expr`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymbolicUtils"
 uuid = "d1185830-fcd6-423d-90d6-eec64667417b"
-version = "4.44.0"
+version = "4.44.1"
 authors = ["Shashi Gowda"]
 
 [deps]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -74,3 +74,14 @@ SymbolicUtils.simplify_fractions
 SymbolicUtils.quick_cancel
 SymbolicUtils.flatten_fractions
 ```
+
+## Deprecated
+
+These names are still exported so that existing code keeps working, but each one warns on
+use and will be removed in the next breaking release. Their entries record what to write
+instead.
+
+```@docs
+SymbolicUtils.istree
+SymbolicUtils.RuleSet
+```

--- a/src/SymbolicUtils.jl
+++ b/src/SymbolicUtils.jl
@@ -106,6 +106,30 @@ end
 include("cache.jl")
 Base.@deprecate istree iscall
 
+"""
+    istree(x)
+
+Deprecated spelling of [`iscall`](@ref). Returns `true` if `x` is a function call
+expression, i.e. one for which [`operation`](@ref) and [`arguments`](@ref) are defined.
+
+`istree` was the name used by the pre-`TermInterface` symbolic interface. It is retained
+only so that older code keeps running, emits a deprecation warning on every call, and will
+be removed in the next breaking release. New code should call `iscall` instead:
+
+```julia
+iscall(x)      # instead of istree(x)
+```
+
+Note that `iscall` is not merely a rename: the term interface splits the old notion of "is
+this a tree node" into `iscall` (the expression is an `operation` applied to `arguments`)
+and the container-specific predicates such as [`SymbolicUtils.issym`](@ref). Code that used
+`istree` to mean "not a leaf" should check `iscall`; code that used `!istree(x)` to mean "is
+a symbol" should check `SymbolicUtils.issym(x)`, which is the precise question.
+
+See also: [`iscall`](@ref), [`operation`](@ref), [`arguments`](@ref).
+"""
+istree
+
 include("small_array.jl")
 
 export istree, operation, arguments, sorted_arguments, iscall, unwrap_const

--- a/src/irstructure.jl
+++ b/src/irstructure.jl
@@ -981,7 +981,10 @@ function get_canonical_expr!(ir::IRStructure{T}, idx::Integer) where {T}
     return __get_canonical_expr(ir, idx)
 end
 
-@deprecate get_canonical_expr(ir, idx) get_canonical_expr!(ir, idx)
+# `get_canonical_expr` was never exported; the default `export_old = true` of `@deprecate`
+# would silently add it to the public API that the (also non-public) `get_canonical_expr!`
+# does not have.
+@deprecate get_canonical_expr(ir, idx) get_canonical_expr!(ir, idx) false
 
 """
     $TYPEDSIGNATURES

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -689,3 +689,27 @@ getdepth(::Any) = typemax(Int)
 end
 
 Base.@deprecate RuleSet(x) Postwalk(Chain(x))
+
+"""
+    RuleSet(rules)
+
+Deprecated. Build the rewriter explicitly instead:
+
+```julia
+using SymbolicUtils.Rewriters
+Postwalk(Chain(rules))
+```
+
+`RuleSet` was the original way to turn a collection of `@rule`s into a callable rewriter.
+It applied every rule in order at every node of the expression, bottom up. That is exactly
+`Postwalk(Chain(rules))`, and `RuleSet(rules)` now constructs and returns that object while
+emitting a deprecation warning; it will be removed in the next breaking release.
+
+Spelling the rewriter out is preferred because the traversal and the combination strategy
+become explicit and independently choosable. `Chain` can be swapped for
+[`SymbolicUtils.Rewriters.RestartedChain`](@ref) to restart the rule list after every
+successful rewrite, [`SymbolicUtils.Rewriters.Fixpoint`](@ref) to iterate to convergence, or
+[`SymbolicUtils.Rewriters.Prewalk`](@ref) to rewrite top down instead of bottom up. See
+[`SymbolicUtils.Rewriters`](@ref) for the full set of combinators.
+"""
+RuleSet


### PR DESCRIPTION
> [!WARNING]
> **Draft — please ignore until reviewed by @ChrisRackauckas.**

## Why

ModelingToolkit's QA suite (SciMLTesting's `run_api_docs`) requires every name on a
package's public API to have a docstring. Nine of MTK's public names fail that check, and
none of them are MTK's: they reach MTK's surface through `@reexport using Symbolics`, and
they are undocumented at their owner. Three of the nine are owned by SymbolicUtils:
`istree`, `RuleSet`, `get_canonical_expr`.

MTK currently carries a `SYMBOLICS_OWNED_REEXPORTS` ignore tuple in `test/qa/qa.jl` listing
those names. https://github.com/SciML/ModelingToolkit.jl/pull/4832 removes that waiver, on
the principle that the fix belongs at the owner. This PR is the SymbolicUtils half.

## What

**`istree` and `RuleSet` — documented.** Both are deprecated but still exported, so they
are still public API, and `?istree` currently answers "No documentation found". Each now
has a docstring saying what it did, what to write instead (`iscall`, and
`Postwalk(Chain(rules))` respectively), and that it will be removed in the next breaking
release. Both are rendered in a new "Deprecated" section of `docs/src/api.md` — public and
documented move together.

**`get_canonical_expr` — de-exported instead.** This one should not be public at all. It
was never exported; it became public by accident in c2825ea6 ("rename `get_canonical_expr`
to `get_canonical_expr!`"), which introduced

```julia
@deprecate get_canonical_expr(ir, idx) get_canonical_expr!(ir, idx)
```

and `Base.@deprecate`'s `export_old` argument defaults to `true`. Its replacement
`get_canonical_expr!` is neither exported nor `@public`, so exporting the deprecated
spelling of a non-public function is clearly unintended. Writing it a docstring to satisfy
the linter would have entrenched the accident, so the export is suppressed with an explicit
`false`.

The binding is untouched — `SymbolicUtils.get_canonical_expr(ir, idx)` still works and
still warns. Only `using SymbolicUtils; get_canonical_expr(...)` unqualified stops
resolving, which has only been possible since June 2026 and only for a deprecated shim.
**This is the one arguably-breaking hunk in the PR.** I versioned it as a patch
(4.44.0 → 4.44.1) on the grounds that it restores the intended surface rather than removing
API, but flagging it explicitly so you can decide whether you want it held for a major
instead.

## Verification

- `run_api_docs(ModelingToolkit; rendered = false)` before, with released
  SymbolicUtils 4.44.0 / Symbolics 7.35.0 and MTK's ignore list removed, reports
  `[@symbolic_wrap, @wrapped, RuleSet, StructuralTransformations, UnPack, get_canonical_expr,
  infimum, is_derivative, istree, solve_for, supremum]` as undocumented.
- With this branch and https://github.com/JuliaSymbolics/Symbolics.jl/pull/1941
  dev'ed in, all nine Symbolics/SymbolicUtils-owned names drop out.
  (`StructuralTransformations` and `UnPack` are module reexports on MTK's own surface --
  a separate issue, not Symbolics'.)
- Runic reports the added code clean.