### PR TITLE
Widen polyform gcd coefficients to Int64 (32-bit)

### DIFF
--- a/src/polyform.jl
+++ b/src/polyform.jl
@@ -227,7 +227,8 @@ function canonicalize_coeffs!(coeffs::Vector{PolyCoeffT})
     for i in eachindex(coeffs)
         v = coeffs[i]
         safe_isinteger(v) || continue
-        coeffs[i] = Int(v)
+        # Int64: on 32-bit Julia, `Int` is Int32 and overflows in MP.gcd/content.
+        coeffs[i] = Int64(v)
     end
 end
 canonicalize_coeffs!(x) = nothing
@@ -243,26 +244,27 @@ function poly_to_gcd_form(p::PolynomialT)
         any_complex |= c isa Complex
         all_int || all_rat || break
     end
+    # Always widen integer/rational coefficients to Int64 / Rational{Int64}.
+    # On 32-bit Julia, `Int` is Int32; homogeneous `Integer.(::Vector{Int32})`
+    # stays Int32 and then `MP.gcd` / `div_multiple` hits DivideError when
+    # content arithmetic overflows (e.g. MomentClosure derivative matching
+    # closures going through `simplify` → `simplify_fractions`).
     cs = if all_int
-        Integer.(MP.coefficients(p))
+        Int64.(MP.coefficients(p))
     elseif all_rat
-        rationalize.(MP.coefficients(p))
+        map(c -> begin
+                r = c isa Rational ? c : rationalize(c)
+                Rational{Int64}(Int64(numerator(r)), Int64(denominator(r)))
+            end, MP.coefficients(p))
     elseif any_complex
         (complex ∘ float).(MP.coefficients(p))
     else
         float.(MP.coefficients(p))
     end
-    # Broadcast preserves the abstractness of the input vector's eltype:
-    # `Integer.(::Vector{Number})` returns `Vector{Number}` if the values
-    # are heterogeneous concrete subtypes of Integer (e.g. `Int8 + Int64`
-    # broadcasts to `Vector{Signed}`). The resulting `DP.Polynomial` then
-    # carries an abstract type parameter (`Integer`/`Signed`/`AbstractFloat`/
-    # `Real`), which crashes `MP.gcd`'s `isolate_variable` reconstruction.
-    # Narrow to a concrete eltype here when needed; on the homogeneous fast
-    # path (eltype already concrete) this is a single `isconcretetype` check
-    # and no extra allocation.
+    # Broadcast can still leave an abstract eltype for heterogeneous floats;
+    # narrow to a concrete eltype when needed (gcd requires it).
     if !isconcretetype(eltype(cs))
-        T = isempty(cs) ? (all_int ? Int : all_rat ? Rational{Int} :
+        T = isempty(cs) ? (all_int ? Int64 : all_rat ? Rational{Int64} :
                            any_complex ? ComplexF64 : Float64) :
             mapreduce(typeof, promote_type, cs)
         cs = Vector{T}(cs)

--- a/test/polyform.jl
+++ b/test/polyform.jl
@@ -149,6 +149,17 @@ let v = only(DP.@polyvar __PolyToGcdFormTest__ monomial_order = MonomialOrder)
             g2 = poly_to_gcd_form(p2)
             @test gcd(g1, g2) isa DP.Polynomial
         end
+
+        @testset "homogeneous Int32 widens to Int64 (32-bit gcd safety)" begin
+            # On 32-bit Julia, integer literals are Int32; homogeneous
+            # `Integer.(::Vector{Int32})` used to keep Int32 and then
+            # `MP.gcd`/`div_multiple` could DivideError (MomentClosure).
+            p = poly_with_coeffs(Number[Int32(1), Int32(-2), Int32(1)],
+                                  (1 - v) * (1 - v))
+            g = poly_to_gcd_form(p)
+            @test eltype(MP.coefficients(g)) === Int64
+            @test gcd(g, g) isa DP.Polynomial
+        end
     end
 end
 


### PR DESCRIPTION
## Summary
- On 32-bit Julia, integer literals are `Int32`. Homogeneous `Integer.(coeffs)` in `poly_to_gcd_form` kept `Int32`, and `MP.gcd` / `div_multiple` then hit `DivideError` during `simplify_fractions`.
- Always convert integer/rational poly coeffs to `Int64` / `Rational{Int64}` before gcd (same for `canonicalize_coeffs!`).
- Adds a regression test for homogeneous `Int32` → `Int64`.

Surfaced by SciML/MomentClosure.jl `bernoulli_closure_tests` on x86 CI.

## Test plan
- [ ] Existing `polyform` tests pass
- [ ] New Int32 widening test passes
- [ ] MomentClosure x86 green when sourcing this branch


Made with [Cursor](https://cursor.com)