### PR TITLE
Make array_literal public API

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -38,6 +38,7 @@ SymbolicUtils.unwrap
 ```@docs
 SymbolicUtils.Mapper
 SymbolicUtils.Mapreducer
+SymbolicUtils.array_literal
 ```
 
 ### Intermediate Representation

--- a/src/SymbolicUtils.jl
+++ b/src/SymbolicUtils.jl
@@ -223,7 +223,7 @@ end
 @public Unknown, ShapeVecT, ShapeT, shape, promote_shape
 @public fntype_ret_type
 @public FnType
-@public Mapper, Mapreducer
+@public Mapper, Mapreducer, array_literal
 @public infer_vartype, search_variables!
 
 # These names form the developer interface consumed by Symbolics.jl and related


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

`array_literal` is the operation of an expression representing an array built from symbolic elements, so any package that walks symbolic expressions must recognize it to say anything about a matrix assembled from scalar variables.

The immediate consumer is SymbolicAnalysis.jl. Today:

```julia
@variables u[1:3]; us = collect(scalarize(u))
M = [us[1] us[2]; us[2] us[3]]
SymbolicAnalysis.analyze(unwrap(logdet(M))).curvature   # UnknownCurvature
```

even though every element of `M` is affine and `logdet` has a `Concave` rule. The reason is that `M` traces to `array_literal(...)`, which the curvature pass has no rule for, so the *argument* fails to certify and the composition falls through. (`logdet` of an `Arr`-shaped matrix variable certifies `Concave` correctly — it is specifically the matrix built from scalars, which is exactly how a solver backend with a vector of optimization variables constructs one.) That blocks the whole positive-semidefinite atom family — `logdet`, `eigmax` — downstream.

With a curvature rule keyed on this operation, `logdet(M)` → `Concave`, `-logdet(M)` → `Convex` (the log-det barrier) and `eigmax(M)` → `Convex`, all verified locally.

This PR only makes the name public so that rule can be written against documented API rather than an internal: it already has a docstring, so this adds `@public` and an API-reference entry next to the other array-operation callables. **No behavior change.**

Same pattern as #1006, which made `Mapper`/`Mapreducer` public so `sum`/`map` over symbolic arrays could be recognized.

Verified locally: `Base.ispublic(SymbolicUtils, :array_literal)` is `true`, the docstring resolves, and the test suite passes. (Runic reports pre-existing formatting diffs on `src/SymbolicUtils.jl` on master as well; the line added here is not among them.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
