### PR TITLE
docs: document the public FnType interface

### DIFF
--- a/docs/src/manual/variants.md
+++ b/docs/src/manual/variants.md
@@ -414,6 +414,10 @@ Here, `f1(x)` is considered a symbolic function `f1` called with the argument `x
 [`SymbolicUtils.is_called_function_symbolic`](@ref) can be used to differentiate between
 these cases.
 
+```@docs
+SymbolicUtils.FnType
+```
+
 ## API
 
 ### Basics

--- a/src/types.jl
+++ b/src/types.jl
@@ -1099,6 +1099,36 @@ promote_shape(f, szs::ShapeT...) = Unknown(-1)
 #### Function-like variables
 #---------------------------
 
+"""
+    FnType{A, R, S}
+
+Type-level description of a symbolic function.
+
+# Parameters
+
+- `A <: Tuple`: tuple of symbolic argument types.
+- `R`: symbolic return type.
+- `S`: supertype represented by the symbolic function, or `Nothing` when no
+  supertype was specified.
+
+`FnType` is used as the `symtype` of a callable symbolic variable. The
+[`@syms`](@ref) macro constructs these types from declarations such as
+`@syms f(::Real, ::Int)::Float64`.
+
+# Examples
+
+```julia
+julia> using SymbolicUtils
+
+julia> @syms f(::Real)::Float64;
+
+julia> SymbolicUtils.symtype(f)
+SymbolicUtils.FnType{Tuple{Real}, Float64, Nothing}
+
+julia> SymbolicUtils.fntype_ret_type(SymbolicUtils.FnType{Tuple{Real}, Float64, Nothing})
+Float64
+```
+"""
 struct FnType{X<:Tuple,Y,Z} end
 
 function (f::BasicSymbolic{T})(args...) where {T}

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -13,6 +13,11 @@ import LinearAlgebra
         @test Base.ispublic(SymbolicUtils, :promote_shape)
     end
 end
+
+@testset "public API docstrings" begin
+    @test Base.Docs.hasdoc(SymbolicUtils, :FnType)
+end
+
 import SpecialFunctions: besselj, bessely, besseli, besselk, polygamma, beta, logbeta, hankelh1, hankelh2, expint, gamma, erf
 
 @testset "promote_symtype with BigInt" begin

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -15,7 +15,7 @@ import LinearAlgebra
 end
 
 @testset "public API docstrings" begin
-    @test Base.Docs.hasdoc(SymbolicUtils, :FnType)
+    @test @doc(SymbolicUtils.FnType) !== nothing
 end
 
 import SpecialFunctions: besselj, bessely, besseli, besselk, polygamma, beta, logbeta, hankelh1, hankelh2, expint, gamma, erf


### PR DESCRIPTION
## Summary

Document the public `FnType` interface at its definition and add it to the rendered manual. Add a focused regression test for the public docstring.

Please ignore this draft until reviewed by @ChrisRackauckas.

## Verification

- `julia --project=. --startup-file=no -e 'using SymbolicUtils; include("test/methods.jl")'`: exited 0; the new `public API docstrings` testset reported `1/1`, and the existing methods testsets completed successfully.
- The initial CI failure was isolated to `Base.Docs.hasdoc`, which is unavailable on Julia 1.10. The test now uses `@doc(SymbolicUtils.FnType) !== nothing`; the standalone Julia 1.10 `@doc` smoke test passed, and the corrected local targeted test passed.
- Local-source Documenter build using a temporary project with this checkout developed exited 0. Existing repository warnings were emitted, but no build error occurred.
- Runic changed-range checks for `src/types.jl` and `test/methods.jl`: formatted output was byte-identical (`cmp` passed).
- `git diff --unified=0 -- '*.jl' | typos -` and `git diff --check` passed.

## Not run

The full package test suite and any long downstream/CI matrix were not run. This package does not currently use SciMLTesting, so no SciMLTesting QA group was applicable.
