### PR TITLE
Fix symbolic intersect/union symtype and mapreduce dims shape aliasing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymbolicUtils"
 uuid = "d1185830-fcd6-423d-90d6-eec64667417b"
-version = "4.46.1"
+version = "4.46.2"
 authors = ["Shashi Gowda"]
 
 [deps]

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -1681,9 +1681,11 @@ function promote_shape(f::Mapreducer, shs::ShapeT...)
     elseif mapped_shape isa Unknown
         return mapped_shape
     else
-        ax = mapped_shape[f.dims]
-        mapped_shape[f.dims] = first(ax):first(ax)
-        return mapped_shape
+        # `mapped_shape` may alias an argument's own shape vector; never mutate it.
+        reduced_shape = copy(mapped_shape)
+        ax = reduced_shape[f.dims]
+        reduced_shape[f.dims] = first(ax):first(ax)
+        return reduced_shape
     end
 end
 
@@ -1843,7 +1845,7 @@ for f in [union, intersect]
         end
         @eval function (::$(typeof(f)))(a::$T1, b::$T2) where {T}
             sh = promote_shape($f, shape(a), shape(b))
-            type = promote_type($f, symtype(a), symtype(b))
+            type = promote_symtype($f, symtype(a), symtype(b))
             return BSImpl.Term{T}($f, ArgsT{T}((Const{T}(a), Const{T}(b))); type, shape = sh)
         end
     end

--- a/test/arrayop.jl
+++ b/test/arrayop.jl
@@ -355,3 +355,22 @@ end
     got = [unwrap_const(substitute(e, d; fold = Val(true))) for e in sc]
     @test got ≈ ref
 end
+@testset "symbolic `intersect`/`union` build terms" begin
+    @syms a[1:2] b[1:2]
+    for f in (intersect, union)
+        for term in (f(a, b), f(a, [1, 2]), f([1, 2], b))
+            @test SymbolicUtils.iscall(term)
+            @test SymbolicUtils.operation(term) === f
+            @test symtype(term) <: Vector
+        end
+    end
+end
+
+@testset "`mapreduce` with `dims` does not mutate argument shapes" begin
+    @syms A[1:2, 1:2]
+    before = copy(shape(A))
+    r = mapreduce(abs2, +, A; dims = 1)
+    @test shape(r) == ShapeVecT([1:1, 1:2])
+    @test shape(A) == before
+    @test SymbolicUtils.iscall(A + [1.0 2.0; 3.0 4.0])
+end


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## What changed and why

Two bugs in symbolic array operations, found while auditing https://github.com/JuliaSymbolics/Symbolics.jl/pull/1971:

1. `intersect`/`union` on symbolic arrays called `promote_type(f, symtype(a), symtype(b))` where `promote_symtype` was meant, so every symbolic set operation threw `MethodError: no method matching promote_type(::typeof(intersect), ::Type{Vector{…}})`.
2. `promote_shape(::Mapreducer, shs...)` reduced the axis by writing into the shape vector it was handed. For a single-argument `mapreduce(f, op, A; dims)`, `promote_shape(Mapper(f), shape(A))` returns `shape(A)` itself, so the write **corrupted the shape of the symbolic array `A`** for the rest of the session — every later `A + M`, `A * …`, `A^x` then failed with a shape error. The fix copies before mutating.

Patch bump to 4.46.2.

## Failing-before evidence

Reproducer (no other packages), on the unfixed code:

```julia
julia> using SymbolicUtils; @syms A[1:2, 1:2] x::Real; M = [1.0 2.0; 3.0 4.0];
julia> intersect(A[:, 1], A[:, 2])
ERROR: MethodError: no method matching promote_type(::typeof(intersect), ::Type{Vector{Number}})
julia> SymbolicUtils.shape(A)
UnitRange{Int64}[1:2, 1:2]
julia> mapreduce(abs2, +, A; dims = 1);
julia> SymbolicUtils.shape(A)
UnitRange{Int64}[1:1, 1:2]           # <- argument mutated
julia> A + M
ERROR: ArgumentError: Cannot add arguments of different sizes - encountered shapes UnitRange{Int64}[1:1, 1:2] and UnitRange{Int64}[1:2, 1:2]
```

The new tests on the unfixed source (`git stash push src/methods.jl`):

```text
symbolic `intersect`/`union` build terms: Error During Test at test/arrayop.jl:358
  MethodError: no method matching promote_type(::typeof(intersect), ::Type{Vector{Number}})
ERROR: LoadError: Some tests did not pass: 0 passed, 0 failed, 1 errored, 0 broken.
```
(the file aborts at the first testset; the `mapreduce` testset's `shape(A) == before` assertion is exactly the reproducer above, observed `false` on the unfixed code.)

## Passing-after verification

```text
julia +1.12 --project=<env with this branch dev'd> test/arrayop.jl
symbolic `intersect`/`union` build terms |   18     18  0.5s
`mapreduce` with `dims` does not mutate argument shapes |    3      3  0.8s

julia +1.12 --project -e 'using Pkg; Pkg.test()'
     Testing SymbolicUtils tests passed
```

Not run locally: Julia 1.10/1.11, downstream (Symbolics) beyond the reproducer above.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5)
https://claude.ai/code/session_01GBZnkXcD22atwFouRNtygF
