### PR TITLE
fix: publish lazy argument caches atomically

### DIFF
--- a/src/terminterface.jl
+++ b/src/terminterface.jl
@@ -135,6 +135,15 @@ function __sorted_args(x::BasicSymbolic{T})::ROArgsT{T} where {T}
     end
 end
 
+@inline function _get_cached_arguments(cache::ArgsCacheT{T}) where {T}
+    return @atomic :acquire cache.value
+end
+
+@inline function _publish_cached_arguments!(cache::ArgsCacheT{T}, candidate::ArgsT{T}) where {T}
+    result = @atomicreplace :acquire_release :acquire cache.value nothing => candidate
+    return result.success ? candidate : result.old::ArgsT{T}
+end
+
 """
     arguments(expr)
 
@@ -175,11 +184,14 @@ function TermInterface.arguments(x::BSImpl.Type{T})::ROArgsT{T} where {T}
         BSImpl.Sym(_) => throw(ArgumentError("`Sym` does not have arguments."))
         BSImpl.Term(; args) => ROArgsT{T}(args)
         BSImpl.AddMul(; coeff, dict, variant, args, shape, type) => begin
-            isempty(args) || return ROArgsT{T}(args)
+            cached = _get_cached_arguments(args)
+            cached === nothing || return ROArgsT{T}(cached)
+
+            newargs = ArgsT{T}()
             @match variant begin
                 AddMulVariant.ADD => begin
                     if !iszero(coeff)
-                        push!(args, Const{T}(coeff))
+                        push!(newargs, Const{T}(coeff))
                     end
                     for (k, v) in dict
                         newterm = @match k begin
@@ -188,39 +200,45 @@ function TermInterface.arguments(x::BSImpl.Type{T})::ROArgsT{T} where {T}
                             end
                             _ => Mul{T}(v, ACDict{T}(k => 1); shape, type)
                         end
-                        push!(args, newterm)
+                        push!(newargs, newterm)
                     end
                 end
                 AddMulVariant.MUL => begin
                     if !_isone(coeff)
-                        push!(args, Const{T}(coeff))
+                        push!(newargs, Const{T}(coeff))
                     end
                     for (k, v) in dict
-                        push!(args, k ^ v)
+                        push!(newargs, k ^ v)
                     end
                 end
             end
-            return ROArgsT{T}(args)
+            return ROArgsT{T}(_publish_cached_arguments!(args, newargs))
         end
         BSImpl.Div(num, den) => ROArgsT{T}(ArgsT{T}((num, den)))
         BSImpl.ArrayOp(; output_idx, expr, reduce, term, ranges, shape, type, args) => begin
             if term === nothing
-                isempty(args) || return ROArgsT{T}(args)
-                push!(args, Const{T}(output_idx))
-                push!(args, Const{T}(expr))
-                push!(args, Const{T}(reduce))
-                push!(args, Const{T}(term))
-                push!(args, Const{T}(ranges))
-                return ROArgsT{T}(args)
+                cached = _get_cached_arguments(args)
+                cached === nothing || return ROArgsT{T}(cached)
+
+                newargs = ArgsT{T}()
+                push!(newargs, Const{T}(output_idx))
+                push!(newargs, Const{T}(expr))
+                push!(newargs, Const{T}(reduce))
+                push!(newargs, Const{T}(term))
+                push!(newargs, Const{T}(ranges))
+                return ROArgsT{T}(_publish_cached_arguments!(args, newargs))
             elseif term isa BasicSymbolic{T}
                 return arguments(term)
             end
         end
         BSImpl.ArrayMaker(; regions, values, args) => begin
-            isempty(args) || return ROArgsT{T}(args)
-            push!(args, BSImpl.Const{T}(regions))
-            push!(args, BSImpl.Const{T}(values))
-            return ROArgsT{T}(args)
+            cached = _get_cached_arguments(args)
+            cached === nothing || return ROArgsT{T}(cached)
+
+            newargs = ArgsT{T}()
+            push!(newargs, BSImpl.Const{T}(regions))
+            push!(newargs, BSImpl.Const{T}(values))
+            return ROArgsT{T}(_publish_cached_arguments!(args, newargs))
         end
     end
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -68,6 +68,14 @@ known at compile time, it should be passed as a `Tuple` to the constructor.
 """
 const SmallV{T} = SmallVec{T, Vector{T}}
 
