### PR TITLE
Compare copied symbolic identities structurally during interning

### DIFF
--- a/src/hashconsing.jl
+++ b/src/hashconsing.jl
@@ -203,10 +203,6 @@ function isequal_bsimpl(a::BSImpl.Type{T}, b::BSImpl.Type{T}, full::Bool)::Bool 
     Tb = MData.variant_type(b)
     Ta === Tb || return false
 
-    if full && ida !== idb && ida !== nothing && idb !== nothing
-        return false
-    end
-
     memo = EQUALITY_MEMO[]
     memo_key = (objectid(a), objectid(b), full)
     if memo !== nothing

--- a/test/hash_consing.jl
+++ b/test/hash_consing.jl
@@ -40,6 +40,27 @@ end
     @test comparisons[] <= 25length(retained)
 end
 
+@testset "Deepcopied expressions preserve interning equivalence" begin
+    @syms copied_symbol
+    for expr in (copied_symbol, sin(copied_symbol), sin(cos(copied_symbol) + copied_symbol))
+        reference = sin(expr)
+        retained = [sin(deepcopy(expr)) for _ in 1:1000]
+        @test all(term -> isequal(term, reference), retained)
+        @test all(term -> hash(term) == hash(reference), retained)
+        @test all(term -> term === reference, retained)
+    end
+
+    original = setmetadata(copied_symbol, Ctx1, [1])
+    copied = deepcopy(original)
+    @test getmetadata(copied, Ctx1) == [1]
+    @test getmetadata(copied, Ctx1) !== getmetadata(original, Ctx1)
+    getmetadata(copied, Ctx1)[1] = 2
+    @test getmetadata(original, Ctx1) == [1]
+    changed = setmetadata(copied, Ctx1, [3])
+    @test getmetadata(changed, Ctx1) == [3]
+    @test sin(changed) !== sin(original)
+end
+
 struct ThrowingEqualityScalar
     tag::Symbol
     value::Int


### PR DESCRIPTION
Re-applies #1057 onto current master; it conflicted once #1056 landed, since both edit `src/hashconsing.jl` and `test/hash_consing.jl`.

Distinct intern IDs are no longer treated as proof of inequality during full symbolic comparison. `deepcopy` mints a new mutable ID token without changing the expression, so that shortcut stopped `sin(deepcopy(x))` from reusing the canonical expression and grew collision chains. The same-ID positive shortcut is kept; different IDs fall through to the existing structural and metadata comparison.

The source change is unchanged from #1057 — the removed block is still present on master. Only the test insertion point moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R