### PR TITLE
Truncate Base.hasha_seed to UInt for 32-bit Julia

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymbolicUtils"
 uuid = "d1185830-fcd6-423d-90d6-eec64667417b"
-version = "4.46.3"
+version = "4.46.4"
 authors = ["Shashi Gowda"]
 
 [deps]

--- a/src/hashconsing.jl
+++ b/src/hashconsing.jl
@@ -377,7 +377,7 @@ when currently `full` may be `true`. `full` should be equal to the current value
 `COMPARE_FULL`. Passing `full` prevents repeatedly accessing a `TaskLocalValue`.
 """
 function hash_addmuldict(d::ACDict, h::UInt, full::Bool)
-    hv = Base.hasha_seed
+    hv = Base.hasha_seed % UInt
     for (k, v) in d
         h1 = hash_somescalar(v, zero(UInt))
         h1 = hash_bsimpl(k, h1, full)
@@ -396,7 +396,7 @@ when currently `full` may be `true`. `full` should be equal to the current value
 Compute a hash value for a ranges dictionary used in `ArrayOp` variants.
 """
 function hash_rangesdict(d::RangesT, h::UInt, full::Bool)
-    hv = Base.hasha_seed
+    hv = Base.hasha_seed % UInt
     for (k, v) in d
         h1 = hash_range(v, zero(UInt))
         h1 = hash_bsimpl(k, h1, full)
@@ -564,7 +564,7 @@ function hash_metadata(m::MetadataT, h::UInt)
     if m === nothing
         return hash(nothing, h)
     elseif m isa Base.ImmutableDict{DataType, Any}
-        hv = Base.hasha_seed
+        hv = Base.hasha_seed % UInt
         return hash(hash_metadict(m, hv), h)
     end
     return _unreachable()


### PR DESCRIPTION
## Summary
- `Base.hasha_seed` is always `UInt64` (`0x8b4142914d506ccb`).
- `#1060` truncated package hex salts with `% UInt`, but left `hv = Base.hasha_seed` bare.
- On i686 that becomes `InexactError: trunc(UInt32, …)` during `hash_bsimpl` / precompile, cascading into Symbolics, Sundials, ModelingToolkit, etc.
- Bump to **4.46.4** for registration.

## Test plan
- [ ] Existing x86 Core CI green
- [ ] `using SymbolicUtils` precompiles on 32-bit Julia

Made with [Cursor](https://cursor.com)