### PR TITLE
Bump to 4.46.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymbolicUtils"
 uuid = "d1185830-fcd6-423d-90d6-eec64667417b"
-version = "4.46.2"
+version = "4.46.3"
 authors = ["Shashi Gowda"]
 
 [deps]


### PR DESCRIPTION
## Summary
- Patch bump to register the 32-bit `hash` seed fix from #1060 so SciML x86 CI can resolve it from General.

## Test plan
- [ ] TagBot / manual tag `v4.46.3` after merge
- [ ] JuliaRegistries/General registration succeeds

Made with [Cursor](https://cursor.com)