### PR TITLE
Make DAG equality memoization identity-safe and reuse task-local storage

### DIFF
--- a/docs/src/developer_api.md
+++ b/docs/src/developer_api.md
@@ -39,6 +39,8 @@ SymbolicUtils.isbinop
 SymbolicUtils.numerators
 SymbolicUtils.denominators
 SymbolicUtils.one_of_vartype
+SymbolicUtils.operation_getname
+SymbolicUtils.operation_hasname
 SymbolicUtils.operator_to_term
 SymbolicUtils.promote_symtype
 SymbolicUtils.query

--- a/docs/src/manual/recursive_utils.md
+++ b/docs/src/manual/recursive_utils.md
@@ -11,6 +11,7 @@ SymbolicUtils.get_substitution_dict
 SymbolicUtils.default_substitute_filter
 SymbolicUtils.query
 SymbolicUtils.default_is_atomic
+SymbolicUtils.operation_is_atomic
 SymbolicUtils.scalarize
 SymbolicUtils.scalarization_function
 ```

--- a/src/hashconsing.jl
+++ b/src/hashconsing.jl
@@ -9,17 +9,59 @@ information.
 """
 const COMPARE_FULL = TaskLocalValue{Bool}(Returns(false))
 
-"""
-Task-local memo of `(objectid(a), objectid(b), full) => result` for the comparison
-currently in progress, or `nothing` when none is running.
+struct EqualityKey
+    a::BasicSymbolic
+    b::BasicSymbolic
+    full::Bool
+    hash::UInt
+end
 
-Expressions are DAGs, so a subterm reachable by several paths would otherwise be
-compared once per path — exponential in the nesting depth on a graph linear in it. The
-entry point in `Base.isequal` opens the memo and closes it again, so a key cannot
-outlive the objects whose identity it records.
+EqualityKey(a, b, full) = EqualityKey(a, b, full, hash((objectid(a), objectid(b), full)))
+
+function Base.isequal(a::EqualityKey, b::EqualityKey)
+    return a.a === b.a && a.b === b.b && a.full === b.full
+end
+
+function Base.hash(key::EqualityKey, h::UInt)
+    return hash(key.hash, h)
+end
+
+mutable struct EqualityMemo
+    const results::Dict{EqualityKey, Bool}
+    const small::Vector{Pair{EqualityKey, Bool}}
+    active::Bool
+end
+
+function equality_memo_get(memo::EqualityMemo, key::EqualityKey)
+    isempty(memo.results) || return get(memo.results, key, nothing)
+    for (cached_key, result) in memo.small
+        isequal(cached_key, key) && return result
+    end
+    return nothing
+end
+
+function equality_memo_set!(memo::EqualityMemo, key::EqualityKey, result::Bool)
+    # Small comparisons must not clear a table sized for a previous large DAG.
+    if isempty(memo.results) && length(memo.small) < 8
+        push!(memo.small, key => result)
+    else
+        for (cached_key, cached_result) in memo.small
+            memo.results[cached_key] = cached_result
+        end
+        empty!(memo.small)
+        memo.results[key] = result
+    end
+    return result
+end
+
 """
-const EQUALITY_MEMO =
-    TaskLocalValue{Union{Nothing, Dict{Tuple{UInt, UInt, Bool}, Bool}}}(Returns(nothing))
+Task-local memo of object pairs and comparison modes for a DAG traversal.
+Keys retain the objects and check identity even when their identity hashes collide.
+The outermost comparison empties the memo on exit, retaining capacity for reuse.
+"""
+const EQUALITY_MEMO = TaskLocalValue(
+    () -> EqualityMemo(Dict{EqualityKey, Bool}(), Pair{EqualityKey, Bool}[], false)
+)
 
 macro __generate_isequal_somescalar()
     expr = Expr(:if)
@@ -208,9 +250,9 @@ function isequal_bsimpl(a::BSImpl.Type{T}, b::BSImpl.Type{T}, full::Bool)::Bool 
     end
 
     memo = EQUALITY_MEMO[]
-    memo_key = (objectid(a), objectid(b), full)
-    if memo !== nothing
-        cached = get(memo, memo_key, nothing)
+    memo_key = EqualityKey(a, b, full)
+    if memo.active
+        cached = equality_memo_get(memo, memo_key)
         cached === nothing || return cached
     end
 
@@ -240,7 +282,7 @@ function isequal_bsimpl(a::BSImpl.Type{T}, b::BSImpl.Type{T}, full::Bool)::Bool 
     if full && partial && !(Ta <: BSImpl.Const)
         partial = metadata_isequal(metadata(a), metadata(b))
     end
-    memo === nothing || (memo[memo_key] = partial)
+    memo.active && equality_memo_set!(memo, memo_key, partial)
     return partial
 end
 
@@ -256,13 +298,20 @@ function Base.isequal(a::BSImpl.Type, b::BSImpl.Type)
     Tb = MData.variant_type(b)
     Ta === Tb || return false
 
-    # Only the outermost comparison sets the memo up; nested ones reuse it as they are.
-    EQUALITY_MEMO[] === nothing || return isequal_bsimpl(a, b, COMPARE_FULL[])
-    EQUALITY_MEMO[] = Dict{Tuple{UInt, UInt, Bool}, Bool}()
+    Ta <: BSImpl.Sym && a.name !== b.name && return false
+
+    full = COMPARE_FULL[]
+    full && ida !== nothing && idb !== nothing && return false
+
+    memo = EQUALITY_MEMO[]
+    memo.active && return isequal_bsimpl(a, b, full)
     try
-        return isequal_bsimpl(a, b, COMPARE_FULL[])
+        memo.active = true
+        return isequal_bsimpl(a, b, full)
     finally
-        EQUALITY_MEMO[] = nothing
+        empty!(memo.small)
+        isempty(memo.results) || empty!(memo.results)
+        memo.active = false
     end
 end
 

--- a/src/hashconsing.jl
+++ b/src/hashconsing.jl
@@ -286,10 +286,12 @@ function isequal_bsimpl(a::BSImpl.Type{T}, b::BSImpl.Type{T}, full::Bool)::Bool 
     return partial
 end
 
-function Base.isequal(a::BSImpl.Type, b::BSImpl.Type)
-    # Copy the early-exit checks in `isequal_bsimpl` here as a fast-path
-    # that doesn't have to hit the `COMPARE_FULL` lookup.
+@inline function Base.isequal(a::BSImpl.Type, b::BSImpl.Type)
     a === b && return true
+    return isequal_with_memo(a, b)
+end
+
+@noinline function isequal_with_memo(a::BSImpl.Type, b::BSImpl.Type)
     ida = a.id
     idb = b.id
     ida === idb && ida !== nothing && return true

--- a/test/equality_memo.jl
+++ b/test/equality_memo.jl
@@ -1,0 +1,127 @@
+using SymbolicUtils, Test
+using SymbolicUtils: BasicSymbolic
+
+abstract type CollidingEqualityVariant <: SymbolicUtils.TreeReal end
+
+# Exercise hash collisions without relying on random allocation addresses.
+Base.objectid(::BasicSymbolic{CollidingEqualityVariant}) = UInt(0)
+
+function equality_sym(::Type{T}, name; metadata = nothing) where {T}
+    return SymbolicUtils.BSImpl.Sym{T}(;
+        name, metadata, shape = SymbolicUtils.ShapeVecT(), type = Real,
+        hash = UInt(0), hash2 = UInt(0), id = nothing
+    )
+end
+
+function equality_term(f, args::Vector{BasicSymbolic{T}}) where {T}
+    return SymbolicUtils.BSImpl.Term{T}(;
+        f, args = SymbolicUtils.ArgsT{T}(args), metadata = nothing,
+        shape = SymbolicUtils.ShapeVecT(), type = Real,
+        hash = UInt(0), hash2 = UInt(0), id = nothing
+    )
+end
+
+struct EqualityOperation
+    compare::Function
+end
+
+Base.isequal(a::EqualityOperation, b::EqualityOperation) = a.compare()
+
+@testset "Equality memo" begin
+    @testset "Identity hash collisions" begin
+        T = CollidingEqualityVariant
+        x1, x2, y = [equality_sym(T, name) for name in (:x, :x, :y)]
+        @test x1 !== x2
+        @test objectid(x1) == objectid(x2) == objectid(y)
+        for width in (0, 16)
+            lhs = BasicSymbolic{T}[equality_sym(T, :x) for _ in 1:width]
+            rhs = BasicSymbolic{T}[equality_sym(T, :x) for _ in 1:width]
+            append!(lhs, [x1, x1])
+            append!(rhs, [x2, y])
+            result = isequal(equality_term(+, lhs), equality_term(+, rhs))
+            @test !result
+        end
+    end
+
+    @testset "Shared DAGs" begin
+        for depth in (8, 16, 32)
+            comparisons = Ref(0)
+            f = EqualityOperation(() -> (comparisons[] += 1; true))
+            g = EqualityOperation(() -> true)
+            a, b = equality_sym.((SymReal,), (:x, :x))
+            for _ in 1:depth
+                a, b = equality_term(f, [a, a]), equality_term(g, [b, b])
+            end
+            @test isequal(a, b)
+            @test comparisons[] == depth
+            @test isequal(a, b)
+            @test comparisons[] == 2depth
+        end
+    end
+
+    @testset "Comparison mode" begin
+        a = equality_sym(SymReal, :x)
+        b = equality_sym(SymReal, :x; metadata = Base.ImmutableDict{DataType, Any}(Int, 1))
+        f = EqualityOperation(
+            () -> begin
+                @test isequal(a, b)
+                @test !SymbolicUtils.@manually_scope SymbolicUtils.COMPARE_FULL => true isequal(a, b)
+                true
+            end
+        )
+        g = EqualityOperation(() -> true)
+        @test isequal(equality_term(f, [a]), equality_term(g, [b]))
+    end
+
+    @testset "Cleanup after exceptions" begin
+        calls = Ref(0)
+        saved = Ref{Any}()
+        a, b = equality_sym.((SymReal,), (:x, :x))
+        f = EqualityOperation(
+            () -> begin
+                calls[] += 1
+                saved[] = SymbolicUtils.EQUALITY_MEMO[]
+                isequal(a, b)
+                error("equality failure")
+            end
+        )
+        lhs, rhs = equality_term(f, [a]), equality_term(EqualityOperation(() -> true), [b])
+        for _ in 1:2
+            @test_throws ErrorException isequal(lhs, rhs)
+            @test isempty(saved[].results)
+            @test isempty(saved[].small)
+            @test !saved[].active
+        end
+        @test calls[] == 2
+        @test isequal(a, b)
+    end
+
+    @testset "Task isolation" begin
+        shared_a, shared_b = equality_sym.((SymReal,), (:x, :x))
+        for _ in 1:16
+            shared_a = equality_term(identity, [shared_a, shared_a])
+            shared_b = equality_term(identity, [shared_b, shared_b])
+        end
+        tasks = map(1:32) do _
+            Threads.@spawn begin
+                @test isequal(shared_a, shared_b)
+                a, b = equality_sym.((SymReal,), (:x, :x))
+                seen = Any[]
+                f = EqualityOperation(
+                    () -> begin
+                        push!(seen, SymbolicUtils.EQUALITY_MEMO[])
+                        yield()
+                        @test SymbolicUtils.EQUALITY_MEMO[] === last(seen)
+                        true
+                    end
+                )
+                g = EqualityOperation(() -> true)
+                @test isequal(equality_term(f, [a]), equality_term(g, [b]))
+                only(seen)
+            end
+        end
+        memos = fetch.(tasks)
+        @test length(IdDict(memo => nothing for memo in memos)) == length(tasks)
+        @test all(memo -> isempty(memo.results) && isempty(memo.small) && !memo.active, memos)
+    end
+end

--- a/test/hash_consing.jl
+++ b/test/hash_consing.jl
@@ -4,6 +4,8 @@ using SymbolicUtils: Fill, Mapper, Mapreducer, ShapeVecT, SymReal
 import MultivariatePolynomials as MP
 import TermInterface
 
+include("equality_memo.jl")
+
 isequal2(a, b) = SymbolicUtils.@manually_scope SymbolicUtils.COMPARE_FULL => true isequal(a, b)
 
 const BSImpl = SymbolicUtils.BasicSymbolicImpl


### PR DESCRIPTION
Follow up on https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1052: an identity-hash collision can make `isequal` return true for unequal expressions. Memo keys now retain both objects and compare them with `===`, including the comparison mode. Task-owned storage is reused and emptied in `finally`; a small buffer avoids clearing a table enlarged by an earlier DAG comparison on every subsequent small comparison.

Adds regressions for collisions in both storage paths, linear comparison counts on shared DAGs, separate metadata modes, exception cleanup, and concurrent tasks comparing shared expressions. Cheap name/ID rejection checks run before entering the memo. The identical-object check stays in a small inlined entry point, keeping memo setup and cleanup out of that fast path.

Please ignore this draft until reviewed by @ChrisRackauckas.

Includes the separate documentation prerequisite https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1054. Those three reference entries fix existing master docs/QA failures and remain separate commits. This PR targets master because the repository's Core/QA workflow only runs for PRs targeting master or v4.

### Failing before / passing after

The same isolated collision regression runs against both checkouts:

```sh
julia +1.12 --compiled-modules=existing --compile=min -O0 --project=collision-master collision_probe.jl
julia +1.12 --compiled-modules=existing --compile=min -O0 --project=SymbolicUtils.jl collision_probe.jl
```

Before, on unmodified master at https://github.com/JuliaSymbolics/SymbolicUtils.jl/commit/748075182f48408d6159b1a6e077cbb55921d695:

```text
Identity hash collisions: Test Failed
Expression: !result
Test Summary:              | Pass  Fail  Total
Equality memo              |    2     1      3
  Identity hash collisions |    2     1      3
