### PR TITLE
Fix nested ImmutableDict metadata updates

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -1006,6 +1006,8 @@ using Base: ImmutableDict
 
 @inline _set_immutable_dict_value(d::ImmutableDict{K,V}, value) where {K,V} =
     ImmutableDict{K,V}(d.parent, d.key, value)
+@inline _set_immutable_dict_parent(d::ImmutableDict{K,V}, parent) where {K,V} =
+    ImmutableDict{K,V}(parent, d.key, d.value)
 
 assocmeta(d::Dict, ctx, val) = (d=copy(d); d[ctx] = val; d)
 function assocmeta(d::Base.ImmutableDict{DataType, Any}, @nospecialize(ctx::DataType), @nospecialize(val))::ImmutableDict{DataType,Any}
@@ -1016,10 +1018,10 @@ function assocmeta(d::Base.ImmutableDict{DataType, Any}, @nospecialize(ctx::Data
         d.key === ctx && return _set_immutable_dict_value(d, val)
         d1 = d.parent
         if isdefined(d1, :parent)
-            d1.key === ctx && return _set_immutable_dict_value(d, _set_immutable_dict_value(d1, val))
+            d1.key === ctx && return _set_immutable_dict_parent(d, _set_immutable_dict_value(d1, val))
             d2 = d1.parent
             if isdefined(d2, :parent)
-                d2.key === ctx && return _set_immutable_dict_value(d, _set_immutable_dict_value(d1, _set_immutable_dict_value(d2, val)))
+                d2.key === ctx && return _set_immutable_dict_parent(d, _set_immutable_dict_parent(d1, _set_immutable_dict_value(d2, val)))
             end
         end
     end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -109,6 +109,8 @@ end
 
 struct Ctx1 end
 struct Ctx2 end
+struct Ctx3 end
+struct Ctx4 end
 
 # needs to be written like this to avoid a segfault on Julia 1.10
 @info "Metadata test"
@@ -127,6 +129,16 @@ for a = [a, sin(a), a+b, a*b, a^3]
 
     @test getmetadata(a′, Ctx1) == "meta_1"
     @test getmetadata(a′, Ctx2) == "meta_2"
+
+    a′ = setmetadata(a′, Ctx3, "meta_3")
+    a′ = setmetadata(a′, Ctx4, "meta_4")
+    a′ = setmetadata(a′, Ctx3, "updated_3")
+    @test getmetadata.(Ref(a′), (Ctx1, Ctx2, Ctx3, Ctx4)) ==
+        ("meta_1", "meta_2", "updated_3", "meta_4")
+
+    a′ = setmetadata(a′, Ctx2, "updated_2")
+    @test getmetadata.(Ref(a′), (Ctx1, Ctx2, Ctx3, Ctx4)) ==
+        ("meta_1", "updated_2", "updated_3", "meta_4")
 end
 
 # In substitute #283


### PR DESCRIPTION
## What changed and why

Updating a metadata entry in the middle of the compact `ImmutableDict` chain rebuilt the outer node with the updated parent dictionary as its value. This left the requested entry stale and corrupted newer metadata values. Rebuild parent links separately from values, and cover updates at both optimized nested depths.

This regression was introduced by https://github.com/JuliaSymbolics/SymbolicUtils.jl/commit/3aeef075d36be1ef13bffaffbfa5b646594a2b7a and affects SymbolicUtils 4.46.0. It currently breaks SymbolicAnalysis' geodesic-curvature analysis.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

Failing before the fix, with the new test retained:

```text
$ julia +release --startup-file=no --project=../SymbolicUtils-test-env test/basics.jl
Test Failed at test/basics.jl:136
  Expression: getmetadata.(Ref(a′), (Ctx1, Ctx2, Ctx3, Ctx4)) ==
              ("meta_1", "meta_2", "updated_3", "meta_4")
   Evaluated: ("meta_1", "meta_2", "meta_3",
               Base.ImmutableDict{DataType, Any}(Ctx3 => "updated_3", Ctx2 => "meta_2", Ctx1 => "meta_1")) ==
              ("meta_1", "meta_2", "updated_3", "meta_4")
ERROR: LoadError: There was an error during testing
```

Passing with the fix applied, using the same command and test:

```text
$ julia +release --startup-file=no --project=../SymbolicUtils-test-env test/basics.jl
Test Summary: | Pass  Total  Time
Base methods  |   35     35  3.6s
Test Summary:    | Pass  Total   Time
array arithmetic |  369    369  12.8s
Test Summary:     | Pass  Total   Time
Symbolic getindex |  345    345  19.1s
[all remaining basics.jl testsets passed; exit 0]
```

Full Core group:

```text
$ GROUP=Core julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary: |  Pass  Broken  Total      Time
Core          | 17887       8  17895  13m06.6s
     Testing SymbolicUtils tests passed
```

Also run successfully:

```text
$ git diff | typos -
[no output; exit 0]
$ git diff --check
[no output; exit 0]
```

## Completed CI classification

All four red checks are composition or shared-infrastructure failures; no failure is introduced by this metadata fix.

- Current-Julia QA reports 164 pre-existing ambiguities plus the Moshi-generated unbound constructor, with 18 pass / 2 fail: https://github.com/JuliaSymbolics/SymbolicUtils.jl/actions/runs/33100107407/job/98615213146. The focused repair is https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1034.
- Julia 1.11 QA adds the four pre-existing non-public `Base.Iterators` accesses, with 17 pass / 2 fail / 1 error: https://github.com/JuliaSymbolics/SymbolicUtils.jl/actions/runs/33100107407/job/98615213142. Those accesses are repaired by https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1035.
- Minimum-Julia QA reports the same 203 ambiguities and unbound constructor as clean master, with 16 pass / 2 fail: https://github.com/JuliaSymbolics/SymbolicUtils.jl/actions/runs/33100107407/job/98615213169.
- Symbolics downstream fails before testing with the same OrderedCollections/ModelingToolkitBase resolver conflict seen on #1034 and #1035: https://github.com/JuliaSymbolics/SymbolicUtils.jl/actions/runs/33100107367/job/98615213613.

All three Core lanes pass. The downstream ModelingToolkit Initialization/Interface and Catalyst jobs that expose corrupted nested metadata also pass on this branch; the same jobs on #1034 and #1035 produce `expected Tuple{Symbol, Symbol}, got Base.ImmutableDict{DataType, Any}`, directly matching the bug repaired here.

## Not verified / existing failures

`GROUP=QA` is not green on current master or this branch: Aqua reports 164 method ambiguities and a Moshi-generated `BasicSymbolicImpl.Div` constructor with an unbound type parameter. This change adds no public methods involved in either report. A separate clean-master investigation confirmed the same 18-pass/2-fail result on unmodified master; its corrective QA work remains separate from this behavior fix.

Runic was invoked on both changed files, but current master has broad pre-existing Runic drift. The unrelated whole-file mechanical rewrite was reverted to keep this behavioral fix focused; the added lines retain the surrounding file style.

No public API or dependency changes.

🤖 Generated with Codex CLI 0.150.1 (model: unknown; session: local session ID 01a0441e-3d2f-7170-ab6e-58ef72975a9f)
