### PR TITLE
docs: render public operation extension points

### DIFF
--- a/docs/src/developer_api.md
+++ b/docs/src/developer_api.md
@@ -39,6 +39,8 @@ SymbolicUtils.isbinop
 SymbolicUtils.numerators
 SymbolicUtils.denominators
 SymbolicUtils.one_of_vartype
+SymbolicUtils.operation_getname
+SymbolicUtils.operation_hasname
 SymbolicUtils.operator_to_term
 SymbolicUtils.promote_symtype
 SymbolicUtils.query

--- a/docs/src/manual/recursive_utils.md
+++ b/docs/src/manual/recursive_utils.md
@@ -11,6 +11,7 @@ SymbolicUtils.get_substitution_dict
 SymbolicUtils.default_substitute_filter
 SymbolicUtils.query
 SymbolicUtils.default_is_atomic
+SymbolicUtils.operation_is_atomic
 SymbolicUtils.scalarize
 SymbolicUtils.scalarization_function
 ```


### PR DESCRIPTION
The public extension points `operation_is_atomic`, `operation_getname`, and `operation_hasname` have docstrings but were missing from the rendered reference. Add their `@docs` entries to the recursive utilities and expression interfaces pages. This resolves the broken cross-references and the public-API documentation QA failure.

Please ignore this draft until reviewed by @ChrisRackauckas.

### Verification

The omissions were introduced by https://github.com/JuliaSymbolics/SymbolicUtils.jl/commit/7422fb28a1ed60618bd8559d6b52a036b1d223bf. The same documentation build passes on its immediate parent and fails at that commit:

```text
Error: Cannot resolve @ref for md"[`operation_is_atomic`](@ref)" in docs/src/developer_api.md.
Error: Cannot resolve @ref for md"[`operation_is_atomic`](@ref)" in docs/src/manual/recursive_utils.md.
ERROR: LoadError: `makedocs` encountered an error [:cross_references]
```

Clean master also fails `SciMLTesting.run_api_docs(SymbolicUtils)`:

```text
Expression: isempty(unrendered)
Evaluated: isempty([:operation_getname, :operation_hasname, :operation_is_atomic])
Public API documentation | 1 passed, 1 failed
```

With these entries, on Julia 1.12.7:

```text
julia --compiled-modules=existing --compile=min -O0 --project=docs docs/make.jl
[ Info: HTMLWriter: rendering HTML pages.
exit 0

SciMLTesting.run_api_docs(SymbolicUtils)
Public API documentation | 2 passed

JULIA_PKG_PRECOMPILE_AUTO=0 JULIA_NUM_THREADS=4 GROUP=QA julia --project -e 'using Pkg; Pkg.test(; julia_args=["--compiled-modules=existing"])'
SciMLTesting QA | 20 passed | 9m13.1s
AdjView JET     | 37 passed | 32.9s
Testing SymbolicUtils tests passed

typos docs/src/manual/recursive_utils.md docs/src/developer_api.md
git diff --check
exit 0
```

Runic is inapplicable: only three Markdown reference entries changed. The full Core group, other Julia versions, and downstream jobs were not run for this documentation-only change. Existing HTML-size warnings remain; no checks or warnings were disabled.

### Hosted verification

Core and QA passed on minimum Julia, Julia 1.11, and latest Julia (six jobs). Documentation build/deployment and spelling passed. Downstream and benchmark jobs were still pending at this update.

### Links

- https://github.com/JuliaSymbolics/SymbolicUtils.jl/commit/7422fb28a1ed60618bd8559d6b52a036b1d223bf — introducing commit.
- https://github.com/JuliaSymbolics/SymbolicUtils.jl/actions/runs/33964754473 — Core/QA CI.
- https://github.com/JuliaSymbolics/SymbolicUtils.jl/actions/runs/33964754527 — docs build and deployment.
- https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1055 — dependent equality follow-up.

AI involvement: Codex CLI 0.153.4; model: gpt-6-astra; local session: 01a07134-d4c2-7971-977b-ea22bf0ce943; transcript: /home/crackauc/.codex/sessions/2026/09/05/rollout-2026-09-05T06-54-42-01a07134-d4c2-7971-977b-ea22bf0ce943.jsonl.