```

With the fix:

```text
Test Summary: | Pass  Total
Equality memo |    3      3
```

An independent adjacent-commit check confirmed that the immediate parent passes the same probe. Introducing commit: https://github.com/JuliaSymbolics/SymbolicUtils.jl/commit/748075182f48408d6159b1a6e077cbb55921d695.

The probe specializes `objectid` to a constant for a test-only symbolic subtype, a deterministic way to exercise a permitted hash collision. The committed test covers both a short comparison and enough distinct pairs to exercise the dictionary.

<details>
<summary>Standalone collision probe</summary>

```julia
using SymbolicUtils, Test
using SymbolicUtils: BasicSymbolic

abstract type CollidingEqualityVariant <: SymbolicUtils.TreeReal end

# Exercise hash collisions without relying on random allocation addresses.
Base.objectid(::BasicSymbolic{CollidingEqualityVariant}) = UInt(0)

function equality_sym(::Type{T}, name; metadata = nothing) where {T}
    return SymbolicUtils.BSImpl.Sym{T}(;
        name, metadata, shape = SymbolicUtils.ShapeVecT(), type = Real,
        hash = UInt(0), hash2 = UInt(0), id = nothing
    )
end

function equality_term(f, args::Vector{BasicSymbolic{T}}) where {T}
    return SymbolicUtils.BSImpl.Term{T}(;
        f, args = SymbolicUtils.ArgsT{T}(args), metadata = nothing,
        shape = SymbolicUtils.ShapeVecT(), type = Real,
        hash = UInt(0), hash2 = UInt(0), id = nothing
    )
