### PR TITLE
Release 4.46.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymbolicUtils"
 uuid = "d1185830-fcd6-423d-90d6-eec64667417b"
-version = "4.46.0"
+version = "4.46.1"
 authors = ["Shashi Gowda"]
 
 [deps]


### PR DESCRIPTION
Fix nested `ImmutableDict` metadata updates (#1033).

Updating a metadata entry in the middle of the compact chain rebuilt the outer node with the updated parent dictionary as its *value*, leaving the requested entry stale and clobbering a newer entry. Affects 4.46.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R