+# Lazy derived data on hash-consed symbolic nodes must be published atomically.
+# A cache slot replaces the eagerly allocated empty SmallVec previously stored on
+# every cache-bearing node; the complete SmallVec is allocated only on first use.
+mutable struct ArgumentCache{T}
+    @atomic value::Union{Nothing, T}
+    ArgumentCache{T}() where {T} = new{T}(nothing)
+end
+
 """
     ShapeVecT(ranges)
 
@@ -245,7 +253,7 @@ Core ADT for symbolic expressions.
         const metadata::MetadataT
         const shape::ShapeT
         const type::TypeT
-        const args::SmallV{BasicSymbolicImpl.Type{T}}
+        const args::ArgumentCache{SmallV{BasicSymbolicImpl.Type{T}}}
         hash::UInt
         hash2::UInt
         id::IdentT
@@ -286,7 +294,7 @@ Core ADT for symbolic expressions.
         const metadata::MetadataT
         const shape::ShapeT
         const type::TypeT
-        const args::SmallV{BasicSymbolicImpl.Type{T}}
+        const args::ArgumentCache{SmallV{BasicSymbolicImpl.Type{T}}}
         hash::UInt
         hash2::UInt
         id::IdentT
@@ -302,7 +310,7 @@ Core ADT for symbolic expressions.
         # _has_ to be an array shape.
         const shape::ShapeT
         const type::TypeT
-        const args::SmallV{BasicSymbolicImpl.Type{T}}
+        const args::ArgumentCache{SmallV{BasicSymbolicImpl.Type{T}}}
         hash::UInt
         hash2::UInt
         id::IdentT
@@ -322,6 +330,7 @@ The type of a mutable buffer containing symbolic arguments. Passing this to the
 [`SymbolicUtils.Term`](@ref) constructor will avoid allocating a new array.
 """
 const ArgsT{T} = SmallV{BasicSymbolic{T}}
