### PR TITLE
Isolate scratch buffers for nested array reductions

### DIFF
--- a/src/substitute.jl
+++ b/src/substitute.jl
@@ -501,31 +501,37 @@ function Base.empty!(x::ArrayOpReduceCache)
     return x
 end
 
-const ARRAYOP_REDUCE_SYMREAL = TaskLocalValue{ArrayOpReduceCache{SymReal}}(ArrayOpReduceCache{SymReal})
-const ARRAYOP_REDUCE_SAFEREAL = TaskLocalValue{ArrayOpReduceCache{SafeReal}}(ArrayOpReduceCache{SafeReal})
+const ARRAYOP_REDUCE_SYMREAL = TaskLocalValue{Vector{ArrayOpReduceCache{SymReal}}}(() -> ArrayOpReduceCache{SymReal}[])
+const ARRAYOP_REDUCE_SAFEREAL = TaskLocalValue{Vector{ArrayOpReduceCache{SafeReal}}}(() -> ArrayOpReduceCache{SafeReal}[])
 
-arrayop_reduce_cache(::Type{SymReal}) = empty!(ARRAYOP_REDUCE_SYMREAL[])
-arrayop_reduce_cache(::Type{SafeReal}) = empty!(ARRAYOP_REDUCE_SAFEREAL[])
+arrayop_reduce_caches(::Type{SymReal}) = ARRAYOP_REDUCE_SYMREAL[]
+arrayop_reduce_caches(::Type{SafeReal}) = ARRAYOP_REDUCE_SAFEREAL[]
 
 function _reduce_eliminated_idxs(expr::BasicSymbolic{T}, output_idx::OutIdxT{T}, ranges::RangesT{T}, @nospecialize(reduce)) where {T}
-    cache = arrayop_reduce_cache(T)
-    new_ranges = cache.new_ranges
-    subrules = cache.subrules
-    new_expr = Code.unidealize_indices(expr, ranges, new_ranges)
-    merge!(new_ranges, ranges)
-    collapsed = cache.collapsed_idxs
-    union!(collapsed, keys(new_ranges))
-    setdiff!(collapsed, output_idx)
-    collapsed_ranges = cache.collapsed_ranges
-    for i in collapsed
-        push!(collapsed_ranges, new_ranges[i])
-    end
-    return mapreduce(reduce, Iterators.product(collapsed_ranges...)) do iidxs
-        for (idx, ii) in zip(iidxs, collapsed)
-            subrules[ii] = idx
+    pool = arrayop_reduce_caches(T)
+    cache = isempty(pool) ? ArrayOpReduceCache{T}() : pop!(pool)
+    # Substitution may recursively reduce another ArrayOp in the same task.
+    try
+        new_ranges = cache.new_ranges
+        subrules = cache.subrules
+        new_expr = Code.unidealize_indices(expr, ranges, new_ranges)
+        merge!(new_ranges, ranges)
+        collapsed = cache.collapsed_idxs
+        union!(collapsed, keys(new_ranges))
+        setdiff!(collapsed, output_idx)
+        collapsed_ranges = cache.collapsed_ranges
+        for i in collapsed
+            push!(collapsed_ranges, new_ranges[i])
         end
-        return substitute(new_expr, subrules)::BasicSymbolic{T}
-    end::BasicSymbolic{T}
+        return mapreduce(reduce, Iterators.product(collapsed_ranges...)) do iidxs
+            for (idx, ii) in zip(iidxs, collapsed)
+                subrules[ii] = idx
+            end
+            return substitute(new_expr, subrules)::BasicSymbolic{T}
+        end::BasicSymbolic{T}
+    finally
+        push!(pool, empty!(cache))
+    end
 end
 
 struct IdHashWrapper{T}

--- a/test/array_reduction_cache.jl
+++ b/test/array_reduction_cache.jl
@@ -1,0 +1,16 @@
+using SymbolicUtils, Test
+using SymbolicUtils: Sym, SymReal, ShapeVecT, clear_cache!
+
+@testset "Nested array reductions retain their own scratch buffers" begin
+    for (S, P) in ((1, 1), (1, 3), (2, 1), (2, 3)), n in 1:16
+        x = Sym{SymReal}(Symbol(:reduction_x, S, :_, P, :_, n); type = Matrix{Real}, shape = ShapeVecT([1:S, 1:P]))
+        y = Sym{SymReal}(Symbol(:reduction_y, S, :_, P, :_, n); type = Matrix{Real}, shape = ShapeVecT([1:S, 1:P]))
+        expr = broadcast(+, x, broadcast(*, 0, y))
+        # Exercise an uncached reduction after constructing nested broadcasts.
+        clear_cache!(SymbolicUtils.reduce_eliminated_idxs_1)
+        clear_cache!(SymbolicUtils._getindex_1)
+        for index in CartesianIndices((S, P))
+            @test isequal(expr[Tuple(index)...], x[Tuple(index)...])
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,7 @@ if GROUP == "Core"
             @safetestset "Basics" begin include("basics.jl") end
             @safetestset "Thread-safe arguments" begin include("threadsafe_arguments.jl") end
             @safetestset "ArrayOp" begin include("arrayop.jl") end
+            @safetestset "Array reduction cache" begin include("array_reduction_cache.jl") end
             @safetestset "ArrayMaker" begin include("arraymaker.jl") end
             @safetestset "Order" begin include("order.jl") end
             @safetestset "PolyForm" begin include("polyform.jl") end