end

struct EqualityOperation
    compare::Function
end

Base.isequal(a::EqualityOperation, b::EqualityOperation) = a.compare()

@testset "Equality memo" begin
    @testset "Identity hash collisions" begin
        T = CollidingEqualityVariant
        x1, x2, y = [equality_sym(T, name) for name in (:x, :x, :y)]
        @test x1 !== x2
        @test objectid(x1) == objectid(x2) == objectid(y)
        result = isequal(equality_term(+, [x1, x1]), equality_term(+, [x2, y]))
        @test !result
    end

end
```

</details>

### Local verification

All runs use temporary directories under the workspace on `/home`, with four Julia threads where applicable. Julia executables were invoked through `/home/crackauc/.juliaup/bin/julia`.

```text
JULIA_PKG_PRECOMPILE_AUTO=0 JULIA_NUM_THREADS=4 GROUP=Core julia +1.12 --project -e 'using Pkg; Pkg.test(; julia_args=["--compiled-modules=existing"])'
Test Summary: |  Pass  Broken  Total      Time
Core          | 18010       3  18013  21m36.7s
Testing SymbolicUtils tests passed

JULIA_PKG_PRECOMPILE_AUTO=0 JULIA_NUM_THREADS=4 GROUP=QA julia +1.12 --project -e 'using Pkg; Pkg.test(; julia_args=["--compiled-modules=existing"])'
SciMLTesting QA | 20 passed | 8m42.4s
AdjView JET     | 37 passed | 25.8s
Testing SymbolicUtils tests passed

