### PR TITLE
Fix hash seeds for 32-bit and add x86 CI lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,29 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           file: lcov.info
+
+  # 32-bit (i686) Julia on ubuntu — needs i386 libs before setup-julia.
+  test-x86:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        group:
+          - 'Core'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install 32-bit runtime libraries (i386)
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libc6:i386 libstdc++6:i386 libgcc-s1:i386 libatomic1:i386
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+          arch: x86
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        env:
+          GROUP: ${{ matrix.group }}

--- a/src/hashconsing.jl
+++ b/src/hashconsing.jl
@@ -413,9 +413,11 @@ end
 Custom hash functions for `vartype(x)`, since hashes of types defined in a module are not
 stable across machines or processes.
 """
-vartype_hash(::Type{SymReal}, h::UInt) = hash(0x3fffc14710d3391a, h)
-vartype_hash(::Type{SafeReal}, h::UInt) = hash(0x0e8c1e3ac836f40d, h)
-vartype_hash(::Type{TreeReal}, h::UInt) = hash(0x44ec30357ff75155, h)
+# `% UInt` so these seeds fit on 32-bit (`UInt === UInt32`); bare UInt64
+# literals passed to `hash` can InexactError when mixed into a UInt32 seed.
+vartype_hash(::Type{SymReal}, h::UInt) = hash(0x3fffc14710d3391a % UInt, h)
+vartype_hash(::Type{SafeReal}, h::UInt) = hash(0x0e8c1e3ac836f40d % UInt, h)
+vartype_hash(::Type{TreeReal}, h::UInt) = hash(0x44ec30357ff75155 % UInt, h)
 
 """
     $TYPEDSIGNATURES
@@ -423,7 +425,7 @@ vartype_hash(::Type{TreeReal}, h::UInt) = hash(0x44ec30357ff75155, h)
 Custom hash functions for `AddMul.variant`, since it falls back to the `Base.Enum`
 implementation, which uses `objectid`, which changes across runs.
 """
-hash_addmulvariant(x::AddMulVariant.T, h::UInt) = hash(x === AddMulVariant.ADD ? 0x6d86258fc9cc0742 : 0x5e0a17a14cd8c815, h)
+hash_addmulvariant(x::AddMulVariant.T, h::UInt) = hash(x === AddMulVariant.ADD ? 0x6d86258fc9cc0742 % UInt : 0x5e0a17a14cd8c815 % UInt, h)
 
 const FNTYPE_SEED = 0x8b414291138f6c45 % UInt
 


### PR DESCRIPTION
## Summary
- Truncate `vartype_hash` / `hash_addmulvariant` UInt64 seeds with `% UInt` so hashing works when `UInt === UInt32`.
- Add an Ubuntu `arch: x86` CI job (with i386 runtime libs before setup-julia).

This unblocks SciML packages that pull SymbolicUtils on the new org-wide 32-bit lanes (e.g. ODEInterfaceDiffEq precompile was hitting `InexactError: trunc(UInt32, 0x8b4142914d506ccb)`).

## Test plan
- [ ] Existing CI matrix still green
- [ ] New `test-x86` / Core job green on this PR

Made with [Cursor](https://cursor.com)