### PR DESCRIPTION
> 🚧 **UNREVIEWED — awaiting review by @ChrisRackauckas.** Filed by an AI agent running as @chrisrackauckas; Chris has not reviewed this change. Please ignore this draft until he reviews it.
> Harness: Claude Code 2.1.270 · Model: claude-fable-5-1
> Conversation: local Claude Code session `9b5c3ae5-6a0f-41b8-bd69-03bf3b5e7083` (no shareable URL available)

`_reduce_eliminated_idxs` used a single task-local `ArrayOpReduceCache` for its `new_ranges` / `subrules` / `collapsed_idxs` / `collapsed_ranges` scratch buffers, but the `substitute` it calls inside `mapreduce` can itself reduce another `ArrayOp` on the same task, which re-enters `_reduce_eliminated_idxs` and clobbers the caller's buffers mid-iteration. The observable symptom is a nested broadcast like `broadcast(+, x, broadcast(*, 0, y))` scalarizing to a result that still contains the eliminated index placeholders (`x[_1, _2]` instead of `x[1, 1]`), depending on cache state. This replaces the single cache with a task-local pool (a `Vector` of caches): each call pops a cache (or allocates one), and returns it emptied in a `finally`, so nested calls get their own buffers while the buffers are still reused across calls.

New test `test/array_reduction_cache.jl` (Core group) exercises 64 shape/replicate combinations after clearing the memoization caches so the reduction path actually runs, 192 assertions.

**Before / after** (Julia 1.12.6, aarch64 Linux; log names refer to the local validation directory of the session that produced them):

```
# new test file on unmodified base (symbolic-reduction-official-before.log):
Nested array reductions retain their own scratch buffers |  139    53    192  19.3s
  Expression: isequal(expr[Tuple(index)...], x[Tuple(index)...])
   Evaluated: isequal(reduction_x1_1_2[_1, _2], reduction_x1_1_2[1, 1])
# 40-case standalone reproducer on unmodified base (symbolic-reduction-before.log):
ERROR: LoadError: Some tests did not pass: 25 passed, 15 failed, 0 errored, 0 broken.

# same file / reproducer with the fix (symbolic-reduction-after.log):
Nested singleton broadcasts after cache eviction         |   40     40  11.4s
Nested array reductions retain their own scratch buffers |  192    192  3.5s

# re-run today against current origin/master 5bc28be6 (this branch's base), unmodified:
ERROR: LoadError: Some tests did not pass: 146 passed, 46 failed, 0 errored, 0 broken.
   Evaluated: isequal(reduction_x1_1_1[_1, _2], reduction_x1_1_1[1, 1])
Test Summary:                                            | Pass  Fail  Total   Time
Nested array reductions retain their own scratch buffers |  146    46    192  31.7s
(the exact failed count varies with memoization-cache state between runs: 53 of 192 in the earlier run, 46 today)

# re-run today on this branch (master 5bc28be6 + this commit):
SymbolicUtils from: .../su-pr-2/src/SymbolicUtils.jl
Test Summary:                                            | Pass  Total   Time
Nested array reductions retain their own scratch buffers |  192    192  39.4s
```

**Full suite** (not re-run for this rebase; cited from the earlier local runs on the pre-#1072 base):
- `Pkg.test("SymbolicUtils")` Core with this fix stacked on the constant-indices fix (`symbolic-reduction-core.log`): `Core | 18294 passed, 3 broken, 18297 total` — the 3 broken are pre-existing on master.
- QA group (`symbolic-reduction-qa.log`): `SciMLTesting QA | 20 20`, `AdjView JET | 37 37`.
- Combined head of https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1073 + this PR + https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1075 (`symbolic-slices-core2.log`): `Core | 18235 passed, 3 broken, 18238 total`; QA 20 + JET 37 (`symbolic-slices-qa2.log`).

**Formatting / spelling:** `typos` (typos-cli 1.50.1, repo `.typos.toml`) clean on the changed files; on the raw `git diff` text it flags only the `index 64b2b1d0..eb4fe0ba` blob-hash header line (`ba`), not code. Runic: the new test file and the `src/substitute.jl` hunk are Runic-clean (Runic wants the same 61 pre-existing line changes in that file before and after this PR); the one added line in `test/runtests.jl` uses the file's existing one-line `@safetestset` style, which Runic would expand — the surrounding file is not Runic-formatted on master and this repo has no Runic CI, so it was kept consistent with its neighbours.

**What was not verified:** x86-64, Julia versions other than 1.12.6, multi-threaded stress of the pool (the pool is task-local, so no cross-task sharing is introduced, but this was not separately benchmarked), downstream packages, and the full Core suite on the rebased base (master moved by one commit, #1072, which does not touch `substitute.jl`).

**Dependencies:** none. The `src` change cherry-picks cleanly onto master; the original commit was authored on top of https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1073, and the only conflict on rebasing it alone was the adjacent `test/runtests.jl` insertion line, resolved by keeping just this PR's line. Independent of https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1073 and https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1075.

---
🤖 Posted by an AI agent — harness: Claude Code 2.1.270 · model: claude-fable-5-1
Conversation: local Claude Code session `9b5c3ae5-6a0f-41b8-bd69-03bf3b5e7083` (no shareable URL available)
