### PR TITLE
Restore metadata-aware hashing during full-comparison interning

### DIFF
--- a/src/hashconsing.jl
+++ b/src/hashconsing.jl
@@ -597,9 +597,7 @@ function hash_bsimpl(s::BSImpl.Type{T}, h::UInt, full) where {T}
 end
 
 function Base.hash(s::BSImpl.Type, h::UInt)
-    # Always use the metadata-free hash to avoids a task-local lookup on every hash.
-    # This is coarser than `full = true` but is still ok as a hash function in both modes.
-    return hash_bsimpl(s, h, false)
+    return hash_bsimpl(s, h, COMPARE_FULL[])
 end
 
 const ENABLE_HASHCONSING = Ref(true)

--- a/test/hash_consing.jl
+++ b/test/hash_consing.jl
@@ -11,6 +11,35 @@ const BSImpl = SymbolicUtils.BasicSymbolicImpl
 struct Ctx1 end
 struct Ctx2 end
 
+struct CountedMetadata
+    value::Int
+    comparisons::Ref{Int}
+end
+
+Base.hash(x::CountedMetadata, h::UInt) = hash(x.value, h)
+function Base.isequal(a::CountedMetadata, b::CountedMetadata)
+    a.comparisons[] += 1
+    return a.value == b.value
+end
+
+@testset "Metadata hashing scales with retained values" begin
+    @syms metadata_symbol
+    comparisons = Ref(0)
+    retained = [
+        setmetadata(metadata_symbol, Ctx1, CountedMetadata(i, comparisons))
+            for i in 1:1000
+    ]
+    @test isequal(first(retained), last(retained))
+    @test isequal(first(retained) == last(retained), metadata_symbol == metadata_symbol)
+    @test hash(first(retained)) == hash(last(retained))
+    for (i, expr) in enumerate(retained)
+        @test getmetadata(expr, Ctx1).value == i
+        @test expr === setmetadata(metadata_symbol, Ctx1, CountedMetadata(i, comparisons))
+    end
+    # Count probes rather than wall time to detect quadratic collision chains.
+    @test comparisons[] <= 25length(retained)
+end
+
 struct ThrowingEqualityScalar
     tag::Symbol
     value::Int


### PR DESCRIPTION
## Change

Restore metadata-aware hashing while hash-consing uses full comparison. Ordinary public `isequal`, symbolic `==`, and hashing retain their metadata-free semantics outside that context. The previous coarse hash put retained symbols with distinct metadata into the same weak-cache probe chain, producing quadratic comparison growth.

Please ignore this draft until reviewed by @ChrisRackauckas.

## Verification

Julia 1.11.9, native `GROUP=Core julia --project=. --startup-file=no -e 'using Pkg; Pkg.test()'`, identical new regression on both worktrees:

```text
Before (748075182f48408d6159b1a6e077cbb55921d695):
Metadata hashing scales with retained values: Test Failed
Expression: comparisons[] <= 25 * length(retained)
Evaluated: 1000970 <= 25000
Core | 19982 pass | 1 fail | 3 existing broken | 13m16.6s

After:
Core | 19983 pass | 3 existing broken | 12m34.1s
Testing SymbolicUtils tests passed
```

The test retains 1,000 distinct metadata-bearing expressions, checks public equality/hash invariants, checks every metadata value, and verifies that identical metadata still interns to the same object. It counts comparisons rather than timing to avoid a noisy performance threshold.

A separate public-API reducer importing only SymbolicUtils and Test isolates the adjacent-commit boundary. Its six checks pass on parent `df4b804d`, fail only the scaling check on `37faa3266c9c710ad4ed790c9350a5f913b592a6` and current base, and pass with this fix. Metadata comparisons for 1,000 retained expressions: parent 4, introducing commit 499,828, current base 499,826, fixed 4.

`julia +1.12 --project=@runic -m Runic --check src/hashconsing.jl test/hash_consing.jl`, spelling over the diff, and `git diff --check` pass.

## Tradeoff and remaining validation

The task-local lookup has a measurable ordinary-hashing cost. A metadata-free workload performing one million hashes (seven samples after warmup) measured median 0.018013 s before and 0.037678 s after, with 16 allocated bytes and identical checksums in both. This is not a universally faster hash implementation; it trades that overhead for removing quadratic metadata collision chains. A table-specific hashing interface could avoid that overhead in a separate dependency-level design.

Native QA on current base and this candidate both fail the same existing rendered-public-API check: `operation_getname`, `operation_hasname`, and `operation_is_atomic` are missing from rendered docs (19 pass, 1 fail). The independent clean-base reproduction and existing documentation fix are tracked by https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1054. On a separate worktree composing this hash fix with that existing docs change, `GROUP=QA julia --project=. --startup-file=no -e 'using Pkg; Pkg.test()'` passes: SciMLTesting QA 20/20 (2m19.1s), AdjView JET 37/37 (29.1s), terminal exit 0. No unrelated docs changes are included here.

Exact-version EMA validation is still running. GPU, downstream CI matrices, and other Julia versions have not been validated for this patch. No tests were disabled or relaxed.

## Links

- Introducing commit: https://github.com/JuliaSymbolics/SymbolicUtils.jl/commit/37faa3266c9c710ad4ed790c9350a5f913b592a6
- Independent documentation prerequisite: https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1054

🤖 Generated with Codex CLI 0.153.4 (model: gpt-6-astra); local transcript: `/home/crackauc/.codex/sessions/2026/09/05/rollout-2026-09-05T05-08-31-01a070d3-9e50-71c2-98f5-129385e50fb7.jsonl`.
