### PR TITLE
Make create_array a public extension point

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymbolicUtils"
 uuid = "d1185830-fcd6-423d-90d6-eec64667417b"
-version = "4.45.0"
+version = "4.46.0"
 authors = ["Shashi Gowda"]
 
 [deps]

--- a/docs/src/manual/codegen.md
+++ b/docs/src/manual/codegen.md
@@ -32,6 +32,7 @@ SymbolicUtils.Code.Func
 SymbolicUtils.Code.SpawnFetch
 SymbolicUtils.Code.SetArray
 SymbolicUtils.Code.MakeArray
+SymbolicUtils.Code.create_array
 SymbolicUtils.Code.MakeSparseArray
 SymbolicUtils.Code.MakeTuple
 SymbolicUtils.Code.LiteralExpr

--- a/src/code.jl
+++ b/src/code.jl
@@ -1344,6 +1344,15 @@ end
     arr
 end
 
+"""
+    create_array(similarto, output_eltype, ::Val{ndims}, ::Val{dims}, elems...)
+
+Construct an array with dimensions `dims` and elements `elems`, using `similarto` to
+select the array type. `output_eltype` may be `nothing` to infer the element type.
+
+Array packages can support [`MakeArray`](@ref) code generation by defining methods for
+their array type.
+"""
 @inline function create_array(A::Type{<:Array}, T, ::Val, d::Val, elems...)
     _create_array(A, T, d, elems...)
 end
@@ -2248,7 +2257,7 @@ function apply_optimization_rules(ir::IRStructure, expr, rules)
     ir, expr
 end
 
-@public LazyState, cse_inside_expr, fast_toexpr, function_to_expr, get_rewrites
+@public LazyState, create_array, cse_inside_expr, fast_toexpr, function_to_expr, get_rewrites
 @public supports_with_allocator, with_allocator
 
 end

--- a/test/code.jl
+++ b/test/code.jl
@@ -13,6 +13,13 @@ test_repr(a, b) = @test repr(Base.remove_linenums!(a)) == repr(Base.remove_linen
 nanmath_st = Code.NameState()
 nanmath_st.rewrites[:nanmath] = true
 
+@testset "public array-construction extension point" begin
+    if isdefined(Base, :ispublic)
+        @test Base.ispublic(SymbolicUtils.Code, :create_array)
+    end
+    @test @doc(SymbolicUtils.Code.create_array) !== nothing
+end
+
 @testset "Code" begin
     @syms a b c d e p q t x(t) y(t) z(t)
     @test toexpr(Assignment(a, b)) == :(a = b)


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

`SymbolicUtils.Code.create_array` is the documented extension hook used by `MakeArray`, but it was not declared public. This declares it public, gives the function its own docstring and rendered API entry, and advances the minor version because downstream array packages can now implement it as supported API.

This is the owner-side prerequisite for restoring optional CasADi array construction without reaching into SymbolicUtils internals.

## Discriminating verification

The public-contract check fails on unmodified `upstream/master`:

```text
$ julia +1 --project -e 'using SymbolicUtils; @assert Base.ispublic(SymbolicUtils.Code, :create_array) "Code.create_array is not public"'
ERROR: AssertionError: Code.create_array is not public
```

The same check passes on this branch:

```text
$ julia +1 --project -e 'using SymbolicUtils; @assert Base.ispublic(SymbolicUtils.Code, :create_array); @assert (@doc SymbolicUtils.Code.create_array) !== nothing; println("create_array public and documented")'
create_array public and documented
```

## Local verification

```text
$ GROUP=Core julia +release --project -e 'using Pkg; Pkg.test()'
Test Summary: |  Pass  Broken  Total      Time
Core          | 17877       8  17885  12m53.5s
Testing SymbolicUtils tests passed

$ julia +1 --project=docs docs/make.jl
[ Info: CheckDocument: running document checks.
[ Info: HTMLWriter: rendering HTML pages.
[ Info: Automatic `version="4.46.0"` for inventory from ../Project.toml
# exit 0; deployment was skipped outside CI

$ julia +1 --project=../runic-check-env -e 'using Runic; exit(Runic.main(["--check", "src/code.jl", "--lines=1347:1355", "--lines=2260:2260"]))'
# exit 0
$ julia +1 --project=../runic-check-env -e 'using Runic; exit(Runic.main(["--check", "test/code.jl", "--lines=16:22"]))'
# exit 0
$ typos Project.toml src/code.jl test/code.jl docs/src/manual/codegen.md
# exit 0
$ git diff --check upstream/master...HEAD
# exit 0
```

`GROUP=QA` was run on Julia 1.12.7 and is not green on either checkout. Both this branch and a pristine `upstream/master` checkout report exactly `18 passed, 2 failed`: Aqua finds 164 existing method ambiguities and one existing unbound type parameter in the Moshi-generated `Div` constructor. This patch adds no methods or constructors. A separate clean-master investigation is required by repository policy and has been queued; it is not mixed into this public-API PR.

No GPU or downstream groups were run. No dependency or license changes are included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a04-70ae-77a0-ba1b-ec7a1ed9ef47