julia +1.12 --compiled-modules=existing --compile=min -O0 -t4 --project -e 'include("test/equality_memo.jl")'
Equality memo | 31 passed

julia +1.10 --compiled-modules=no --compile=min -O0 -t4 --project=validation110 -e 'include("SymbolicUtils.jl/test/equality_memo.jl")'
Equality memo | 31 passed

julia +1.12 --compiled-modules=existing --compile=min -O0 --project=docs docs/make.jl
[ Info: HTMLWriter: rendering HTML pages.
exit 0
```

The first final-source QA run reported `Persistent tasks: Test Failed` (19 passed, 1 failed). Aqua’s precompilation subprocess exceeded its existing 60-second exit window while compiler subprocesses were active. Repeating the exact same command with no source, timeout, or assertion changes passed all 20 QA and 37 JET checks. This is consistent with compilation timing; no check was disabled.

Runic.jl on changed Julia regions and the new test file, `typos` on the touched files, and `git diff --check` all pass. The Core output includes three existing broken tests; this change adds none. No test, assertion, or documentation check was disabled. Julia versions: 1.12.7 and 1.10.11.

### Hosted verification

Final commit: https://github.com/JuliaSymbolics/SymbolicUtils.jl/commit/778a7a323d80bf024130901a21f78611adbea0ea.

All six Core/QA jobs passed, and their logs were read: https://github.com/JuliaSymbolics/SymbolicUtils.jl/actions/runs/33969617656.

| Julia matrix entry | Core passed / existing broken | QA passed | AdjView JET passed |
| --- | ---: | ---: | ---: |
| Minimum | 17,979 / 3 | 18 | 37 |
| 1.11 | 18,010 / 3 | 20 | 37 |
| Latest | 18,010 / 3 | 20 | 37 |

Docs rendered and deployed successfully: https://github.com/JuliaSymbolics/SymbolicUtils.jl/actions/runs/33969617625. Spelling also passed.

Both hosted benchmark jobs passed. Compared with master:

| Benchmark | Latest Julia | LTS Julia |
| --- | ---: | ---: |
| Identical comparisons | 8.41 → 4.86 μs (1.73× faster) | 9.71 → 4.35 μs (2.23× faster) |
| Unequal comparisons | 0.552 → 0.355 ms (1.56× faster) | 0.930 → 0.592 ms (1.57× faster) |
| Unequal-comparison allocations | 8,000 → 0 | 8,000 → 0 |

Results: https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1055#issuecomment-5551952290 and https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1055#issuecomment-5551982444.

Downstream integration jobs and external Buildkite remain pending/running; those results are not claimed as verified. The obsolete integration run for the previous commit was canceled after checking that it had no reported failures; the final-commit integration run remains active.

### Performance and limits

The first hosted benchmark found an identical-object regression on the newer compiler. Separating the identical-object entry point from memo setup reduced a paired local 2,000-comparison batch from 33.24 μs to 13.89 μs (both zero allocations); unequal comparisons measured 1.1390 ms → 1.1059 ms. This comparison uses the initial follow-up commit as its baseline, not merged master.

Paired measurements alternate the two warmed processes on the same CPU core, with seven rounds and ten samples per case per round. The table reports median best times across rounds; allocations are per complete batch.

| Case | Repetitions | Merged PR | Follow-up | Allocated bytes before → after |
| --- | ---: | ---: | ---: | ---: |
| Unequal symbols | 20,000 | 7.7444 ms | 6.6206 ms | 12,480,000 → 0 |
| Unequal terms | 20,000 | 13.4297 ms | 8.9548 ms | 12,480,000 → 0 |
| Shared DAG, depth 32 | 100 | 6.8145 ms | 7.9050 ms | 920,992 → 0 |
| Deep unequal expressions | 2,000 | 1.4917 ms | 1.0863 ms | 1,248,000 → 0 |

<details>
<summary>Paired benchmark command and scripts</summary>

Command from the workspace root: `TMPDIR="$PWD/scratch" python3 paired_bench.py`. Both local checkout environments were instantiated beforehand.

`equality_bench_driver.jl`:

```julia
using SymbolicUtils

@syms x y z w
struct BenchTag end

function dag(leaf, depth)
    e = leaf
    for i in 1:depth
        e = (e + i) * (e + y)
    end
    return e
end

function batch(a, b, repetitions)
    result = false
    for _ in 1:repetitions
        result |= isequal(a, b)
    end
    return result
end

tagged = setmetadata(x, BenchTag, 1)
function deep_expr(vars, depth)
    expr = vars[1]
    for i in 1:depth
        v = vars[mod1(i, length(vars))]
        expr = sin(expr * v + v^2 - v)
    end
    return expr
end
cases = (
    ("unequal symbols", x, y, 20000),
    ("unequal terms", sin(x), cos(y), 20000),
    ("shared DAG depth 32", dag(x, 32), dag(tagged, 32), 100),
    ("deep unequal expressions", deep_expr([x, y, z, w], 300), deep_expr([y, z, w, x], 300), 2000),
)
for (_, a, b, repetitions) in cases
    batch(a, b, repetitions)
end
println("READY"); flush(stdout)
for command in eachline(stdin)
    for (name, a, b, repetitions) in cases
        measurements = [@timed batch(a, b, repetitions) for _ in 1:10]
        best = measurements[argmin(getproperty.(measurements, :time))]
        println(name, ": repetitions=", repetitions, " seconds=", best.time, " bytes=", best.bytes)
    end

    println("DONE"); flush(stdout)
end
```

`paired_bench.py`:

```python
import json
import statistics
import subprocess
from pathlib import Path

root = Path.cwd()
processes = {}
for name, project in [('before', 'collision-master'), ('after', 'SymbolicUtils.jl')]:
    err = open(root / f'paired-{name}.log', 'w')
    processes[name] = subprocess.Popen(
        ['taskset', '-c', '126', '/home/crackauc/.juliaup/bin/julia', '+1.12',
         '--compiled-modules=existing', f'--project={project}', 'equality_bench_driver.jl'],
        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=err, text=True,
    )

for name, process in processes.items():
    assert process.stdout.readline().strip() == 'READY', name

results = {name: {} for name in processes}
for round_number in range(7):
    for name in (['before', 'after'] if round_number % 2 == 0 else ['after', 'before']):
        process = processes[name]
        process.stdin.write('go' + chr(10))
        process.stdin.flush()
        while True:
            line = process.stdout.readline().strip()
            if line == 'DONE':
                break
            if not line:
                raise RuntimeError(f'{name} exited unexpectedly')
            case, measurement = line.split(': ', 1)
            fields = dict(item.split('=') for item in measurement.split())
            results[name].setdefault(case, []).append(fields)

for process in processes.values():
    process.stdin.close()
    assert process.wait() == 0

summary = {}
for name, cases in results.items():
    summary[name] = {
        case: {
            'seconds_median': statistics.median(float(r['seconds']) for r in runs),
            'bytes_median': statistics.median(int(r['bytes']) for r in runs),
            'repetitions': int(runs[0]['repetitions']),
        } for case, runs in cases.items()
    }
print(json.dumps(summary, indent=2))
```

</details>

The shared-DAG timing is about 16% slower in this sample, while retaining the linear comparison count and eliminating warmed allocations. Storage retains capacity per task, but no expression references remain after a comparison. The task-isolation tests do not establish safety for concurrent mutation of expressions.

The complete minimum-version/Julia 1.11 matrices, downstream packages, and hosted benchmarks were not run locally. This is an internal implementation change with no new public API or dependencies.

### Links

- Original change: https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1052
- Documentation prerequisite: https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1054
- Follow-up: https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1055
- Final Core/QA matrix: https://github.com/JuliaSymbolics/SymbolicUtils.jl/actions/runs/33969617656
- Final docs build/deploy: https://github.com/JuliaSymbolics/SymbolicUtils.jl/actions/runs/33969617625
- Final benchmarks: https://github.com/JuliaSymbolics/SymbolicUtils.jl/actions/runs/33969616301
- Pending downstream checks: https://github.com/JuliaSymbolics/SymbolicUtils.jl/actions/runs/33969617577

AI involvement: Codex CLI 0.153.4; model: gpt-6-astra; local session: 01a07134-d4c2-7971-977b-ea22bf0ce943; transcript: /home/crackauc/.codex/sessions/2026/09/05/rollout-2026-09-05T06-54-42-01a07134-d4c2-7971-977b-ea22bf0ce943.jsonl.
