### PR TITLE
Compare copied symbolic identities structurally during interning

### DIFF
--- a/src/hashconsing.jl
+++ b/src/hashconsing.jl
@@ -203,10 +203,6 @@ function isequal_bsimpl(a::BSImpl.Type{T}, b::BSImpl.Type{T}, full::Bool)::Bool 
     Tb = MData.variant_type(b)
     Ta === Tb || return false
 
-    if full && ida !== idb && ida !== nothing && idb !== nothing
-        return false
-    end
-
     memo = EQUALITY_MEMO[]
     memo_key = (objectid(a), objectid(b), full)
     if memo !== nothing

--- a/test/hash_consing.jl
+++ b/test/hash_consing.jl
@@ -11,6 +11,27 @@ const BSImpl = SymbolicUtils.BasicSymbolicImpl
 struct Ctx1 end
 struct Ctx2 end
 
+@testset "Deepcopied expressions preserve interning equivalence" begin
+    @syms copied_symbol
+    for expr in (copied_symbol, sin(copied_symbol), sin(cos(copied_symbol) + copied_symbol))
+        reference = sin(expr)
+        retained = [sin(deepcopy(expr)) for _ in 1:1000]
+        @test all(term -> isequal(term, reference), retained)
+        @test all(term -> hash(term) == hash(reference), retained)
+        @test all(term -> term === reference, retained)
+    end
+
+    original = setmetadata(copied_symbol, Ctx1, [1])
+    copied = deepcopy(original)
+    @test getmetadata(copied, Ctx1) == [1]
+    @test getmetadata(copied, Ctx1) !== getmetadata(original, Ctx1)
+    getmetadata(copied, Ctx1)[1] = 2
+    @test getmetadata(original, Ctx1) == [1]
+    changed = setmetadata(copied, Ctx1, [3])
+    @test getmetadata(changed, Ctx1) == [3]
+    @test sin(changed) !== sin(original)
+end
+
 struct ThrowingEqualityScalar
     tag::Symbol
     value::Int


### PR DESCRIPTION
## Change

Do not treat distinct intern IDs as proof of inequality during full symbolic comparison. `deepcopy` creates a new mutable ID token without changing the expression, so that shortcut prevents expressions such as `sin(deepcopy(x))` from reusing the canonical expression and creates growing collision chains. Keep the same-ID positive shortcut and use existing structural/metadata comparison for different IDs.

Please ignore this draft until reviewed by @ChrisRackauckas.

## Verification

Julia 1.11.9 native `GROUP=Core julia --project=. --startup-file=no -e 'using Pkg; Pkg.test()'`, with the identical new official test on both worktrees:

```text
Before (748075182f48408d6159b1a6e077cbb55921d695):
Deepcopied expressions preserve interning equivalence: Test Failed
Expression: all((term->term === reference), retained)
Core | 17990 pass | 3 fail | 3 existing broken | 12m58.4s

After:
Core | 17993 pass | 3 existing broken | 14m09.7s
Testing SymbolicUtils tests passed
```

Runic checks on both changed files, spelling over the source diff, and `git diff --check` pass.

The standalone public-API reducer imports only SymbolicUtils and Test. Current base fails three canonicalization checks (7 pass, 3 fail); the candidate passes 10/10. Checks cover ordinary equality/hash invariants, nested terms, raw deep-copied mutable metadata nonaliasing, mutation isolation, and distinct values assigned with public `setmetadata` remaining distinct.

The minimal historical reducer is:

```julia
using SymbolicUtils, Test
@syms x
reference = sin(x)
copied = sin(deepcopy(x))
same_value = isequal(copied, reference)
same_hash = hash(copied) == hash(reference)
same_instance = copied === reference
@testset "Copied symbol interning" begin
    @test same_value
    @test same_hash
    @test same_instance
end
```

On Julia 1.11.9, parent `80ccd13f3335b071b2e4b078784fd6f3df61aa45` passes 3/3; `af4ff8f60b57800be2cfcb267438e5e23832fea0` fails only `same_instance` (2 pass, 1 fail). All common dependency entries have identical versions; the rewrite intentionally replaces Unityper with Moshi and associated dependencies (63 entries before, 69 after). The earlier mutable-ID introduction `51d787130d151085daec69a6ab3fdf0bedfb8935` and its parent both pass and are not the failing boundary.

## Performance tradeoff

Repeatedly retaining `sin(deepcopy(x))` for 10,000 copies: the final 1,000-copy batch takes about 5.5 s on current source, versus 0.00545 s with the candidate. This is a workload-specific measurement, not a universal speedup.

Conversely, a collision-heavy workload of 1,000 genuinely unequal metadata-bearing nodes, repeatedly interning their `sin` terms ten times, slows from median 2.387 s to 4.437 s across five warmed samples. Allocations are unchanged at 3,127,120,000 bytes. Removing the negative shortcut requires deeper comparisons; this tradeoff is explicit. No unrelated metadata-hashing or DAG-memo changes are included.

Native `GROUP=QA julia --project=. --startup-file=no -e 'using Pkg; Pkg.test()'` on Julia 1.11.9, composing only this fix with the existing documentation correction from https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1054, passes SciMLTesting QA 20/20 (2m23.1s) and AdjView JET 37/37 (30.4s), exit 0. No unrelated docs changes are included. Current base independently fails the existing rendered-public-API check without that documentation correction.

An EMA Carcione control retaining 2,000 remade problems also completed successfully with this fix alone on exact SymbolicUtils 4.46.1. All 433 manifest entries are identical except the local SymbolicUtils source. Its initial multi-parameter solve checks pass 6/6; late 100-remake batches remain about 0.88–1.08 s, versus 35.63 s for the unfixed final batch (the fixed final batch is 1.55 s including 0.65 s GC). The separate metadata-hashing fix alone did not remove this growth (39.86 s final batch). This control retains all problems; it does not disable interning or cap caches.

The exact 2,000-sample sensitivity example and full EMA docs build are still running. No completion claim is made for those runs yet. Other Julia versions, GPU, and downstream CI matrices were not validated locally for this patch. No tests were disabled or relaxed.

## Links

- Introducing rewrite: https://github.com/JuliaSymbolics/SymbolicUtils.jl/commit/af4ff8f60b57800be2cfcb267438e5e23832fea0
- Independent documentation prerequisite: https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1054
- Separate metadata-hashing fix: https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1056

🤖 Generated with Codex CLI 0.153.4 (model: gpt-6-astra); local transcript: `/home/crackauc/.codex/sessions/2026/09/05/rollout-2026-09-05T05-08-31-01a070d3-9e50-71c2-98f5-129385e50fb7.jsonl`.
