### PR TITLE
fix(polyform): support array-form MSE expressions

### DIFF
--- a/src/polyform.jl
+++ b/src/polyform.jl
@@ -20,6 +20,14 @@ function basicsymbolic_to_polyvar(bs_to_poly::AbstractDict, x::BasicSymbolic)::P
     end
 end
 
+function opaque_symbolic_to_polyvar(
+        bs_to_poly::AbstractDict, x::BasicSymbolic, inner_name::Symbol)::PolyVarT
+    get!(bs_to_poly, x) do
+        name = Symbol(inner_name, :_, hash(x))
+        MP.similar_variable(ExamplePolyVar, name)
+    end
+end
+
 """
     $TYPEDSIGNATURES
 
@@ -140,6 +148,16 @@ function to_poly!(poly_to_bs::AbstractDict, bs_to_poly::AbstractDict, expr::Basi
                 get!(poly_to_bs, pvar, expr)
                 return pvar
             end
+        end
+        BSImpl.ArrayOp(;) => begin
+            pvar = opaque_symbolic_to_polyvar(bs_to_poly, expr, :arrayop)
+            get!(poly_to_bs, pvar, expr)
+            return pvar
+        end
+        BSImpl.ArrayMaker(;) => begin
+            pvar = opaque_symbolic_to_polyvar(bs_to_poly, expr, :arraymaker)
+            get!(poly_to_bs, pvar, expr)
+            return pvar
         end
         BSImpl.Div(; num, den, type, shape) => begin
             if isconst(den)

--- a/test/arrayop.jl
+++ b/test/arrayop.jl
@@ -138,6 +138,11 @@ end
         @test symtype(var) == Number
         @test isequal(scalarize(var), f(collect(v)))
     end
+
+    @syms w R[1:1, 1:3]
+    array_mse = w * sum(abs2.(R)) / length(R)
+    @test isarrayop(sum(abs2.(R)))
+    @test isequal(expand(array_mse), (1 // 3) * w * sum(abs2.(R)))
 end
 
 @testset "`map` and `mapreduce` on oddly sized arrays" begin


### PR DESCRIPTION
Treat ArrayOp and ArrayMaker nodes as opaque polynomial variables during polynomial conversion, allowing scalar coefficients in symbolic array expressions to be expanded safely.

Add a regression test for expanding a weighted MSE loss constructed from a symbolic array.