### PR TITLE
Document the shape promotion interface

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -18,6 +18,10 @@ SymbolicUtils.setmetadata
 ### Type Promotion
 ```@docs; canonical=false
 SymbolicUtils.promote_symtype
+SymbolicUtils.promote_shape
+SymbolicUtils.Unknown
+SymbolicUtils.ShapeVecT
+SymbolicUtils.ShapeT
 ```
 
 ### Array Operation Callables

--- a/src/SymbolicUtils.jl
+++ b/src/SymbolicUtils.jl
@@ -215,7 +215,7 @@ end
 @public symtype, issym, isterm, isdiv, Sym
 @public isconst
 @public ispow
-@public Unknown, ShapeVecT, ShapeT, promote_shape
+@public Unknown, ShapeVecT, ShapeT, shape, promote_shape
 @public fntype_ret_type
 @public FnType
 @public Mapper, Mapreducer

--- a/src/SymbolicUtils.jl
+++ b/src/SymbolicUtils.jl
@@ -215,6 +215,7 @@ end
 @public symtype, issym, isterm, isdiv, Sym
 @public isconst
 @public ispow
+@public Unknown, ShapeVecT, ShapeT, promote_shape
 @public fntype_ret_type
 @public FnType
 @public Mapper, Mapreducer

--- a/src/types.jl
+++ b/src/types.jl
@@ -67,11 +67,43 @@ A custom vector type which does not allocate for small numbers of elements. If t
 known at compile time, it should be passed as a `Tuple` to the constructor.
 """
 const SmallV{T} = SmallVec{T, Vector{T}}
-const ShapeVecT = SmallV{UnitRange{Int}}
-"""
-    $TYPEDEF
 
-Type that represents the [`SymbolicUtils.shape`](@ref) of symbolics.
+"""
+    ShapeVecT(ranges)
+
+Concrete shape representation for a symbolic scalar or array.
+
+# Arguments
+
+- `ranges`: a tuple or iterable of `UnitRange{Int}` axes. An empty collection
+  represents a scalar.
+
+# Returns
+
+- A compact vector of axes suitable for `SymbolicUtils.shape` and
+  [`promote_shape`](@ref).
+
+# Examples
+
+```jldoctest
+julia> using SymbolicUtils
+
+julia> SymbolicUtils.ShapeVecT((1:2, 1:3))
+2-element SymbolicUtils.ShapeVecT:
+ 1:2
+ 1:3
+
+julia> isempty(SymbolicUtils.ShapeVecT())
+true
+```
+"""
+const ShapeVecT = SmallV{UnitRange{Int}}
+
+"""
+    ShapeT
+
+Union of the concrete [`ShapeVecT`](@ref) representation and [`Unknown`](@ref),
+which records a known or unknown number of dimensions when the axes are unavailable.
 """
 const ShapeT = Union{Unknown, ShapeVecT}
 """
@@ -1026,8 +1058,39 @@ promote_symtype(f, Ts...) = Any
 """
     promote_shape(f, shs::ShapeT...)
 
-The shape of the result of applying `f` to arguments of [`shape`](@ref) `shs...`.
-It is recommended that implemented methods `@nospecialize` all the shape arguments.
+Infer the symbolic result shape for applying `f` to operands with shapes `shs`.
+
+Packages that introduce symbolic operations may extend this function. Each method must
+return a [`ShapeT`](@ref), use [`ShapeVecT`](@ref) for known axes, and use
+[`Unknown`](@ref) when only the dimensionality is known. Implementations should
+`@nospecialize` shape arguments unless dispatch requires a concrete shape type.
+
+# Arguments
+
+- `f`: operation or callable whose result shape is being inferred.
+- `shs::ShapeT...`: symbolic operand shapes.
+
+# Returns
+
+- A [`ShapeT`](@ref) describing the result.
+
+# Examples
+
+```jldoctest
+julia> using SymbolicUtils
+
+julia> struct PreserveShape end
+
+julia> SymbolicUtils.promote_shape(
+           ::PreserveShape, sh::SymbolicUtils.ShapeT
+       ) = sh
+
+julia> SymbolicUtils.promote_shape(
+           PreserveShape(), SymbolicUtils.ShapeVecT((1:4,))
+       )
+1-element SymbolicUtils.ShapeVecT:
+ 1:4
+```
 """
 promote_shape(f, szs::ShapeT...) = Unknown(-1)
 

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -3,6 +3,15 @@ using SymbolicUtils: Sym, Term, symtype, BasicSymbolic, Const, ArgsT, promote_sy
 using Test
 import NaNMath
 import LinearAlgebra
+
+@testset "public shape promotion interface" begin
+    if isdefined(Base, :ispublic)
+        @test Base.ispublic(SymbolicUtils, :Unknown)
+        @test Base.ispublic(SymbolicUtils, :ShapeVecT)
+        @test Base.ispublic(SymbolicUtils, :ShapeT)
+        @test Base.ispublic(SymbolicUtils, :promote_shape)
+    end
+end
 import SpecialFunctions: besselj, bessely, besseli, besselk, polygamma, beta, logbeta, hankelh1, hankelh2, expint, gamma, erf
 
 @testset "promote_symtype with BigInt" begin

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -9,6 +9,7 @@ import LinearAlgebra
         @test Base.ispublic(SymbolicUtils, :Unknown)
         @test Base.ispublic(SymbolicUtils, :ShapeVecT)
         @test Base.ispublic(SymbolicUtils, :ShapeT)
+        @test Base.ispublic(SymbolicUtils, :shape)
         @test Base.ispublic(SymbolicUtils, :promote_shape)
     end
 end


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- declare `Unknown`, `ShapeVecT`, `ShapeT`, `shape`, and `promote_shape` as public API
- add SciMLStyle definition-site documentation and executable examples for the shape-promotion interface
- render the promoted names in the API manual and test their public status

This gives packages extending symbolic array shape inference a documented owner API instead of requiring access to SymbolicUtils internals. `shape` already had a definition-site docstring and rendered manual entry; the follow-up commit adds its public declaration and public-status test.

## Local verification

- Julia 1.12.6 Core: 17,866 passed, 8 pre-existing broken; package tests passed
- Julia 1.10.11 Core: 17,845 passed, 3 pre-existing broken; package tests passed
- Julia 1.12.6 documentation build: passed, including the new doctests
- Runic applied to the changed line ranges: exit 0 with no resulting diff
- `git diff --check`: passed
