### PR TITLE
Compare an expression as the DAG it is, not the tree it denotes

### DIFF
--- a/src/hashconsing.jl
+++ b/src/hashconsing.jl
@@ -9,6 +9,18 @@ information.
 """
 const COMPARE_FULL = TaskLocalValue{Bool}(Returns(false))
 
+"""
+Task-local memo of `(objectid(a), objectid(b), full) => result` for the comparison
+currently in progress, or `nothing` when none is running.
+
+Expressions are DAGs, so a subterm reachable by several paths would otherwise be
+compared once per path — exponential in the nesting depth on a graph linear in it. The
+entry point in `Base.isequal` opens the memo and closes it again, so a key cannot
+outlive the objects whose identity it records.
+"""
+const EQUALITY_MEMO =
+    TaskLocalValue{Union{Nothing, Dict{Tuple{UInt, UInt, Bool}, Bool}}}(Returns(nothing))
+
 macro __generate_isequal_somescalar()
     expr = Expr(:if)
     cur_expr = expr
@@ -194,6 +206,13 @@ function isequal_bsimpl(a::BSImpl.Type{T}, b::BSImpl.Type{T}, full::Bool) where 
         return false
     end
 
+    memo = EQUALITY_MEMO[]
+    memo_key = (objectid(a), objectid(b), full)
+    if memo !== nothing
+        cached = get(memo, memo_key, nothing)
+        cached === nothing || return cached
+    end
+
     partial = @match (a, b) begin
         (BSImpl.Const(; val = v1), BSImpl.Const(; val = v2)) => begin
             isequal_somescalar(v1, v2)::Bool && (!full || (typeof(v1) === typeof(v2))::Bool)
@@ -220,6 +239,7 @@ function isequal_bsimpl(a::BSImpl.Type{T}, b::BSImpl.Type{T}, full::Bool) where 
     if full && partial && !(Ta <: BSImpl.Const)
         partial = metadata_isequal(metadata(a), metadata(b))
     end
+    memo === nothing || (memo[memo_key] = partial)
     return partial
 end
 
@@ -235,7 +255,17 @@ function Base.isequal(a::BSImpl.Type, b::BSImpl.Type)
     Tb = MData.variant_type(b)
     Ta === Tb || return false
 
-    return isequal_bsimpl(a, b, COMPARE_FULL[])
+    # The outermost comparison owns the memo and nested ones reuse it. Clearing it on
+    # the way out keeps `objectid` keys from outliving the objects they identify.
+    outermost = EQUALITY_MEMO[] === nothing
+    if outermost
+        EQUALITY_MEMO[] = Dict{Tuple{UInt, UInt, Bool}, Bool}()
+    end
+    try
+        return isequal_bsimpl(a, b, COMPARE_FULL[])
+    finally
+        outermost && (EQUALITY_MEMO[] = nothing)
+    end
 end
 
 Base.isequal(a::BSImpl.Type, b::WeakRef) = isequal(a, b.value)

--- a/src/hashconsing.jl
+++ b/src/hashconsing.jl
@@ -192,7 +192,8 @@ end
 Core equality comparison for `BasicSymbolic`. `full` is the current value of
 `COMPARE_FULL[]`, but passed explicitly to reduce accessing a `TaskLocalValue`.
 """
-function isequal_bsimpl(a::BSImpl.Type{T}, b::BSImpl.Type{T}, full::Bool) where {T}
+# Declared `Bool` because the memo grows the recursion past what inference settles on.
+function isequal_bsimpl(a::BSImpl.Type{T}, b::BSImpl.Type{T}, full::Bool)::Bool where {T}
     a === b && return true
     ida = a.id
     idb = b.id
@@ -255,16 +256,13 @@ function Base.isequal(a::BSImpl.Type, b::BSImpl.Type)
     Tb = MData.variant_type(b)
     Ta === Tb || return false
 
-    # The outermost comparison owns the memo and nested ones reuse it. Clearing it on
-    # the way out keeps `objectid` keys from outliving the objects they identify.
-    outermost = EQUALITY_MEMO[] === nothing
-    if outermost
-        EQUALITY_MEMO[] = Dict{Tuple{UInt, UInt, Bool}, Bool}()
-    end
+    # Only the outermost comparison sets the memo up; nested ones reuse it as they are.
+    EQUALITY_MEMO[] === nothing || return isequal_bsimpl(a, b, COMPARE_FULL[])
+    EQUALITY_MEMO[] = Dict{Tuple{UInt, UInt, Bool}, Bool}()
     try
         return isequal_bsimpl(a, b, COMPARE_FULL[])
     finally
-        outermost && (EQUALITY_MEMO[] = nothing)
+        EQUALITY_MEMO[] = nothing
     end
 end
 


### PR DESCRIPTION
Fixes #1049.

`isequal` on two structurally equal but non-identical `BasicSymbolic` values walked the
expression as a tree rather than the DAG it is: a subterm reachable by several paths was
compared once per path instead of once in total. That is `O(2^depth)` on a graph with
`O(depth)` nodes.

It is reachable from ordinary use — hash-consing calls `isequal` on a cache hit, and the
per-key lookups inside `isequal_addmuldict` run with `COMPARE_FULL = false`, where the
id-based shortcut cannot fire.

### The guard is not the bug

`isequal_bsimpl` already has a shortcut that would cut the recursion for two distinct
interned nodes:

```julia
if full && ida !== idb && ida !== nothing && idb !== nothing
    return false
end
```

I have deliberately left it as it is. Under `COMPARE_FULL = false` the comparison ignores
metadata, so two values with different ids can legitimately be equal under that relation,
and concluding otherwise would be wrong. What was missing is memoisation, not a wider
shortcut.

### The change

A task-local `Dict{Tuple{UInt, UInt, Bool}, Bool}` memo, keyed by the two objects'
identities and the current `full` flag. The outermost `Base.isequal` creates it and
clears it in a `finally`, so nested comparisons share one memo and no `objectid` key
outlives the object it identifies.

### Effect

Reproducer from #1049 — a depth-`n` DAG of about `2n` nodes:

| depth | before | after |
| ----- | -------- | -------- |
| 16 | 0.0347 s | 2.1e-5 s |
| 20 | 0.7089 s | 2.0e-5 s |
| 24 | 8.0718 s | 2.0e-5 s |
| 100 | — | 1.07e-4 s |
| 200 | — | 1.97e-4 s |

Doubling the depth now doubles the time rather than squaring it.

Downstream, this is what made `ODEProblem` construction take 320 s for a model that
builds in 2 s in a fresh session, and 4460 s in CI — the second and later builds of
equivalent models hit the cache and paid the exponential walk on every reconstructed
node.

### Checks

- `Pkg.test("SymbolicUtils")` passes.
- Equality answers are unchanged, including the negative cases (different leaf, different
  depth, and the identical-object fast path).
