### PR TITLE
Make expand and argument ordering robust to array- and function-valued constants

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymbolicUtils"
 uuid = "d1185830-fcd6-423d-90d6-eec64667417b"
-version = "4.46.5"
+version = "4.46.6"
 authors = ["Shashi Gowda"]
 
 [deps]

--- a/src/ordering.jl
+++ b/src/ordering.jl
@@ -9,10 +9,27 @@
 <ₑ(a::Number, b::BasicSymbolic) = true
 
 <ₑ(a::Function, b::Function) = nameof(a) <ₑ nameof(b)
+# Function-valued constants (e.g. the operation of a `broadcast` term) sort before terms.
+<ₑ(a::Function, b::BasicSymbolic) = true
+<ₑ(a::BasicSymbolic, b::Function) = false
 
 <ₑ(a::Type, b::Type) = nameof(a) <ₑ nameof(b)
-<ₑ(a::T, b::S) where{T,S} = T<S
+# Values of unrelated types without a dedicated method: order by type name so that
+# sorting arguments never throws.
+<ₑ(a::T, b::S) where{T,S} = string(T) < string(S)
 <ₑ(a::T, b::T) where{T} = a < b
+
+# Array-valued constants (e.g. a numeric matrix multiplying a symbolic array) are ordered
+# by dimensionality, then length, then lexicographically by their entries.
+function <ₑ(a::AbstractArray, b::AbstractArray)
+    ka, kb = (ndims(a), length(a)), (ndims(b), length(b))
+    ka == kb || return ka < kb
+    for (x, y) in zip(a, b)
+        x <ₑ y && return true
+        y <ₑ x && return false
+    end
+    return false
+end
 
 """
 $(SIGNATURES)

--- a/src/polyform.jl
+++ b/src/polyform.jl
@@ -168,6 +168,13 @@ function to_poly!(poly_to_bs::AbstractDict, bs_to_poly::AbstractDict, expr::Basi
             get!(poly_to_bs, pvar, expr)
             return pvar
         end
+        _ => begin
+            # `ArrayOp` and `ArrayMaker` are not polynomial in their scalar entries;
+            # treat them as opaque variables like any other non-algebraic term.
+            pvar = basicsymbolic_to_polyvar(bs_to_poly, expr)
+            get!(poly_to_bs, pvar, expr)
+            return pvar
+        end
     end
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -798,7 +798,9 @@ function _name_as_operator(x::BasicSymbolic)
         _ => _name_as_operator(operation(x))
     end
 end
-_name_as_operator(x) = nameof(x)
+_name_as_operator(x::Union{Function, Type, Module}) = nameof(x)
+# Callable structs (e.g. `Mapreducer`, `Fill`) have no `nameof`; use their type name.
+_name_as_operator(x) = nameof(typeof(x))
 
 """
     Base.nameof(s::BasicSymbolic)

--- a/test/order.jl
+++ b/test/order.jl
@@ -90,3 +90,23 @@ end
     args = sort(arguments(expr), lt=<ₑ)
     @test all(((a, b), )->a <ₑ b,  combinations(args, 2))
 end
+
+@testset "ordering of array-valued constants" begin
+    @syms x[1:2, 1:3]
+    A = [0.0 1.0; 1.0 0.0]
+    B = [1.0 0.0; 0.0 1.0]
+    ex = A * x + B * x
+    @test isequal(ex, B * x + A * x)
+    @test !(SymbolicUtils.:<ₑ(A, A))
+    @test SymbolicUtils.:<ₑ(A, B) != SymbolicUtils.:<ₑ(B, A)
+    @test string(ex) isa String
+end
+
+@testset "ordering of function-valued constants" begin
+    @syms x[1:3] y[1:3]
+    @test SymbolicUtils.:<ₑ(/, x)
+    @test !SymbolicUtils.:<ₑ(x, /)
+    ex = (x ./ y) .+ (x .- y)
+    @test string(ex) isa String
+    @test SymbolicUtils.:<ₑ("a", :b) != SymbolicUtils.:<ₑ(:b, "a")
+end

--- a/test/polyform.jl
+++ b/test/polyform.jl
@@ -193,3 +193,11 @@ end
     @test !SymbolicUtils.fraction_isone(x)
     @test SymbolicUtils.fraction_isone(o)
 end
+
+@testset "expand with array reductions and callable-struct operations" begin
+    @syms a b x[1:3]
+    s = sum(abs2, x .+ 1)
+    @test isequal(expand(s), s)
+    @test isequal(expand(a * (s + b)), a * s + a * b)
+    @test isequal(expand(s / 3), (1 // 3) * s)
+end


### PR DESCRIPTION
> **Note:** please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

`expand` threw `matching non-exhaustive` on any expression containing a lazy array reduction (`sum(abs2, x .+ 1)`), because `to_poly!` had no arm for the `ArrayOp`/`ArrayMaker` variants. This breaks `ModelingToolkitBase.OptimizationFunction`, which unconditionally calls `expand(cost(sys))`, for any optimization `System` whose cost is a lazy array reduction (the representation the NeuralPDE parser rewrite in https://github.com/SciML/NeuralPDE.jl/issues/1161 uses). Sorting the arguments of the terms that appear in such systems threw as well. Four small fixes:

1. `to_poly!`: treat `ArrayOp`/`ArrayMaker` as opaque polynomial variables, like other non-algebraic terms.
2. `_name_as_operator`: callable-struct operations (`Mapreducer`, `Fill`) have no `nameof`; use the type name.
3. `<ₑ`: sorting the arguments of `A * x + B * x` with numeric matrices `A`, `B` called `isless(::Matrix, ::Matrix)`; add a total order for array-valued constants (dimensionality, length, then entries).
4. `<ₑ`: a term whose constants include a function (the operation of a `broadcast` term, e.g. `(x ./ y) .+ (x .- y)`) fell through to the generic `<ₑ(a::T, b::S) = T < S` fallback, which compares *types* and is undefined. Order function-valued constants before symbolic terms, and make the generic fallback order unrelated types by name so that sorting never throws.

Patch release bump to 4.46.6.

## Verification

New tests in `test/polyform.jl` and `test/order.jl`. Without the `src/` changes (`git stash push src/`):

```
expand with array reductions and callable-struct operations: Error During Test at test/polyform.jl:200
  matching non-exhaustive
... (3 errors)
ordering of array-valued constants: Error During Test at test/order.jl:100
  MethodError: no method matching isless(::Matrix{Float64}, ::Matrix{Float64})
... (2 errors)
```

and for the function-valued case (observed downstream while lowering a mixed derivative in NeuralPDE, `MethodError: no method matching isless(::Type{BasicSymbolic}, ::Type{typeof(/)})` from `sorted_arguments`).

With the changes, Julia 1.11.9:

```
Test Summary: | Pass  Total   Time
polyform      |   50     50  46.2s
Test Summary: | Pass  Total  Time
order         |   66     66  6.2s
```

Full `GROUP=Core` run with fixes 1–3 (before fix 4 and the last test-expectation tweak): `18017 passed, 1 failed, 3 broken` where the one failure was my own overly strict `isequal(expand(s / 3), s / 3)` expectation (now compares against `(1//3) * s`); the 3 broken are pre-existing in the `ArrayOp` testset.

## Not verified

The full Core group was not rerun after fix 4 (only `order.jl` and `polyform.jl`); QA group and Julia 1.10 were not run locally. `typos` flags a pre-existing "Trivials" in `src/types.jl:266`, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5-1)

https://claude.ai/code/session_01WYPUXLxE9jVu2jXLFRd8ax
