### PR TITLE
Revert "Restore metadata-aware hashes during full-comparison interning" (#1056)

### DIFF
--- a/src/hashconsing.jl
+++ b/src/hashconsing.jl
@@ -597,7 +597,9 @@ function hash_bsimpl(s::BSImpl.Type{T}, h::UInt, full) where {T}
 end
 
 function Base.hash(s::BSImpl.Type, h::UInt)
-    return hash_bsimpl(s, h, COMPARE_FULL[])
+    # Always use the metadata-free hash to avoids a task-local lookup on every hash.
+    # This is coarser than `full = true` but is still ok as a hash function in both modes.
+    return hash_bsimpl(s, h, false)
 end
 
 const ENABLE_HASHCONSING = Ref(true)

--- a/test/hash_consing.jl
+++ b/test/hash_consing.jl
@@ -11,35 +11,6 @@ const BSImpl = SymbolicUtils.BasicSymbolicImpl
 struct Ctx1 end
 struct Ctx2 end
 
-struct CountedMetadata
-    value::Int
-    comparisons::Ref{Int}
-end
-
-Base.hash(x::CountedMetadata, h::UInt) = hash(x.value, h)
-function Base.isequal(a::CountedMetadata, b::CountedMetadata)
-    a.comparisons[] += 1
-    return a.value == b.value
-end
-
-@testset "Metadata hashing scales with retained values" begin
-    @syms metadata_symbol
-    comparisons = Ref(0)
-    retained = [
-        setmetadata(metadata_symbol, Ctx1, CountedMetadata(i, comparisons))
-            for i in 1:1000
-    ]
-    @test isequal(first(retained), last(retained))
-    @test isequal(first(retained) == last(retained), metadata_symbol == metadata_symbol)
-    @test hash(first(retained)) == hash(last(retained))
-    for (i, expr) in enumerate(retained)
-        @test getmetadata(expr, Ctx1).value == i
-        @test expr === setmetadata(metadata_symbol, Ctx1, CountedMetadata(i, comparisons))
-    end
-    # Count probes rather than wall time to detect quadratic collision chains.
-    @test comparisons[] <= 25length(retained)
-end
-
 struct ThrowingEqualityScalar
     tag::Symbol
     value::Int


### PR DESCRIPTION
Reverts https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1056.

## Why

#1056 is a line-for-line reversal of https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/999, which removed the task-local `COMPARE_FULL` lookup from `Base.hash` for a measured ~5% end-to-end win. #1056 was merged without that discussion being revisited. Its own body reports ordinary hashing going from 0.018 s to 0.038 s per million hashes, and its benchmark CI showed `codegen/arrayop_nested/fast_toexpr` at 0.84x and `overhead/acrule/a+b` at 0.86x.

The quadratic probe-chain problem #1056 addressed (many retained expressions differing only in metadata land in one `WeakCacheSet` chain) is real and should be fixed, but in the interning path — a metadata-aware key hash for the `WeakCacheSet` lookup, as suggested in #999 — rather than by making every `Base.hash` call pay for the task-local read. The regression test from #1056 is removed here with the fix; a follow-up should reintroduce it alongside an interning-local fix.

Nothing released contains #1056: registry 4.46.2 is https://github.com/JuliaSymbolics/SymbolicUtils.jl/commit/685454733ca6 and master since then is unreleased.

## Verification

`git revert edf4898` applied cleanly; `git diff 6a4f82e0 -- src/hashconsing.jl test/hash_consing.jl` is empty, i.e. both files are byte-identical to master as of #1054, whose CI was green. No local test run — the resulting tree is one CI has already covered.

## Links

- https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1056 — reverted PR
- https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/999 — the change #1056 reversed, with the benchmark discussion
- https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1057#issuecomment-5552974099 — related: the deepcopy/hash-consing direction Aayush asked for

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5-1)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
