### PR TITLE
fix: restore the untyped three-argument `Base.ImmutableDict` constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymbolicUtils"
 uuid = "d1185830-fcd6-423d-90d6-eec64667417b"
-version = "4.46.0"
+version = "4.46.1"
 authors = ["Shashi Gowda"]
 
 [deps]

--- a/src/types.jl
+++ b/src/types.jl
@@ -1004,6 +1004,12 @@ end
 
 using Base: ImmutableDict
 
+# Base defines no untyped three-argument `ImmutableDict` constructor. This method
+# existed here as piracy for years and downstream packages call it directly, so
+# removing it in v4.46.0 broke every already-registered version of them. Keep it
+# until the next breaking release; new code should use `ImmutableDict{K, V}(d, k, v)`.
+Base.ImmutableDict(d::ImmutableDict{K, V}, x, y) where {K, V} = ImmutableDict{K, V}(d, x, y)
+
 @inline _set_immutable_dict_value(d::ImmutableDict{K,V}, value) where {K,V} =
     ImmutableDict{K,V}(d.parent, d.key, value)
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -318,3 +318,13 @@ end
     den = x'x
     @test isequal(quick_cancel(num, den), (num, den))
 end
+
+# Downstream packages call the untyped three-argument constructor, which Base itself
+# does not define; dropping it in v4.46.0 broke their already-registered versions.
+@testset "untyped three-argument `Base.ImmutableDict` constructor" begin
+    d = Base.ImmutableDict{DataType, Any}(Int, 1)
+    d2 = Base.ImmutableDict(d, Float64, 2.0)
+    @test d2 isa Base.ImmutableDict{DataType, Any}
+    @test d2[Int] == 1
+    @test d2[Float64] == 2.0
+end

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -3,6 +3,9 @@ using SymbolicUtils
 
 run_qa(
     SymbolicUtils;
+    # The untyped three-argument `Base.ImmutableDict` constructor is a deliberate
+    # compatibility method kept for downstream packages; see `src/types.jl`.
+    aqua_kwargs = (; piracies = (; treat_as_own = [Base.ImmutableDict],)),
     ei_kwargs = (;
         no_implicit_imports = (; allow_unanalyzable = (SymbolicUtils.BasicSymbolicImpl,)),
         no_stale_explicit_imports = (; ignore = (:children,), allow_unanalyzable = (SymbolicUtils.BasicSymbolicImpl,)),


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Opened as a draft.

## What changed and why

v4.46.0 removed this line from `src/types.jl` in [`3aeef075`](https://github.com/JuliaSymbolics/SymbolicUtils.jl/commit/3aeef075d36be1ef13bffaffbfa5b646594a2b7a) ("test: add strict SciMLTesting QA") to clear an Aqua piracy finding:

```julia
# pirated for Setfield purposes:
Base.ImmutableDict(d::ImmutableDict{K,V}, x, y)  where {K, V} = ImmutableDict{K,V}(d, x, y)
```

Base defines no untyped three-argument `ImmutableDict` constructor — only `ImmutableDict(d, ::Pair)` and the *typed* inner `ImmutableDict{K,V}(parent, key, value)`. That pirated method was the only thing making `Base.ImmutableDict(d, k, v)` resolve, and downstream packages call it directly. Removing it in a **minor** release means the resolver treats it as non-breaking and happily pairs 4.46.0 with already-registered downstream versions that then throw `MethodError`:

| Package | Call site | Effect with SU 4.46.0 |
|---|---|---|
| Symbolics ≤ 7.36 | `src/variable.jl:589` (`renamed_metadata`) | any `diff2term`/`rename` throws; fixed in 7.37.0 (#1960) |
| ModelingToolkitBase ≤ 1.68 | `src/variables.jl:303` (`shift2term`) | shifted array variables throw |
| SymbolicIntegration 3.7.0 | `src/methods/rule_based/rule2.jl` | **fails to precompile** |

This surfaced as a ModelingToolkit precompile failure in downstream CI. Fixing the callers (done/underway) does not help the ~30 already-registered versions a resolver can still legally select, so this PR restores the method as an explicitly-documented compatibility shim with an Aqua `treat_as_own` exception, to be dropped at the next breaking release.

## Verification

Julia 1.12.7. Against **unmodified, registered** Symbolics 7.36.0:

```
########## BEFORE (stock SymbolicUtils 4.46.0) ##########
unit     : FAIL -> MethodError: no method matching Base.ImmutableDict(::Base.ImmutableDict{DataType, Any}, ::Type{Float64}, ::Float64)
diff2term: FAIL -> MethodError: no method matching Base.ImmutableDict(::Base.ImmutableDict{DataType, Any}, ::Type{Symbolics.VariableSource}
########## AFTER (this branch) ##########
unit     : OK  -> Base.ImmutableDict{DataType, Any}(Float64 => 2.0, Int64 => 1)
diff2term: OK  -> xˍt(t)
```

The new test in `test/misc.jl` discriminates — reverting only `src/types.jl`:

```
### BEFORE (src/types.jl reverted to pre-fix) ###
untyped three-argument `Base.ImmutableDict` constructor: Error During Test
  MethodError: no method matching Base.ImmutableDict(::Base.ImmutableDict{DataType, Any}, ::Type{Float64}, ::Float64)
### AFTER ###
Test Summary:                                           | Pass  Total  Time
untyped three-argument `Base.ImmutableDict` constructor |    3      3  0.1s
```

`Pkg.test()` (Core):

```
Test Summary: |  Pass  Broken  Total      Time
Core          | 17885       3  17888  12m27.7s
     Testing SymbolicUtils tests passed
```

`GROUP=QA` — this branch vs. clean master, side by side:

```
                              this branch            clean master
SciMLTesting QA            |   18   2    20   |   18   2    20
  Method ambiguity         |        1     1   |        1     1     <- pre-existing
  Unbound type parameters  |        1     1   |        1     1     <- pre-existing
  Piracy                   |    1         1   |    1         1
```

Identical: the two failures reproduce on unmodified master, and this branch adds none. The `treat_as_own` exception is load-bearing — without it Aqua flags exactly `Base.ImmutableDict(d::Base.ImmutableDict{K, V}, x, y) where {K, V} @ SymbolicUtils src/types.jl:1011`.

## Not verified

- Downstream / GPU / docs jobs.
- Whether the two pre-existing QA failures (Moshi-generated `Div` constructor unbound `T`; `typed_vcat` ambiguities) should block a release — they are red on master today and are not touched here.

## Worth pushing back on

- Restoring piracy is a deliberate step backwards on the QA cleanup. The alternative — fix only the callers — leaves every already-registered version broken with no compat bound that can express it. I think the shim is right until 5.0, but that is a judgment call.
- The Aqua exception uses `treat_as_own = [Base.ImmutableDict]`, which suppresses *any* future piracy on that type, not just this method.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C73qSfpoV1bHGbknXLX9Q2
