### PR TITLE
Preserve symbolic indices when substituting into constant arrays

### DIFF
--- a/src/symbolic_ops/getindex.jl
+++ b/src/symbolic_ops/getindex.jl
@@ -512,6 +512,9 @@ function _getindex(::Type{T}, arr::BasicSymbolic{T}, idxs::Union{BasicSymbolic{T
     end
 end
 function _getindex(::Type{T}, x::AbstractArray, idxs...) where {T}
-    Const{T}(getindex(x, idxs...))
+    if any(idx -> idx isa BasicSymbolic{T}, idxs)
+        return _getindex(T, Const{T}(x), idxs...)
+    end
+    return Const{T}(getindex(x, idxs...))
 end
 Base.getindex(x::BasicSymbolic{T}, i::CartesianIndex) where {T} = x[Tuple(i)...]

--- a/test/constant_array_indices.jl
+++ b/test/constant_array_indices.jl
@@ -1,0 +1,22 @@
+using SymbolicUtils, Test
+using SymbolicUtils: iscall, operation, unwrap_const
+
+@testset "Substitution preserves symbolic indices into constant arrays" begin
+    @syms index::Int replacement::Int
+    for values in (collect(1:4), collect(1.0:4.0))
+        expression = term(getindex, values, index; type = eltype(values))
+        replaced = substitute(expression, Dict(index => replacement))
+        @test iscall(replaced)
+        @test isequal(operation(replaced), getindex)
+        @test unwrap_const(substitute(replaced, Dict(replacement => 2))) == values[2]
+        @test unwrap_const(substitute(expression, Dict(index => 3))) == values[3]
+    end
+    values = [1 3; 2 4]
+    expression = term(getindex, values, index, 2; type = Int)
+    replaced = substitute(expression, Dict(index => replacement))
+    @test unwrap_const(substitute(replaced, Dict(replacement => 1))) == 3
+    @test unwrap_const(substitute(replaced, Dict(replacement => 2))) == 4
+    nested = substitute(expression + 1, Dict(index => replacement))
+    @test unwrap_const(substitute(nested, Dict(replacement => 1))) == 4
+    @test unwrap_const(substitute(nested, Dict(replacement => 2))) == 5
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,7 @@ if GROUP == "Core"
             @safetestset "Basics" begin include("basics.jl") end
             @safetestset "Thread-safe arguments" begin include("threadsafe_arguments.jl") end
             @safetestset "ArrayOp" begin include("arrayop.jl") end
+            @safetestset "Constant array indices" begin include("constant_array_indices.jl") end
             @safetestset "ArrayMaker" begin include("arraymaker.jl") end
             @safetestset "Order" begin include("order.jl") end
             @safetestset "PolyForm" begin include("polyform.jl") end


### PR DESCRIPTION
> 🚧 **UNREVIEWED — awaiting review by @ChrisRackauckas.** Filed by an AI agent running as @chrisrackauckas; Chris has not reviewed this change. Please ignore this draft until he reviews it.
> Harness: Claude Code 2.1.270 · Model: claude-fable-5-1
> Conversation: local Claude Code session `9b5c3ae5-6a0f-41b8-bd69-03bf3b5e7083` (no shareable URL available)

Substituting a symbolic index into a `getindex` on a constant (`Const`) array currently falls through to Julia's numeric `getindex`, which throws `ArgumentError: invalid index: replacement of type ...BasicSymbolicImpl{SymReal}`. This routes any `_getindex(::Type{T}, x::AbstractArray, idxs...)` call that still carries a `BasicSymbolic` index through the existing `Const{T}(x)` symbolic path, so the expression stays symbolic until the index is numeric; fully numeric indices still evaluate eagerly as before. Motivation: symbolic array substitution in downstream loop-form residual code (https://github.com/JuliaComputing/BatteryComponents.jl/pull/202) hit this error.

```julia
using SymbolicUtils
@syms index::Int replacement::Int
expr = term(getindex, [1, 2, 3], index; type = Int)
substitute(expr, Dict(index => replacement))   # ArgumentError before this PR
```

New test `test/constant_array_indices.jl` (added to the Core group) covers integer and float vectors, a Cartesian matrix index, a nested expression, and subsequent numeric evaluation.

**Before / after** (Julia 1.12.6, aarch64 Linux; log names refer to the local validation directory of the session that produced them):

```
# new test file on unmodified base (symbolic-index-official-before.log, -before-v2.log):
ERROR: LoadError: Some tests did not pass: 0 passed, 0 failed, 1 errored, 0 broken.
  ArgumentError: invalid index: replacement of type SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymReal}

# same file with the fix (symbolic-index-official-fixed-v2.log):
Substitution preserves symbolic indices into constant arrays |   12     12  22.1s

# re-run today against current origin/master 5bc28be6 (this branch's base), unmodified:
ERROR: LoadError: Some tests did not pass: 0 passed, 0 failed, 1 errored, 0 broken.
  ArgumentError: invalid index: replacement of type SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymReal}
Test Summary:                                                | Error  Total   Time
Substitution preserves symbolic indices into constant arrays |     1      1  19.3s

# re-run today on this branch (master 5bc28be6 + this commit):
SymbolicUtils from: .../su-pr-1/src/SymbolicUtils.jl
Test Summary:                                                | Pass  Total   Time
Substitution preserves symbolic indices into constant arrays |   12     12  28.2s
```

**Full suite** (not re-run for this rebase; cited from the earlier local runs on the pre-#1072 base):
- `Pkg.test("SymbolicUtils")` Core with this fix alone (`symbolic-index-core-four.log`): `Core | 18102 passed, 3 broken, 18105 total` — the 3 broken are pre-existing on master.
- QA group (`symbolic-index-qa.log`): `Quality Assurance | 20 20`, AdjView JET `37` passed.
- Combined head of this PR + https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1074 + https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1075 (`symbolic-slices-core2.log`): `Core | 18235 passed, 3 broken, 18238 total`; QA 20 + JET 37 (`symbolic-slices-qa2.log`).

**Formatting / spelling:** `typos` (typos-cli 1.50.1, repo `.typos.toml`) clean on the changed files and on the diff. Runic: the new test file and the `src` hunk are Runic-clean; the one added line in `test/runtests.jl` uses the file's existing one-line `@safetestset ... begin include(...) end` style, which Runic would expand — the surrounding file is not Runic-formatted on master and this repo has no Runic CI, so it was kept consistent with its neighbours.

**What was not verified:** x86-64, Julia versions other than 1.12.6, downstream packages (Symbolics, ModelingToolkit), and the full Core suite on the rebased base (master moved by one commit, #1072, which touches `ordering.jl`/`polyform.jl`/`types.jl`, not `getindex.jl`).

**Dependencies:** none. Independent of https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1074 and https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1075; applies cleanly on master.

---
🤖 Posted by an AI agent — harness: Claude Code 2.1.270 · model: claude-fable-5-1
Conversation: local Claude Code session `9b5c3ae5-6a0f-41b8-bd69-03bf3b5e7083` (no shareable URL available)
