### PR TITLE
docs: render operation_* projection hooks (stacked on #1043)

### DIFF
--- a/docs/src/developer_api.md
+++ b/docs/src/developer_api.md
@@ -39,6 +39,9 @@ SymbolicUtils.isbinop
 SymbolicUtils.numerators
 SymbolicUtils.denominators
 SymbolicUtils.one_of_vartype
+SymbolicUtils.operation_getname
+SymbolicUtils.operation_hasname
+SymbolicUtils.operation_is_atomic
 SymbolicUtils.operator_to_term
 SymbolicUtils.promote_symtype
 SymbolicUtils.query

--- a/docs/src/manual/recursive_utils.md
+++ b/docs/src/manual/recursive_utils.md
@@ -11,6 +11,7 @@ SymbolicUtils.get_substitution_dict
 SymbolicUtils.default_substitute_filter
 SymbolicUtils.query
 SymbolicUtils.default_is_atomic
+SymbolicUtils.operation_is_atomic
 SymbolicUtils.scalarize
 SymbolicUtils.scalarization_function
 ```


### PR DESCRIPTION
Stacked on https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1043 (base: `struct-projection-hooks` at `2b0817d273ede11376d224b037a5b01a2159d269`).

**Ignore this PR until it is reviewed by @ChrisRackauckas.**

## What changed and why

https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1043 made `operation_getname`, `operation_hasname`, and `operation_is_atomic` public. SciMLTesting QA requires every public name to appear in a `@docs` block, and Documenter could not resolve the new `[`operation_is_atomic`](@ref)` in `default_is_atomic`'s docstring. This PR only adds those three names to the existing `@docs` lists on the developer API page and `operation_is_atomic` next to `default_is_atomic` on the recursive-utils page. The functions already had docstrings; nothing in `src/` changes.

## Verification

`GROUP=QA` on Julia 1.11, on the #1043 tip (`2b0817d273ede11376d224b037a5b01a2159d269`) **before** this commit:

```
public API is rendered in docs: Test Failed
  Expression: isempty(unrendered)
   Evaluated: isempty([:operation_getname, :operation_hasname, :operation_is_atomic])

Test Summary:                                  | Pass  Fail  Total     Time
SciMLTesting QA                                |   19     1     20  3m49.5s
  Quality Assurance                            |   19     1     20  1m09.5s
      public API has docstrings                |    1            1     0.0s
      public API is rendered in docs           |          1      1     3.8s
```

Same command **after** this commit (`1403807f70e2daee0f607e172c1ac615a8db8d25`):

```
Test Summary:   | Pass  Total     Time
SciMLTesting QA |   20     20  1m20.6s
Test Summary: | Pass  Total   Time
AdjView JET   |   37     37  34.6s
     Testing SymbolicUtils tests passed
```

Docs build (`julia +1.11 --project=docs/ docs/make.jl`) after the fix completed `RenderDocument` / `HTMLWriter` with no `:cross_references` error. Documenter skipped deploy locally (not CI).

`typos` on the two edited docs files: clean. No Julia source changed, so Runic was not run.

## Not verified

- Core tests (docs-only change; Core already passed on #1043).
- Integration / downstream suites (already green on #1043; this PR does not change `src/`).
- GPU and other allowed-to-fail jobs.
- Spell Check / Benchmark CI (names are existing identifiers).

## Review note

This should merge into #1043 (or after it), not independently onto master: the three names do not exist on master. If #1043 is squash-merged, rebase this branch onto master before merging.

🤖 Generated with Grok Build 1.0.13 (model: grok-4.6)
Agent-Session: 01a070f5-dfc5-73b1-afe0-80e8489adde1 (local session ID; transcript `~/.grok/sessions/%2Fhome%2Fcrackauc%2Fsandbox%2Ftmp_20260905_094552_32632/01a070f5-dfc5-73b1-afe0-80e8489adde1`)
