### PR TITLE
Expand parent operations when scalarizing array slices

### DIFF
--- a/src/substitute.jl
+++ b/src/substitute.jl
@@ -908,7 +908,7 @@ scalarization_function(::typeof(getindex)) = _getindex_scal
 function _getindex_scal(::typeof(getindex), x::BasicSymbolic{T}, ::Val{toplevel}) where {T, toplevel}
     sh = shape(x)
     if length(sh) > 0
-        return [x[idx] for idx in eachindex(x)]
+        return [toplevel ? x[idx] : scalarize(x[idx]) for idx in eachindex(x)]
     end
     args = MData.variant_getfield(x, BSImpl.Term, :args)
     idx = try

--- a/test/array_slice_scalarization.jl
+++ b/test/array_slice_scalarization.jl
@@ -1,0 +1,19 @@
+using SymbolicUtils, Test
+using SymbolicUtils: scalarize
+
+@testset "Scalarizing slices expands their parent array operations" begin
+    for (S, P) in ((1, 1), (1, 3), (2, 1), (2, 3))
+        @syms x[1:S, 1:1] y[1:S, 1:P]
+        replicated = x * ones(1, P)
+        residual = replicated[:, 1:1] - y[:, 1:1]
+        result = scalarize(residual)
+        @test isequal(result, [x[s, 1] - y[s, 1] for s in 1:S, _ in 1:1])
+        @test isequal(scalarize(result), result)
+        @test isequal(
+            scalarize(replicated[:, 1:1], Val(true)),
+            [replicated[s, 1] for s in 1:S, _ in 1:1]
+        )
+        product = replicated[:, 1:1] .* replicated[:, P:P]
+        @test isequal(scalarize(product), [x[s, 1]^2 for s in 1:S, _ in 1:1])
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,9 @@ if GROUP == "Core"
             @safetestset "Basics" begin include("basics.jl") end
             @safetestset "Thread-safe arguments" begin include("threadsafe_arguments.jl") end
             @safetestset "ArrayOp" begin include("arrayop.jl") end
+            @safetestset "Array slice scalarization" begin
+                include("array_slice_scalarization.jl")
+            end
             @safetestset "ArrayMaker" begin include("arraymaker.jl") end
             @safetestset "Order" begin include("order.jl") end
             @safetestset "PolyForm" begin include("polyform.jl") end


### PR DESCRIPTION
> 🚧 **UNREVIEWED — awaiting review by @ChrisRackauckas.** Filed by an AI agent running as @chrisrackauckas; Chris has not reviewed this change. Please ignore this draft until he reviews it.
> Harness: Claude Code 2.1.270 · Model: claude-fable-5-1
> Conversation: local Claude Code session `9b5c3ae5-6a0f-41b8-bd69-03bf3b5e7083` (no shareable URL available)

`_getindex_scal` (the `scalarize` handler for `getindex`) returns `[x[idx] for idx in eachindex(x)]` for a shaped slice, so scalarizing a slice of an array *operation* — e.g. `(x * ones(1, P))[:, 1:1]` — stops at `(x*[1.0;;])[1, 1]` and treats each entry as an opaque scalar instead of expanding the parent operation to `x[1, 1]`. Downstream that means derivatives/residuals over slices of matrix expressions see independent variables rather than the underlying operation. This makes the non-top-level case recurse: `[toplevel ? x[idx] : scalarize(x[idx]) for idx in eachindex(x)]`. The `toplevel = Val(true)` path is deliberately unchanged, because recursing there broke top-level collection (`test/arraymaker.jl:69 nested`) in a first attempt — see the full-suite note below.

New test `test/array_slice_scalarization.jl` (Core group) checks, for four `(S, P)` shapes: the slice residual scalarizes to `x[s, 1] - y[s, 1]`, the result is idempotent under `scalarize`, `Val(true)` still returns the un-expanded slice entries, and a product of two slices scalarizes to `x[s, 1]^2` — 16 assertions.

**Before / after** (Julia 1.12.6, aarch64 Linux; log names refer to the local validation directory of the session that produced them):

```
# new test file (12-assertion draft at the time) on unmodified base (array-slice-scalarization-before.log): 12 failures, e.g.
Scalarizing slices expands their parent array operations: Test Failed at .../test/array_slice_scalarization.jl:10
  Expression: isequal(result, [x[s, 1] - y[s, 1] for s = 1:S, _ = 1:1])
   Evaluated: isequal(...[(x*[1.0;;])[1, 1] - y[1, 1];;], ...[x[1, 1] - y[1, 1];;])

# final 16-assertion file with the fix (array-slice-hot-final.log, symbolic-slices-targeted3.log):
Scalarizing slices expands their parent array operations |   16     16  0.7s

# re-run today against current origin/master 5bc28be6 (this branch's base), unmodified:
ERROR: LoadError: Some tests did not pass: 4 passed, 12 failed, 0 errored, 0 broken.
   Evaluated: isequal(...[(x*[1.0;;])[1, 1] - y[1, 1];;], ...[x[1, 1] - y[1, 1];;])
Test Summary:                                            | Pass  Fail  Total   Time
Scalarizing slices expands their parent array operations |    4    12     16  37.0s
(the 4 passes are the Val(true) top-level assertions, whose behaviour this PR intentionally leaves unchanged)

# re-run today on this branch (master 5bc28be6 + this commit):
SymbolicUtils from: .../su-pr-3/src/SymbolicUtils.jl
Test Summary:                                            | Pass  Total     Time
Scalarizing slices expands their parent array operations |   16     16  1m02.3s
```

**Full suite** (not re-run for this rebase; cited from the earlier local runs on the pre-#1072 base, with https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1073 and https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1074 also applied):
- Final guard, `Pkg.test("SymbolicUtils")` Core (`symbolic-slices-core2.log`): `Core | 18235 passed, 3 broken, 18238 total` — the 3 broken are pre-existing on master.
- QA group (`symbolic-slices-qa2.log`): `SciMLTesting QA | 20 20`, `AdjView JET | 37 37`.
- For the record, the rejected first attempt (recursing at top level too) gave `18230 passed, 1 failed` with `nested: Test Failed at test/arraymaker.jl:69` (`symbolic-slices-full.log`); the `toplevel ?` guard in this PR is what fixed that.

**Formatting / spelling:** `typos` (typos-cli 1.50.1, repo `.typos.toml`) clean on the changed files and the diff. Runic: the new test file, the `src/substitute.jl` hunk, and the `test/runtests.jl` insertion are all Runic-clean (Runic wants the same pre-existing line changes in those files before and after this PR).

**What was not verified:** x86-64, Julia versions other than 1.12.6, downstream packages (Symbolics/ModelingToolkit scalarization consumers), performance of the extra recursion on large slices (memoized `scalarize` should absorb most of it, not measured), and the full Core suite on the rebased base (master moved by one commit, #1072, which does not touch `substitute.jl`).

**Dependencies:** none. The `src` change cherry-picks cleanly onto master; the original commit was authored on top of https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1073 and https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1074, and the only conflict on rebasing it alone was the adjacent `test/runtests.jl` insertion lines, resolved by keeping just this PR's block. Independent of https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1073 and https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1074.

---
🤖 Posted by an AI agent — harness: Claude Code 2.1.270 · model: claude-fable-5-1
Conversation: local Claude Code session `9b5c3ae5-6a0f-41b8-bd69-03bf3b5e7083` (no shareable URL available)