+const ArgsCacheT{T} = ArgumentCache{ArgsT{T}}
 """
 The type of a read-only buffer containing symbolic arguments. Passing this to the
 [`SymbolicUtils.Term`](@ref) constructor will avoid allocating a new array. This is
@@ -562,10 +571,10 @@ end
 ordered_override_properties(::Type{<:BSImpl.Const}) = (0, nothing,)
 ordered_override_properties(::Type{<:BSImpl.Sym}) = (0, 0, nothing)
 ordered_override_properties(::Type{<:BSImpl.Term}) = (0, 0, nothing)
-ordered_override_properties(::Type{BSImpl.AddMul{T}}) where {T} = (ArgsT{T}(), 0, 0, nothing)
+ordered_override_properties(::Type{BSImpl.AddMul{T}}) where {T} = (ArgsCacheT{T}(), 0, 0, nothing)
 ordered_override_properties(::Type{<:BSImpl.Div}) = (0, 0, nothing)
-ordered_override_properties(::Type{<:BSImpl.ArrayOp{T}}) where {T} = (ArgsT{T}(), 0, 0, nothing)
-ordered_override_properties(::Type{<:BSImpl.ArrayMaker{T}}) where {T} = (ArgsT{T}(), 0, 0, nothing)
+ordered_override_properties(::Type{<:BSImpl.ArrayOp{T}}) where {T} = (ArgsCacheT{T}(), 0, 0, nothing)
+ordered_override_properties(::Type{<:BSImpl.ArrayMaker{T}}) where {T} = (ArgsCacheT{T}(), 0, 0, nothing)
 
 function ConstructionBase.getproperties(obj::BSImpl.Type)
     @match obj begin
@@ -594,7 +603,7 @@ function ConstructionBase.setproperties(obj::BSImpl.Type{T}, patch::NamedTuple) 
         BSImpl.AddMul(; coeff, dict, variant, metadata, shape, type) =>
             BSImpl.AddMul{T}(get(p, :coeff, coeff), get(p, :dict, dict), get(p, :variant, variant),
                              get(p, :metadata, metadata), get(p, :shape, shape), get(p, :type, type),
-                             ArgsT{T}(), Z, Z, nothing)
+                             ArgsCacheT{T}(), Z, Z, nothing)
         BSImpl.Div(; num, den, simplified, metadata, shape, type) =>
             BSImpl.Div{T}(get(p, :num, num), get(p, :den, den), get(p, :simplified, simplified),
                           get(p, :metadata, metadata), get(p, :shape, shape), get(p, :type, type),
@@ -603,11 +612,11 @@ function ConstructionBase.setproperties(obj::BSImpl.Type{T}, patch::NamedTuple) 
             BSImpl.ArrayOp{T}(get(p, :output_idx, output_idx), get(p, :expr, expr),
                               get(p, :reduce, reduce), get(p, :term, term), get(p, :ranges, ranges),
                               get(p, :metadata, metadata), get(p, :shape, shape), get(p, :type, type),
-                              ArgsT{T}(), Z, Z, nothing)
+                              ArgsCacheT{T}(), Z, Z, nothing)
         BSImpl.ArrayMaker(; regions, values, metadata, shape, type) =>
             BSImpl.ArrayMaker{T}(get(p, :regions, regions), get(p, :values, values),
                                  get(p, :metadata, metadata), get(p, :shape, shape),
-                                 get(p, :type, type), ArgsT{T}(), Z, Z, nothing)
+                                 get(p, :type, type), ArgsCacheT{T}(), Z, Z, nothing)
     end
     hashcons(newobj::BasicSymbolic{T})
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,7 @@ if GROUP == "Core"
                 # @safetestset "Precompilation" begin include("precompilation.jl") end
             end
             @safetestset "Basics" begin include("basics.jl") end
+            @safetestset "Thread-safe arguments" begin include("threadsafe_arguments.jl") end
             @safetestset "ArrayOp" begin include("arrayop.jl") end
             @safetestset "ArrayMaker" begin include("arraymaker.jl") end
             @safetestset "Order" begin include("order.jl") end

--- a/test/threadsafe_arguments.jl
+++ b/test/threadsafe_arguments.jl
@@ -1,0 +1,60 @@
+using Test
+using SymbolicUtils
+using SymbolicUtils: SymReal
+using TermInterface
+using Base.Threads
+
+function fresh_sum(trial; nargs = 1024)
+    xs = [
+        SymbolicUtils.Sym{SymReal}(Symbol(:threadsafe_args_, trial, :_, i); type = Real)
+        for i in 1:nargs
+    ]
+    return sum(xs), xs
+end
+
+@testset "lazy arguments cache publication" begin
+    expr, _ = fresh_sum(0; nargs = 32)
+    first_args = arguments(expr)
+    second_args = arguments(expr)
+    @test isequal(collect(first_args), collect(second_args))
+    @test parent(first_args) === parent(second_args)
+end
+
+@testset "concurrent first arguments access" begin
+    if nthreads() == 1 && get(ENV, "SYMBOLICUTILS_ARGUMENTS_SUBPROCESS", "0") != "1"
+        script = @__FILE__
+        project = dirname(@__DIR__)
+        cmd = addenv(
+            `$(Base.julia_cmd()) --project=$project --threads=4 $script`,
+            "SYMBOLICUTILS_ARGUMENTS_SUBPROCESS" => "1",
+        )
+        @test success(cmd)
+    else
+        @test nthreads() > 1
+        for trial in 1:25
+            expr, xs = fresh_sum(trial)
+            expected = Set(xs)
+            ready = Atomic{Int}(0)
+            go = Atomic{Bool}(false)
+            ntasks = max(8, 4 * nthreads())
+            tasks = [
+                @spawn begin
+                    atomic_add!(ready, 1)
+                    while !go[]
+                        yield()
+                    end
+                    arguments(expr)
+                end for _ in 1:ntasks
+            ]
+            while ready[] < ntasks
+                yield()
+            end
+            go[] = true
+            results = fetch.(tasks)
+            published = parent(first(results))
+            @test all(args -> parent(args) === published, results)
+            @test all(length(args) == length(expected) for args in results)
+            @test all(isequal(Set(args), expected) for args in results)
+        end
+    end
+end


### PR DESCRIPTION
Closes #1066.
Closes #696.

This also fixes the SymbolicUtils root cause reported in
JuliaDynamics/NetworkDynamics.jl#384.

Lazy argument caches for `AddMul`, `ArrayOp`, and `ArrayMaker` are currently populated by mutating the cache's `SmallVec` in place. Concurrent first calls to `arguments` on the same hash-consed symbolic node can therefore write to the same vector and fail with a `ConcurrencyViolationError`.

This changes lazy cache initialization to use one-time atomic publication:

1. A reader first checks whether a complete cached `ArgsT` has already been published.
2. On a cache miss, it constructs the argument vector privately.
3. The complete vector is published with an atomic compare-and-swap.
4. If another task won the race, the losing task discards its candidate and returns the already-published vector.

This preserves lazy argument construction and avoids placing a lock on the warm `arguments` path. Readers never mutate a shared partially initialized argument vector.

The change applies only to the three variants with lazily derived argument caches:

- `AddMul`
- `ArrayOp`
- `ArrayMaker`

Ordinary `Term.args` remains unchanged.

`ConstructionBase.setproperties` continues to invalidate the derived argument cache when constructing a modified node.

A regression test synchronizes multiple tasks on the first `arguments(expr)` access and verifies that all readers receive complete arguments backed by the same published cache. The test also handles the normal single-threaded package test configuration by spawning a multithreaded Julia subprocess.

Targeted validation was performed with 8 Julia threads, including repeated synchronized concurrent first-access trials. The atomic cache-holder mechanism was also checked on Julia 1.10 and Julia 1.12.